### PR TITLE
Allow reading yaml from stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,6 @@ git tag -a v0.1.0 -m "First release" && git push upstream v0.1.0
 ```
 replicated release inspect 130 | sed 1,4d > config.yaml
 vim config.yaml
-replicated release create --yaml "$(< config.yaml)"
+cat config.yaml | replicated release create --yaml -
 # SEQUENCE: 131
 ```

--- a/cli/cmd/release_create.go
+++ b/cli/cmd/release_create.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
 
 	"github.com/replicatedhq/replicated/client"
 	"github.com/spf13/cobra"
@@ -27,6 +29,14 @@ func init() {
 func (r *runners) releaseCreate(cmd *cobra.Command, args []string) error {
 	if createReleaseYaml == "" {
 		return fmt.Errorf("yaml is required")
+	}
+
+	if createReleaseYaml == "-" {
+		bytes, err := ioutil.ReadAll(os.Stdin)
+		if err != nil {
+			return err
+		}
+		createReleaseYaml = string(bytes)
 	}
 
 	// if the --promote param was used make sure it identifies exactly one

--- a/cli/cmd/release_create.go
+++ b/cli/cmd/release_create.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"io/ioutil"
-	"os"
 
 	"github.com/replicatedhq/replicated/client"
 	"github.com/spf13/cobra"
@@ -32,7 +31,7 @@ func (r *runners) releaseCreate(cmd *cobra.Command, args []string) error {
 	}
 
 	if createReleaseYaml == "-" {
-		bytes, err := ioutil.ReadAll(os.Stdin)
+		bytes, err := ioutil.ReadAll(r.stdin)
 		if err != nil {
 			return err
 		}

--- a/cli/cmd/release_update.go
+++ b/cli/cmd/release_update.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"strconv"
 
 	"github.com/replicatedhq/replicated/client"
@@ -26,6 +27,13 @@ func init() {
 func (r *runners) releaseUpdate(cmd *cobra.Command, args []string) error {
 	if updateReleaseYaml == "" {
 		return fmt.Errorf("yaml is required")
+	}
+	if updateReleaseYaml == "-" {
+		bytes, err := ioutil.ReadAll(r.stdin)
+		if err != nil {
+			return err
+		}
+		updateReleaseYaml = string(bytes)
 	}
 	if len(args) < 1 {
 		return errors.New("release sequence is required")

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -68,9 +68,17 @@ Use "{{.CommandPath}} [command] --help" for more information about a command.{{e
 
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute(w io.Writer) error {
+func Execute(stdin io.Reader, stdout io.Writer, stderr io.Writer) error {
+	w := tabwriter.NewWriter(stdout, minWidth, tabWidth, padding, padChar, tabwriter.TabIndent)
+
 	// get api client and app ID after flags are parsed
-	runCmds := &runners{w: tabwriter.NewWriter(w, minWidth, tabWidth, padding, padChar, tabwriter.TabIndent)}
+	runCmds := &runners{
+		stdin: stdin,
+		w:     w,
+	}
+	if stderr != nil {
+		RootCmd.SetOutput(stderr)
+	}
 
 	channelCreateCmd.RunE = runCmds.channelCreate
 	channelInspectCmd.RunE = runCmds.channelInspect

--- a/cli/cmd/runner.go
+++ b/cli/cmd/runner.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"io"
 	"text/tabwriter"
 
 	"github.com/replicatedhq/replicated/client"
@@ -9,7 +10,8 @@ import (
 // Runner holds the I/O dependencies and configurations used by individual
 // commands, which are defined as methods on this type.
 type runners struct {
-	api   client.Client
-	w     *tabwriter.Writer
 	appID string
+	api   client.Client
+	stdin io.Reader
+	w     *tabwriter.Writer
 }

--- a/cli/main.go
+++ b/cli/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-	if err := cmd.Execute(os.Stdout); err != nil {
+	if err := cmd.Execute(os.Stdin, os.Stdout, os.Stderr); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}

--- a/cli/test/channel_adoption_test.go
+++ b/cli/test/channel_adoption_test.go
@@ -43,9 +43,7 @@ var _ = Describe("channel adoption", func() {
 				var stderr bytes.Buffer
 
 				cmd.RootCmd.SetArgs([]string{"channel", "adoption", appChan.Id, "--app", app.Slug})
-				cmd.RootCmd.SetOutput(&stderr)
-
-				err := cmd.Execute(&stdout)
+				err := cmd.Execute(nil, &stdout, &stderr)
 				assert.Nil(t, err)
 
 				assert.Zero(t, stderr, "Expected no stderr output")

--- a/cli/test/channel_counts_test.go
+++ b/cli/test/channel_counts_test.go
@@ -44,7 +44,7 @@ var _ = Describe("channel counts", func() {
 				cmd.RootCmd.SetArgs([]string{"channel", "counts", appChan.Id, "--app", app.Slug})
 				cmd.RootCmd.SetOutput(&stderr)
 
-				err := cmd.Execute(&stdout)
+				err := cmd.Execute(nil, &stdout, &stderr)
 				assert.Nil(t, err)
 
 				assert.Zero(t, stderr, "Expected no stderr output")

--- a/cli/test/channel_create_test.go
+++ b/cli/test/channel_create_test.go
@@ -38,7 +38,7 @@ var _ = Describe("channel create", func() {
 
 			cmd.RootCmd.SetArgs([]string{"channel", "create", "--name", name, "--description", desc, "--app", app.Slug})
 			cmd.RootCmd.SetOutput(&stderr)
-			err := cmd.Execute(&stdout)
+			err := cmd.Execute(nil, &stdout, &stderr)
 
 			assert.Nil(t, err)
 

--- a/cli/test/channel_inspect_test.go
+++ b/cli/test/channel_inspect_test.go
@@ -42,7 +42,7 @@ var _ = Describe("channel inspect", func() {
 				cmd.RootCmd.SetArgs([]string{"channel", "inspect", appChan.Id, "--app", app.Slug})
 				cmd.RootCmd.SetOutput(&stderr)
 
-				err := cmd.Execute(&stdout)
+				err := cmd.Execute(nil, &stdout, &stderr)
 				assert.Nil(t, err)
 
 				assert.Zero(t, stderr, "Expected no stderr output")

--- a/cli/test/channel_ls_test.go
+++ b/cli/test/channel_ls_test.go
@@ -40,7 +40,7 @@ var _ = Describe("channel ls", func() {
 
 			cmd.RootCmd.SetArgs([]string{"channel", "ls", "--app", app.Slug})
 			cmd.RootCmd.SetOutput(&stderr)
-			err := cmd.Execute(&stdout)
+			err := cmd.Execute(nil, &stdout, &stderr)
 
 			assert.Nil(t, err)
 

--- a/cli/test/channel_releases_test.go
+++ b/cli/test/channel_releases_test.go
@@ -52,7 +52,7 @@ var _ = Describe("channel releases", func() {
 			cmd.RootCmd.SetArgs([]string{"channel", "releases", appChan.Id, "--app", app.Slug})
 			cmd.RootCmd.SetOutput(&stderr)
 
-			err := cmd.Execute(&stdout)
+			err := cmd.Execute(nil, &stdout, &stderr)
 			assert.Nil(t, err)
 
 			assert.Empty(t, stderr.String(), "Expected no stderr output")

--- a/cli/test/channel_rm_test.go
+++ b/cli/test/channel_rm_test.go
@@ -41,7 +41,7 @@ var _ = Describe("channel rm", func() {
 			cmd.RootCmd.SetArgs([]string{"channel", "rm", appChan.Id, "--app", app.Slug})
 			cmd.RootCmd.SetOutput(&stderr)
 
-			err := cmd.Execute(&stdout)
+			err := cmd.Execute(nil, &stdout, &stderr)
 			assert.Nil(t, err)
 
 			assert.Zero(t, stderr, "Expected no stderr output")

--- a/cli/test/release_create_test.go
+++ b/cli/test/release_create_test.go
@@ -34,7 +34,7 @@ var _ = Describe("release create", func() {
 
 			cmd.RootCmd.SetArgs([]string{"release", "create", "--yaml", yaml, "--app", app.Slug})
 			cmd.RootCmd.SetOutput(&stderr)
-			err := cmd.Execute(&stdout)
+			err := cmd.Execute(nil, &stdout, &stderr)
 
 			assert.Nil(t, err)
 
@@ -47,6 +47,28 @@ var _ = Describe("release create", func() {
 			assert.Equal(t, "SEQUENCE: 1", r.Text())
 
 			assert.False(t, r.Scan())
+		})
+	})
+
+	Context(`with "-" argument to --yaml flag in an app with no release where stdin contains valid yaml`, func() {
+		It("should create a release from stdin", func() {
+			var stdin = bytes.NewBufferString(yaml)
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+
+			cmd.RootCmd.SetArgs([]string{"release", "create", "--yaml", "-", "--app", app.Slug})
+			cmd.RootCmd.SetOutput(&stderr)
+			err := cmd.Execute(stdin, &stdout, &stderr)
+
+			assert.Nil(t, err)
+
+			assert.Empty(t, stderr.String(), "Expected no stderr output")
+			assert.NotEmpty(t, stdout.String(), "Expected stdout output")
+
+			r := bufio.NewScanner(&stdout)
+
+			assert.True(t, r.Scan())
+			assert.Equal(t, "SEQUENCE: 1", r.Text())
 		})
 	})
 })

--- a/cli/test/release_inspect.go
+++ b/cli/test/release_inspect.go
@@ -42,7 +42,7 @@ var _ = Describe("release inspect", func() {
 			cmd.RootCmd.SetArgs([]string{"release", "inspect", seq, "--app", app.Slug})
 			cmd.RootCmd.SetOutput(&stderr)
 
-			err := cmd.Execute(&stdout)
+			err := cmd.Execute(nil, &stdout, &stderr)
 			assert.Nil(t, err)
 
 			assert.Empty(t, stderr.String(), "Expected no stderr output")

--- a/cli/test/release_ls_test.go
+++ b/cli/test/release_ls_test.go
@@ -38,7 +38,7 @@ var _ = Describe("release ls", func() {
 			cmd.RootCmd.SetArgs([]string{"release", "ls", "--app", app.Slug})
 			cmd.RootCmd.SetOutput(&stderr)
 
-			err := cmd.Execute(&stdout)
+			err := cmd.Execute(nil, &stdout, &stderr)
 			assert.Nil(t, err)
 
 			assert.Empty(t, stderr.String(), "Expected no stderr output")

--- a/cli/test/release_promote_test.go
+++ b/cli/test/release_promote_test.go
@@ -49,7 +49,7 @@ var _ = Describe("release promote", func() {
 			cmd.RootCmd.SetArgs([]string{"release", "promote", sequence, appChan.Id, "--app", app.Slug})
 			cmd.RootCmd.SetOutput(&stderr)
 
-			err := cmd.Execute(&stdout)
+			err := cmd.Execute(nil, &stdout, &stderr)
 			assert.Nil(t, err)
 
 			assert.Empty(t, stderr.String(), "Expected no stderr output")

--- a/cli/test/release_update_test.go
+++ b/cli/test/release_update_test.go
@@ -43,7 +43,7 @@ var _ = Describe("release update", func() {
 			cmd.RootCmd.SetArgs([]string{"release", "update", sequence, "--yaml", yaml, "--app", app.Slug})
 			cmd.RootCmd.SetOutput(&stderr)
 
-			err := cmd.Execute(&stdout)
+			err := cmd.Execute(nil, &stdout, &stderr)
 			assert.Nil(t, err)
 
 			assert.Empty(t, stderr.String(), "Expected no stderr output")


### PR DESCRIPTION
This is useful on Windows where the "$(< replicated.yml)" syntax is not supported.
It allows for `type replicated.yml | replicated release create create --promote Unstable --yaml -`