### PR TITLE
add pact tests for ship release promotion

### DIFF
--- a/pacts/replicated-cli-vendor-graphql-api.json
+++ b/pacts/replicated-cli-vendor-graphql-api.json
@@ -92,6 +92,90 @@
           }
         }
       }
+    },
+    {
+      "description": "A mocked minimal request to promote a new release for ship-app-1",
+      "providerState": "Prepare to (mock) promote a release for ship-app-1",
+      "request": {
+        "method": "POST",
+        "path": "/graphql",
+        "headers": {
+          "Authorization": "basic-read-write-token",
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "operationName": "",
+          "query": "\nmutation promoteShipRelease($appId: ID!, $sequence: Int, $channelIds: [String], $versionLabel: String!, $troubleshootSpecId: ID!) {\n  promoteShipRelease(appId: $appId, sequence: $sequence, channelIds: $channelIds, troubleshootSpecId: $troubleshootSpecId) {\n    id\n  }\n}",
+          "variables": {
+            "appId": "ship-app-1",
+            "channelIds": [
+              "Nightly"
+            ],
+            "sequence": 1,
+            "troubleshootSpecId": ""
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+        },
+        "body": {
+          "data": {
+            "promoteShipRelease": {
+              "id": "generated uuid"
+            }
+          }
+        },
+        "matchingRules": {
+          "$.body.data.promoteShipRelease.id": {
+            "match": "type"
+          }
+        }
+      }
+    },
+    {
+      "description": "A real request to promote a new release for ship-app-1",
+      "providerState": "Prepare to promote a release for ship-app-1",
+      "request": {
+        "method": "POST",
+        "path": "/graphql",
+        "headers": {
+          "Authorization": "basic-read-write-token",
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "operationName": "",
+          "query": "\nmutation promoteShipRelease($appId: ID!, $sequence: Int, $channelIds: [String], $versionLabel: String!, $releaseNotes: String, $troubleshootSpecId: ID!) {\n  promoteShipRelease(appId: $appId, sequence: $sequence, channelIds: $channelIds, versionLabel: $versionLabel, releaseNotes: $releaseNotes, troubleshootSpecId: $troubleshootSpecId) {\n    id\n  }\n}",
+          "variables": {
+            "appId": "ship-app-1",
+            "channelIds": [
+              "Nightly"
+            ],
+            "releaseNotes": "notesHere",
+            "sequence": 1,
+            "troubleshootSpecId": "",
+            "versionLabel": "versionHere"
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+        },
+        "body": {
+          "data": {
+            "promoteShipRelease": {
+              "id": "generated uuid"
+            }
+          }
+        },
+        "matchingRules": {
+          "$.body.data.promoteShipRelease.id": {
+            "match": "type"
+          }
+        }
+      }
     }
   ],
   "metadata": {

--- a/pkg/shipclient/release.go
+++ b/pkg/shipclient/release.go
@@ -222,8 +222,8 @@ func (c *GraphQLClient) PromoteRelease(appID string, sequence int64, label strin
 
 	request := GraphQLRequest{
 		Query: `
-mutation promoteShipRelease($appId: ID!, $sequence: Int, $channelIds: [String], $versionLabel: String!, $releaseNotes: String, $troubleshootSpecId: ID!, $analyzeSpecId: ID!) {
-  promoteShipRelease(appId: $appId, sequence: $sequence, channelIds: $channelIds, versionLabel: $versionLabel, releaseNotes: $releaseNotes, troubleshootSpecId: $troubleshootSpecId, analyzeSpecId: $analyzeSpecId) {
+mutation promoteShipRelease($appId: ID!, $sequence: Int, $channelIds: [String], $versionLabel: String!, $releaseNotes: String, $troubleshootSpecId: ID!) {
+  promoteShipRelease(appId: $appId, sequence: $sequence, channelIds: $channelIds, versionLabel: $versionLabel, releaseNotes: $releaseNotes, troubleshootSpecId: $troubleshootSpecId) {
     id
   }
 }`,
@@ -233,7 +233,6 @@ mutation promoteShipRelease($appId: ID!, $sequence: Int, $channelIds: [String], 
 			"versionLabel":       label,
 			"releaseNotes":       notes,
 			"troubleshootSpecId": "",
-			"analyzeSpecId":      "",
 			"channelIds":         channelIDs,
 		},
 	}

--- a/pkg/shipclient/release_test.go
+++ b/pkg/shipclient/release_test.go
@@ -81,3 +81,141 @@ mutation uploadRelease($appId: ID!) {
 		t.Fatalf("Error on Verify: %v", err)
 	}
 }
+
+func Test_PromoteReleaseMinimal(t *testing.T) {
+	var test = func() (err error) {
+		u := fmt.Sprintf("http://localhost:%d/graphql", pact.Server.Port)
+
+		request := GraphQLRequest{
+			Query: `
+mutation promoteShipRelease($appId: ID!, $sequence: Int, $channelIds: [String], $versionLabel: String!, $troubleshootSpecId: ID!) {
+  promoteShipRelease(appId: $appId, sequence: $sequence, channelIds: $channelIds, troubleshootSpecId: $troubleshootSpecId) {
+    id
+  }
+}`,
+
+			Variables: map[string]interface{}{
+				"appId":              "ship-app-1",
+				"sequence":           1,
+				"troubleshootSpecId": "",
+				"channelIds":         []string{"Nightly"},
+			},
+		}
+
+		uri, err := url.Parse(u)
+		assert.Nil(t, err)
+		c := &GraphQLClient{
+			GQLServer: uri,
+			Token:     "basic-read-write-token",
+		}
+
+		response := GraphQLResponseUploadRelease{}
+
+		err = c.executeRequest(request, &response)
+		assert.Nil(t, err)
+
+		return nil
+	}
+
+	pact.AddInteraction().
+		Given("Prepare to (mock) promote a release for ship-app-1").
+		UponReceiving("A mocked minimal request to promote a new release for ship-app-1").
+		WithRequest(dsl.Request{
+			Method: "POST",
+			Path:   dsl.String("/graphql"),
+			Headers: dsl.MapMatcher{
+				"Authorization": dsl.String("basic-read-write-token"),
+				"Content-Type":  dsl.String("application/json"),
+			},
+			Body: map[string]interface{}{
+				"operationName": "",
+				"query": `
+mutation promoteShipRelease($appId: ID!, $sequence: Int, $channelIds: [String], $versionLabel: String!, $troubleshootSpecId: ID!) {
+  promoteShipRelease(appId: $appId, sequence: $sequence, channelIds: $channelIds, troubleshootSpecId: $troubleshootSpecId) {
+    id
+  }
+}`,
+				"variables": map[string]interface{}{
+					"appId":              "ship-app-1",
+					"sequence":           1,
+					"troubleshootSpecId": "",
+					"channelIds":         []string{"Nightly"},
+				},
+			},
+		}).
+		WillRespondWith(dsl.Response{
+			Status: 200,
+			Body: map[string]interface{}{
+				"data": map[string]interface{}{
+					"promoteShipRelease": map[string]interface{}{
+						"id": dsl.Like(dsl.String("generated uuid")),
+					},
+				},
+			},
+		})
+
+	if err := pact.Verify(test); err != nil {
+		t.Fatalf("Error on Verify: %v", err)
+	}
+}
+
+func Test_PromoteReleaseActual(t *testing.T) {
+	var test = func() (err error) {
+		u := fmt.Sprintf("http://localhost:%d/graphql", pact.Server.Port)
+
+		uri, err := url.Parse(u)
+		assert.Nil(t, err)
+		c := &GraphQLClient{
+			GQLServer: uri,
+			Token:     "basic-read-write-token",
+		}
+
+		err = c.PromoteRelease("ship-app-1", 1, "versionHere", "notesHere", "Nightly")
+		assert.Nil(t, err)
+
+		return nil
+	}
+
+	pact.AddInteraction().
+		Given("Prepare to promote a release for ship-app-1").
+		UponReceiving("A real request to promote a new release for ship-app-1").
+		WithRequest(dsl.Request{
+			Method: "POST",
+			Path:   dsl.String("/graphql"),
+			Headers: dsl.MapMatcher{
+				"Authorization": dsl.String("basic-read-write-token"),
+				"Content-Type":  dsl.String("application/json"),
+			},
+			Body: map[string]interface{}{
+				"operationName": "",
+				"query": `
+mutation promoteShipRelease($appId: ID!, $sequence: Int, $channelIds: [String], $versionLabel: String!, $releaseNotes: String, $troubleshootSpecId: ID!) {
+  promoteShipRelease(appId: $appId, sequence: $sequence, channelIds: $channelIds, versionLabel: $versionLabel, releaseNotes: $releaseNotes, troubleshootSpecId: $troubleshootSpecId) {
+    id
+  }
+}`,
+				"variables": map[string]interface{}{
+					"appId":              "ship-app-1",
+					"sequence":           1,
+					"versionLabel":       "versionHere",
+					"releaseNotes":       "notesHere",
+					"troubleshootSpecId": "",
+					"channelIds":         []string{"Nightly"},
+				},
+			},
+		}).
+		WillRespondWith(dsl.Response{
+			Status: 200,
+			Body: map[string]interface{}{
+				"data": map[string]interface{}{
+					"promoteShipRelease": map[string]interface{}{
+						"id": dsl.Like(dsl.String("generated uuid")),
+					},
+				},
+			},
+		})
+
+	if err := pact.Verify(test); err != nil {
+		t.Fatalf("Error on Verify: %v", err)
+	}
+}


### PR DESCRIPTION
One test is as stripped down as I can make the request, while the other uses the actual client code