### PR TITLE
CH440: Use RFC3339 for all printed times.

### DIFF
--- a/cli/cmd/channel_inspect.go
+++ b/cli/cmd/channel_inspect.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -10,7 +11,7 @@ import (
 
 // channelInspectCmd represents the channelInspect command
 var channelInspectCmd = &cobra.Command{
-	Use:   "inspect",
+	Use:   "inspect CHANNEL_ID",
 	Short: "Show full details for a channel",
 	Long:  "Show full details for a channel",
 }
@@ -21,7 +22,7 @@ func init() {
 
 func (r *runners) channelInspect(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
-		return fmt.Errorf(cmd.UsageString())
+		return errors.New("channel ID is required")
 	}
 	chanID := args[0]
 

--- a/cli/cmd/channel_rm.go
+++ b/cli/cmd/channel_rm.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -19,7 +20,7 @@ func init() {
 
 func (r *runners) channelRemove(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
-		return fmt.Errorf("channel ID is required")
+		return errors.New("channel ID is required")
 	}
 	chanID := args[0]
 

--- a/cli/cmd/release_inspect.go
+++ b/cli/cmd/release_inspect.go
@@ -12,7 +12,7 @@ import (
 
 // releaseInspectCmd represents the inspect command
 var releaseInspectCmd = &cobra.Command{
-	Use:   "inspect",
+	Use:   "inspect SEQUENCE",
 	Short: "Print the YAML config for a release",
 	Long:  "Print the YAML config for a release",
 }

--- a/cli/cmd/release_promote.go
+++ b/cli/cmd/release_promote.go
@@ -1,8 +1,8 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
-	"os"
 	"strconv"
 
 	"github.com/spf13/cobra"
@@ -14,7 +14,7 @@ var releaseVersion string
 
 // releasePromoteCmd represents the releasePromote command
 var releasePromoteCmd = &cobra.Command{
-	Use:   "promote SEQUENCE CHANNEL",
+	Use:   "promote SEQUENCE CHANNEL_ID",
 	Short: "Set the release for a channel",
 	Long: `Set the release for a channel
 
@@ -32,8 +32,7 @@ func init() {
 func (r *runners) releasePromote(cmd *cobra.Command, args []string) error {
 	// parse sequence and channel ID positional arguments
 	if len(args) != 2 {
-		cmd.Usage()
-		os.Exit(1)
+		return errors.New("releasese sequence and channel ID are required")
 	}
 	seq, err := strconv.ParseInt(args[0], 10, 64)
 	if err != nil {

--- a/cli/cmd/release_update.go
+++ b/cli/cmd/release_update.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 
@@ -26,7 +27,7 @@ func (r *runners) releaseUpdate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("yaml is required")
 	}
 	if len(args) < 1 {
-		return fmt.Errorf("release sequence is required")
+		return errors.New("release sequence is required")
 	}
 	seq, err := strconv.ParseInt(args[0], 10, 64)
 	if err != nil {

--- a/cli/print/channel_releases.go
+++ b/cli/print/channel_releases.go
@@ -2,18 +2,18 @@ package print
 
 import (
 	"fmt"
-	"html/template"
 	"text/tabwriter"
+	"text/template"
 
 	channels "github.com/replicatedhq/replicated/gen/go/channels"
 )
 
 var channelReleasesTmplSrc = `CHANNEL_SEQUENCE	RELEASE_SEQUENCE	RELEASED	VERSION	REQUIRED	AIRGAP_STATUS	RELEASE_NOTES
 {{ range . -}}
-{{ .ChannelSequence }}	{{ .ReleaseSequence }}	{{ .Created }}	{{ .Version }}	{{ .Required }}	{{ .AirgapBuildStatus}}	{{ .ReleaseNotes }}
+{{ .ChannelSequence }}	{{ .ReleaseSequence }}	{{ time .Created }}	{{ .Version }}	{{ .Required }}	{{ .AirgapBuildStatus}}	{{ .ReleaseNotes }}
 {{ end }}`
 
-var channelReleasesTmpl = template.Must(template.New("ChannelReleases").Parse(channelReleasesTmplSrc))
+var channelReleasesTmpl = template.Must(template.New("ChannelReleases").Funcs(funcs).Parse(channelReleasesTmplSrc))
 
 func ChannelReleases(w *tabwriter.Writer, releases []channels.ChannelRelease) error {
 	if len(releases) == 0 {

--- a/cli/print/channels.go
+++ b/cli/print/channels.go
@@ -1,8 +1,8 @@
 package print
 
 import (
-	"html/template"
 	"text/tabwriter"
+	"text/template"
 
 	channels "github.com/replicatedhq/replicated/gen/go/channels"
 )

--- a/cli/print/release.go
+++ b/cli/print/release.go
@@ -8,13 +8,13 @@ import (
 )
 
 var releaseTmplSrc = `SEQUENCE: {{ .Sequence }}
-CREATED: {{ .CreatedAt }}
-EDITED: {{ .EditedAt }}
+CREATED: {{ time .CreatedAt }}
+EDITED: {{ time .EditedAt }}
 CONFIG:
 {{ .Config }}
 `
 
-var releaseTmpl = template.Must(template.New("Release").Parse(releaseTmplSrc))
+var releaseTmpl = template.Must(template.New("Release").Funcs(funcs).Parse(releaseTmplSrc))
 
 func Release(w *tabwriter.Writer, release *releases.AppRelease) error {
 	if err := releaseTmpl.Execute(w, release); err != nil {

--- a/cli/print/releases.go
+++ b/cli/print/releases.go
@@ -4,16 +4,17 @@ import (
 	"strings"
 	"text/tabwriter"
 	"text/template"
+	"time"
 
 	releases "github.com/replicatedhq/replicated/gen/go/releases"
 )
 
 var releasesTmplSrc = `SEQUENCE	VERSION	CREATED	EDITED	ACTIVE_CHANNELS
 {{ range . -}}
-{{ .Sequence }}	{{ .Version }}	{{ .CreatedAt }}	{{ .EditedAt }}	{{ .ActiveChannels }}
+{{ .Sequence }}	{{ .Version }}	{{ time .CreatedAt }}	{{ .EditedAt }}	{{ .ActiveChannels }}
 {{ end }}`
 
-var releasesTmpl = template.Must(template.New("Releases").Parse(releasesTmplSrc))
+var releasesTmpl = template.Must(template.New("Releases").Funcs(funcs).Parse(releasesTmplSrc))
 
 func Releases(w *tabwriter.Writer, appReleases []releases.AppReleaseInfo) error {
 	rs := make([]map[string]interface{}, len(appReleases))
@@ -27,7 +28,7 @@ func Releases(w *tabwriter.Writer, appReleases []releases.AppReleaseInfo) error 
 		activeChansField := strings.Join(activeChans, ",")
 
 		// don't print edited if it's the same as created
-		edited := r.EditedAt.String()
+		edited := r.EditedAt.Format(time.RFC3339)
 		if r.CreatedAt.Equal(r.EditedAt) {
 			edited = ""
 		}

--- a/cli/print/util.go
+++ b/cli/print/util.go
@@ -1,0 +1,13 @@
+package print
+
+import (
+	"text/template"
+	"time"
+)
+
+var funcs = template.FuncMap{
+	// Use RFC 3339 for standard time printing in all output
+	"time": func(t time.Time) string {
+		return t.Format(time.RFC3339)
+	},
+}


### PR DESCRIPTION
Short help for release inspect and channel inspect should show required
paramters.
Use errors.New instead of fmt.Errorf unless formatting.