### PR TITLE
add --ensure-channel flag for kots apps

### DIFF
--- a/cli/cmd/entitlements_getcustomerrelease.go
+++ b/cli/cmd/entitlements_getcustomerrelease.go
@@ -13,20 +13,18 @@ import (
 	"github.com/spf13/cobra"
 )
 
-
-func (r * runners) InitEntitlementsGetCustomerReleaseCommand(parent *cobra.Command) {
+func (r *runners) InitEntitlementsGetCustomerReleaseCommand(parent *cobra.Command) {
 	var entitlementsGetCustomerRelease = &cobra.Command{
 		Use:   "get-customer-release",
 		Short: "Preview the end customer release view",
-		Long: `Preview the end customer release view for a given customer ID + installation ID`,
-		RunE: r.entitlementsGetCustomerRelease,
+		Long:  `Preview the end customer release view for a given customer ID + installation ID`,
+		RunE:  r.entitlementsGetCustomerRelease,
 	}
 
-
-	entitlementsGetCustomerRelease.Flags().StringVar(&r.args.entitlementsGetReleaseCustomerID,"customer-id", "", "customer id")
-	entitlementsGetCustomerRelease.Flags().StringVar(&r.args.entitlementsGetReleaseInstallationID,"installation-id", "", "installation id")
+	entitlementsGetCustomerRelease.Flags().StringVar(&r.args.entitlementsGetReleaseCustomerID, "customer-id", "", "customer id")
+	entitlementsGetCustomerRelease.Flags().StringVar(&r.args.entitlementsGetReleaseInstallationID, "installation-id", "", "installation id")
 	// change the default from g.replicated.com to pg.replicated.com
-	entitlementsGetCustomerRelease.Flags().StringVar(&r.args.entitlementsGetReleaseAPIServer,"replicated-api-server", "https://pg.replicated.com/graphql", "Upstream api server")
+	entitlementsGetCustomerRelease.Flags().StringVar(&r.args.entitlementsGetReleaseAPIServer, "replicated-api-server", "https://pg.replicated.com/graphql", "Upstream api server")
 
 	parent.AddCommand(entitlementsGetCustomerRelease)
 }
@@ -55,10 +53,10 @@ func (r *runners) entitlementsGetCustomerRelease(cmd *cobra.Command, args []stri
 	}
 
 	client := &entitlements.PremGraphQLClient{
-		GQLServer: upstream,
-		CustomerID: r.args.entitlementsGetReleaseCustomerID,
+		GQLServer:      upstream,
+		CustomerID:     r.args.entitlementsGetReleaseCustomerID,
 		InstallationID: r.args.entitlementsGetReleaseInstallationID,
-		Logger:    stdoutLogger,
+		Logger:         stdoutLogger,
 	}
 
 	espec, err := client.FetchCustomerRelease()

--- a/cli/cmd/release_create.go
+++ b/cli/cmd/release_create.go
@@ -191,6 +191,8 @@ func (r *runners) getOrCreateChannelForPromotion() (string, error) {
 			if err != nil {
 				return "", errors.Wrapf(err, "create channel %q ", channelID)
 			}
+			fmt.Fprintf(r.w, "Created channel %q with ID %q", r.args.createReleasePromote, channelID)
+
 			return channelID, nil
 		}
 

--- a/cli/cmd/runner.go
+++ b/cli/cmd/runner.go
@@ -41,27 +41,28 @@ type runnerArgs struct {
 	updateCollectorYamlFile string
 	updateCollectorName     string
 
-	createReleaseYaml              string
-	createReleaseYamlFile          string
-	createReleaseYamlDir           string
-	createReleaseConfigYaml        string
-	createReleaseDeploymentYaml    string
-	createReleaseServiceYaml       string
-	createReleasePreflightYaml     string
-	createReleaseSupportBundleYaml string
-	createReleasePromote           string
-	createReleasePromoteDir        string
-	createReleasePromoteRequired   bool
-	createReleasePromoteNotes      string
-	createReleasePromoteVersion    string
-	lintReleaseYaml                string
-	lintReleaseYamlFile            string
-	releaseOptional                bool
-	releaseNotes                   string
-	releaseVersion                 string
-	updateReleaseYaml              string
-	updateReleaseYamlDir           string
-	updateReleaseYamlFile          string
+	createReleaseYaml                 string
+	createReleaseYamlFile             string
+	createReleaseYamlDir              string
+	createReleaseConfigYaml           string
+	createReleaseDeploymentYaml       string
+	createReleaseServiceYaml          string
+	createReleasePreflightYaml        string
+	createReleaseSupportBundleYaml    string
+	createReleasePromote              string
+	createReleasePromoteDir           string
+	createReleasePromoteRequired      bool
+	createReleasePromoteNotes         string
+	createReleasePromoteVersion       string
+	createReleasePromoteEnsureChannel bool
+	lintReleaseYaml                   string
+	lintReleaseYamlFile               string
+	releaseOptional                   bool
+	releaseNotes                      string
+	releaseVersion                    string
+	updateReleaseYaml                 string
+	updateReleaseYamlDir              string
+	updateReleaseYamlFile             string
 
 	entitlementsAPIServer                string
 	entitlementsVerbose                  bool

--- a/cli/test/util.go
+++ b/cli/test/util.go
@@ -105,7 +105,7 @@ func cleanupApps() {
 		t.Fatal(err)
 	}
 
-	req, err := http.NewRequest("POST", idOrigin + "/v1/login", buf)
+	req, err := http.NewRequest("POST", idOrigin+"/v1/login", buf)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/channel.go
+++ b/client/channel.go
@@ -77,7 +77,7 @@ func (c *Client) CreateChannel(appID string, appType string, name string, descri
 		}
 		return c.ShipClient.ListChannels(appID)
 	} else if appType == "kots" {
-		if err := c.KotsClient.CreateChannel(appID, name, description); err != nil {
+		if _, err := c.KotsClient.CreateChannel(appID, name, description); err != nil {
 			return nil, err
 		}
 		return c.KotsClient.ListChannels(appID)

--- a/pkg/kotsclient/channel.go
+++ b/pkg/kotsclient/channel.go
@@ -17,11 +17,15 @@ type GraphQLResponseGetChannel struct {
 }
 
 type GraphQLResponseCreateChannel struct {
-	Data   *KotsGetChannelData `json:"data,omitempty"`
-	Errors []graphql.GQLError  `json:"errors,omitempty"`
+	Data   *KotsCreateChannelData `json:"data,omitempty"`
+	Errors []graphql.GQLError     `json:"errors,omitempty"`
 }
 
 type KotsGetChannelData struct {
+	KotsChannel *KotsChannel `json:"getKotsChannel"`
+}
+
+type KotsCreateChannelData struct {
 	KotsChannel *KotsChannel `json:"createKotsChannel"`
 }
 type KotsChannelData struct {

--- a/pkg/kotsclient/channel.go
+++ b/pkg/kotsclient/channel.go
@@ -15,8 +15,14 @@ type GraphQLResponseGetChannel struct {
 	Data   *KotsGetChannelData `json:"data,omitempty"`
 	Errors []graphql.GQLError  `json:"errors,omitempty"`
 }
+
+type GraphQLResponseCreateChannel struct {
+	Data   *KotsGetChannelData `json:"data,omitempty"`
+	Errors []graphql.GQLError  `json:"errors,omitempty"`
+}
+
 type KotsGetChannelData struct {
-	KotsChannel *KotsChannel `json:"getKotsChannel"`
+	KotsChannel *KotsChannel `json:"createKotsChannel"`
 }
 type KotsChannelData struct {
 	KotsChannels []*KotsChannel `json:"getKotsAppChannels"`
@@ -111,8 +117,8 @@ func (c *GraphQLClient) ListChannels(appID string) ([]types.Channel, error) {
 	return channels, nil
 }
 
-func (c *GraphQLClient) CreateChannel(appID string, name string, description string) error {
-	response := graphql.ResponseErrorOnly{}
+func (c *GraphQLClient) CreateChannel(appID string, name string, description string) (string, error) {
+	response := GraphQLResponseCreateChannel{}
 
 	request := graphql.Request{
 		Query: `
@@ -139,10 +145,10 @@ func (c *GraphQLClient) CreateChannel(appID string, name string, description str
 	}
 
 	if err := c.ExecuteRequest(request, &response); err != nil {
-		return err
+		return "", err
 	}
 
-	return nil
+	return response.Data.KotsChannel.ID, nil
 
 }
 

--- a/pkg/kotsclient/client.go
+++ b/pkg/kotsclient/client.go
@@ -16,7 +16,7 @@ type Client interface {
 	PromoteRelease(appID string, sequence int64, label string, notes string, channelIDs ...string) error
 
 	ListChannels(string) ([]types.Channel, error)
-	CreateChannel(string, string, string) error
+	CreateChannel(appID string, name string, description string) (string, error)
 	GetChannel(appID, channelID string) (*channels.AppChannel, []channels.ChannelRelease, error)
 }
 


### PR DESCRIPTION
Now you can do something like

```shell
replicated release create \
  --yaml-dir=./manifests/ \
  --promote=${GITHUB_BRANCH} \
  --ensure-channel
```

And it will promote the release to the `${GITHUB_BRANCH}` channel, creating that channel if it does not exist yet.