### PR TITLE
Linting for ship apps

### DIFF
--- a/cli/cmd/release_lint.go
+++ b/cli/cmd/release_lint.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	"github.com/replicatedhq/replicated/cli/print"
+	"github.com/spf13/cobra"
+)
+
+var lintReleaseYaml string
+
+var releaseLintCmd = &cobra.Command{
+	Use:   "lint",
+	Short: "Lint a YAML",
+	Long:  "Lint a YAML",
+}
+
+func init() {
+	releaseCmd.AddCommand(releaseLintCmd)
+
+	releaseLintCmd.Flags().StringVar(&lintReleaseYaml, "yaml", "", "The YAML config to lint. Use '-' to read from stdin")
+}
+
+func (r *runners) releaseLint(cmd *cobra.Command, args []string) error {
+	if lintReleaseYaml == "" {
+		return fmt.Errorf("yaml is required")
+	}
+
+	if lintReleaseYaml == "-" {
+		bytes, err := ioutil.ReadAll(r.stdin)
+		if err != nil {
+			return err
+		}
+		lintReleaseYaml = string(bytes)
+	}
+
+	lintResult, err := r.api.LintRelease(r.appID, lintReleaseYaml)
+	if err != nil {
+		return err
+	}
+
+	if err := print.LintErrors(r.w, lintResult); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -101,6 +101,7 @@ func Execute(stdin io.Reader, stdout io.Writer, stderr io.Writer) error {
 	releaseLsCmd.RunE = runCmds.releaseList
 	releaseUpdateCmd.RunE = runCmds.releaseUpdate
 	releasePromoteCmd.RunE = runCmds.releasePromote
+	releaseLintCmd.RunE = runCmds.releaseLint
 
 	RootCmd.SetUsageTemplate(rootCmdUsageTmpl)
 

--- a/cli/print/lint.go
+++ b/cli/print/lint.go
@@ -1,0 +1,22 @@
+package print
+
+import (
+	"text/tabwriter"
+	"text/template"
+
+	"github.com/replicatedhq/replicated/pkg/types"
+)
+
+var lintTmplSrc = `RULE	TYPE	START LINE	END LINE
+{{ range . -}}
+{{ .Rule }}	{{ .Type }}	{{ (index .Positions 0).Start.Line }} 	{{ (index .Positions 0).End.Line }}
+{{ end }}`
+
+var lintTmpl = template.Must(template.New("lint").Parse(lintTmplSrc))
+
+func LintErrors(w *tabwriter.Writer, lintErrors []types.LintMessage) error {
+	if err := lintTmpl.Execute(w, lintErrors); err != nil {
+		return err
+	}
+	return w.Flush()
+}

--- a/client/release.go
+++ b/client/release.go
@@ -112,3 +112,19 @@ func (c *Client) PromoteRelease(appID string, sequence int64, label string, note
 
 	return errors.New("unknown app type")
 }
+
+func (c *Client) LintRelease(appID string, yaml string) ([]types.LintMessage, error) {
+	appType, err := c.GetAppType(appID)
+	if err != nil {
+		return nil, err
+	}
+
+	if appType == "platform" {
+		return nil, errors.New("Linting is not yet supported for Platform applications")
+		// return c.PlatformClient.LintRelease(appID, yaml)
+	} else if appType == "ship" {
+		return c.ShipClient.LintRelease(appID, yaml)
+	}
+
+	return nil, errors.New("unknown app type")
+}

--- a/pkg/platformclient/client.go
+++ b/pkg/platformclient/client.go
@@ -12,6 +12,7 @@ import (
 	channels "github.com/replicatedhq/replicated/gen/go/v1"
 	releases "github.com/replicatedhq/replicated/gen/go/v1"
 	v2 "github.com/replicatedhq/replicated/gen/go/v2"
+	"github.com/replicatedhq/replicated/pkg/types"
 )
 
 const apiOrigin = "https://api.replicated.com/vendor"
@@ -32,6 +33,7 @@ type Client interface {
 	UpdateRelease(appID string, sequence int64, yaml string) error
 	GetRelease(appID string, sequence int64) (*releases.AppRelease, error)
 	PromoteRelease(appID string, sequence int64, label string, notes string, required bool, channelIDs ...string) error
+	LintRelease(string, string) ([]types.LintMessage, error)
 
 	CreateLicense(*v2.LicenseV2) (*v2.LicenseV2, error)
 }

--- a/pkg/platformclient/release.go
+++ b/pkg/platformclient/release.go
@@ -1,11 +1,13 @@
 package platformclient
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
 
 	releases "github.com/replicatedhq/replicated/gen/go/v1"
+	"github.com/replicatedhq/replicated/pkg/types"
 )
 
 // ListReleases lists all releases for an app.
@@ -72,7 +74,7 @@ func (c *HTTPClient) GetRelease(appID string, sequence int64) (*releases.AppRele
 
 // PromoteRelease points the specified channels at a release sequence.
 func (c *HTTPClient) PromoteRelease(appID string, sequence int64, label, notes string, required bool, channelIDs ...string) error {
-	path := fmt.Sprintf("/v1/app/%s/%d/promote", appID, sequence)
+	path := fmt.Sprintf("/v1/app/%s/%d/promote?dry_run=true", appID, sequence)
 	body := &releases.BodyPromoteRelease{
 		Label:        label,
 		ReleaseNotes: notes,
@@ -83,4 +85,8 @@ func (c *HTTPClient) PromoteRelease(appID string, sequence int64, label, notes s
 		return fmt.Errorf("PromoteRelease: %v", err)
 	}
 	return nil
+}
+
+func (c *HTTPClient) LintRelease(appID string, yaml string) ([]types.LintMessage, error) {
+	return nil, errors.New("Not implemnented")
 }

--- a/pkg/shipclient/client.go
+++ b/pkg/shipclient/client.go
@@ -25,6 +25,7 @@ type Client interface {
 	CreateRelease(appID string, yaml string) (*types.ReleaseInfo, error)
 	UpdateRelease(appID string, sequence int64, yaml string) error
 	PromoteRelease(appID string, sequence int64, label string, notes string, channelIDs ...string) error
+	LintRelease(string, string) ([]types.LintMessage, error)
 }
 
 type AppOptions struct {

--- a/pkg/types/release.go
+++ b/pkg/types/release.go
@@ -11,3 +11,21 @@ type ReleaseInfo struct {
 	Sequence       int64
 	Version        string
 }
+
+type LintMessage struct {
+	Rule      string
+	Type      string
+	Positions []*LintPosition
+}
+
+type LintPosition struct {
+	Path  string
+	Start *LintLinePosition
+	End   *LintLinePosition
+}
+
+type LintLinePosition struct {
+	Position int64
+	Line     int64
+	Column   int64
+}


### PR DESCRIPTION
This adds a new command:

`replicated release lint --yaml "$(cat ./ship.yaml)"`

If the current app (`REPLICATED_APP`) is a ship app, it will use the API token to send the YAML to the GraphQL endpoint specified, and lint, returning errors.

Linting on the server side is: a) easier for now (the linter is JS, this project is go).  and b) allows for linting of dynamic dependencies (github assets, registry credentials, etc)