### PR TITLE
add 'metadata: null' to pact jsons

### DIFF
--- a/pacts/replicated-cli-vendor-api.json
+++ b/pacts/replicated-cli-vendor-api.json
@@ -46,7 +46,8 @@
             "match": "type"
           }
         }
-      }
+      },
+      "metadata": null
     },
     {
       "description": "An empty request to create a new release for cli-create-release-app-id",
@@ -83,7 +84,8 @@
             "match": "type"
           }
         }
-      }
+      },
+      "metadata": null
     },
     {
       "description": "A request to get an existing release for cli-create-release-app-id",
@@ -117,7 +119,8 @@
             "match": "type"
           }
         }
-      }
+      },
+      "metadata": null
     }
   ],
   "metadata": {

--- a/pacts/replicated-cli-vendor-graphql-api.json
+++ b/pacts/replicated-cli-vendor-graphql-api.json
@@ -51,7 +51,8 @@
             "match": "type"
           }
         }
-      }
+      },
+      "metadata": null
     },
     {
       "description": "A request to upload a new release for ship-app-1",
@@ -91,7 +92,8 @@
             "match": "type"
           }
         }
-      }
+      },
+      "metadata": null
     },
     {
       "description": "A request to finalize a nonexistent uploaded release for ship-app-1",
@@ -150,7 +152,8 @@
             "match": "type"
           }
         }
-      }
+      },
+      "metadata": null
     },
     {
       "description": "A mocked minimal request to promote a new release for ship-app-1",
@@ -192,7 +195,8 @@
             "match": "type"
           }
         }
-      }
+      },
+      "metadata": null
     },
     {
       "description": "A real request to promote a new release for ship-app-1",
@@ -235,7 +239,8 @@
             "match": "type"
           }
         }
-      }
+      },
+      "metadata": null
     },
     {
       "description": "A real request to list releases for ship-app-1",
@@ -281,7 +286,8 @@
             "match": "type"
           }
         }
-      }
+      },
+      "metadata": null
     },
     {
       "description": "A real request to lint a release for ship-app-1",
@@ -360,7 +366,8 @@
             "match": "type"
           }
         }
-      }
+      },
+      "metadata": null
     }
   ],
   "metadata": {


### PR DESCRIPTION
For some reason having a newer version of the golang:1.12 image results in different output