### PR TITLE
use a better versioning system for pact tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ script:
   - make pacts
   - make test
   - make build
-  - make publish-pacts
+#  - make publish-pacts-prerelease
 after_success:
   - test -n "$TRAVIS_TAG" && make package_docker_docs
   - test -n "$TRAVIS_TAG" && curl -sL https://git.io/goreleaser | bash
+  - test -n "$TRAVIS_TAG" && make publish-pacts

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ script:
   - make pacts
   - make test
   - make build
-#  - make publish-pacts-prerelease
 after_success:
   - test -n "$TRAVIS_TAG" && make package_docker_docs
   - test -n "$TRAVIS_TAG" && curl -sL https://git.io/goreleaser | bash

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
-.PHONY: docs
+.PHONY: docker shell deps test pacts publish-pacts publish-pacts-prerelease get-spec-prod get-spec-local gen-models build docs package_docker_docs
 
 API_PKGS=apps channels releases
-VERSION=$(shell git describe)
+VERSION=$(shell git describe --abbrev=0)
+PREVERSION=$(shell git describe --abbrev=0 | sed 's/v\([0-9]\+\)\.\([0-9]\+\)\.\([0-9]\+\)/echo "v\1.$$((\2+1)).\3-prerelease"/ge') # note - this only works with GNU sed
 
 docker:
 	docker build -t replicatedhq.replicated .
@@ -19,7 +20,6 @@ deps:
 test:
 	go test ./cli/test
 
-.PHONY: pacts
 pacts:
 	docker build -t replicated-cli-test -f hack/Dockerfile.testing .
 	docker run --rm --name replicated-cli-tests \
@@ -35,6 +35,15 @@ publish-pacts:
 		-H "Content-Type: application/json" \
 		-d@pacts/replicated-cli-vendor-graphql-api.json \
 		https://replicated-pact-broker.herokuapp.com/pacts/provider/vendor-graphql-api/consumer/replicated-cli/version/$(VERSION)
+
+publish-pacts-prerelease:
+	curl \
+		--silent --output /dev/null --show-error --fail \
+		--user ${PACT_BROKER_USERNAME}:${PACT_BROKER_PASSWORD} \
+		-X PUT \
+		-H "Content-Type: application/json" \
+		-d@pacts/replicated-cli-vendor-graphql-api.json \
+		https://replicated-pact-broker.herokuapp.com/pacts/provider/vendor-graphql-api/consumer/replicated-cli/version/$(PREVERSION)
 
 # fetch the swagger specs from the production Vendor API
 get-spec-prod:

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,7 @@
-.PHONY: docker shell deps test pacts publish-pacts publish-pacts-prerelease get-spec-prod get-spec-local gen-models build docs package_docker_docs
+.PHONY: docker shell deps test pacts publish-pacts get-spec-prod get-spec-local gen-models build docs package_docker_docs
 
 API_PKGS=apps channels releases
 VERSION=$(shell git describe --abbrev=0)
-PREVERSION=$(shell git describe --abbrev=0 | sed 's/v\([0-9]\+\)\.\([0-9]\+\)\.\([0-9]\+\)/echo "v\1.$$((\2+1)).\3-prerelease"/ge') # note - this only works with GNU sed
 
 docker:
 	docker build -t replicatedhq.replicated .
@@ -35,15 +34,6 @@ publish-pacts:
 		-H "Content-Type: application/json" \
 		-d@pacts/replicated-cli-vendor-graphql-api.json \
 		https://replicated-pact-broker.herokuapp.com/pacts/provider/vendor-graphql-api/consumer/replicated-cli/version/$(VERSION)
-
-publish-pacts-prerelease:
-	curl \
-		--silent --output /dev/null --show-error --fail \
-		--user ${PACT_BROKER_USERNAME}:${PACT_BROKER_PASSWORD} \
-		-X PUT \
-		-H "Content-Type: application/json" \
-		-d@pacts/replicated-cli-vendor-graphql-api.json \
-		https://replicated-pact-broker.herokuapp.com/pacts/provider/vendor-graphql-api/consumer/replicated-cli/version/$(PREVERSION)
 
 # fetch the swagger specs from the production Vendor API
 get-spec-prod:


### PR DESCRIPTION
This way we keep the 'best' of both worlds - we don't need to release this in order to publish the new pact tests, but we avoid cluttering up the pact test matrix with every commit that gets pushed.

Tags will have versions like `v0.10.0`, untagged versions like `v0.10.0-postrelease`.