### PR TITLE
cli/cmd: Fix for string interpolation in error message

### DIFF
--- a/cli/cmd/collector_inspect.go
+++ b/cli/cmd/collector_inspect.go
@@ -29,7 +29,7 @@ func (r *runners) collectorInspect(cmd *cobra.Command, args []string) error {
 	collector, err := r.api.GetCollector(r.appID, id)
 	if err != nil {
 		if err == platformclient.ErrNotFound {
-			return fmt.Errorf("No such collector %d", id)
+			return fmt.Errorf("no such collector '%s'", id)
 		}
 		return err
 	}

--- a/cli/cmd/collector_inspect.go
+++ b/cli/cmd/collector_inspect.go
@@ -29,7 +29,7 @@ func (r *runners) collectorInspect(cmd *cobra.Command, args []string) error {
 	collector, err := r.api.GetCollector(r.appID, id)
 	if err != nil {
 		if err == platformclient.ErrNotFound {
-			return fmt.Errorf("no such collector '%s'", id)
+			return fmt.Errorf("no such collector %q", id)
 		}
 		return err
 	}


### PR DESCRIPTION
Found an error message interpolating a string as an integer.