### PR TITLE
Hide the functionality shown in Vendor CLI so that it only shows what is usable with KOTS applications.

### DIFF
--- a/cli/cmd/channel_adoption.go
+++ b/cli/cmd/channel_adoption.go
@@ -13,7 +13,7 @@ func (r *runners) InitChannelAdoption(parent *cobra.Command) {
 		Short: "Print channel adoption statistics by license type",
 		Long:  "Print channel adoption statistics by license type",
 	}
-
+	cmd.Hidden=true; // Not supported in KOTS (ch #22646)
 	parent.AddCommand(cmd)
 	cmd.RunE = r.channelAdoption
 }

--- a/cli/cmd/channel_adoption.go
+++ b/cli/cmd/channel_adoption.go
@@ -13,7 +13,7 @@ func (r *runners) InitChannelAdoption(parent *cobra.Command) {
 		Short: "Print channel adoption statistics by license type",
 		Long:  "Print channel adoption statistics by license type",
 	}
-	cmd.Hidden=true; // Not supported in KOTS (ch #22646)
+	cmd.Hidden=true; // Not supported in KOTS 
 	parent.AddCommand(cmd)
 	cmd.RunE = r.channelAdoption
 }

--- a/cli/cmd/channel_counts.go
+++ b/cli/cmd/channel_counts.go
@@ -13,7 +13,7 @@ func (r *runners) InitChannelCounts(parent *cobra.Command) {
 		Short: "Print channel license counts",
 		Long:  "Print channel license counts",
 	}
-
+	cmd.Hidden=true; // Not supported in KOTS (ch #22646)
 	parent.AddCommand(cmd)
 	cmd.RunE = r.channelCounts
 }

--- a/cli/cmd/channel_counts.go
+++ b/cli/cmd/channel_counts.go
@@ -13,7 +13,7 @@ func (r *runners) InitChannelCounts(parent *cobra.Command) {
 		Short: "Print channel license counts",
 		Long:  "Print channel license counts",
 	}
-	cmd.Hidden=true; // Not supported in KOTS (ch #22646)
+	cmd.Hidden=true; // Not supported in KOTS 
 	parent.AddCommand(cmd)
 	cmd.RunE = r.channelCounts
 }

--- a/cli/cmd/channel_create.go
+++ b/cli/cmd/channel_create.go
@@ -14,7 +14,7 @@ func (r *runners) InitChannelCreate(parent *cobra.Command) {
   Example:
   replicated channel create --name Beta --description 'New features subject to change'`,
 	}
-
+	cmd.Hidden=true; // Not supported in KOTS (ch #22646)
 	parent.AddCommand(cmd)
 
 	cmd.Flags().StringVar(&r.args.channelCreateName, "name", "", "The name of this channel")

--- a/cli/cmd/channel_create.go
+++ b/cli/cmd/channel_create.go
@@ -14,7 +14,7 @@ func (r *runners) InitChannelCreate(parent *cobra.Command) {
   Example:
   replicated channel create --name Beta --description 'New features subject to change'`,
 	}
-	cmd.Hidden=true; // Not supported in KOTS (ch #22646)
+	cmd.Hidden=true; // Not supported in KOTS 
 	parent.AddCommand(cmd)
 
 	cmd.Flags().StringVar(&r.args.channelCreateName, "name", "", "The name of this channel")

--- a/cli/cmd/channel_inspect.go
+++ b/cli/cmd/channel_inspect.go
@@ -14,7 +14,7 @@ func (r *runners) InitChannelInspect(parent *cobra.Command) {
 		Short: "Show full details for a channel",
 		Long:  "Show full details for a channel",
 	}
-
+	cmd.Hidden=true; // Not supported in KOTS (ch #22646)
 	parent.AddCommand(cmd)
 	cmd.RunE = r.channelInspect
 }

--- a/cli/cmd/channel_inspect.go
+++ b/cli/cmd/channel_inspect.go
@@ -14,7 +14,7 @@ func (r *runners) InitChannelInspect(parent *cobra.Command) {
 		Short: "Show full details for a channel",
 		Long:  "Show full details for a channel",
 	}
-	cmd.Hidden=true; // Not supported in KOTS (ch #22646)
+	cmd.Hidden=true; // Not supported in KOTS 
 	parent.AddCommand(cmd)
 	cmd.RunE = r.channelInspect
 }

--- a/cli/cmd/channel_releases.go
+++ b/cli/cmd/channel_releases.go
@@ -13,7 +13,7 @@ func (r *runners) InitChannelReleases(parent *cobra.Command) {
 		Short: "List all releases in a channel",
 		Long:  "List all releases in a channel",
 	}
-	cmd.Hidden=true; // Not supported in KOTS (ch #22646)
+	cmd.Hidden=true; // Not supported in KOTS 
 	parent.AddCommand(cmd)
 	cmd.RunE = r.channelReleases
 }

--- a/cli/cmd/channel_releases.go
+++ b/cli/cmd/channel_releases.go
@@ -13,7 +13,7 @@ func (r *runners) InitChannelReleases(parent *cobra.Command) {
 		Short: "List all releases in a channel",
 		Long:  "List all releases in a channel",
 	}
-
+	cmd.Hidden=true; // Not supported in KOTS (ch #22646)
 	parent.AddCommand(cmd)
 	cmd.RunE = r.channelReleases
 }

--- a/cli/cmd/channel_rm.go
+++ b/cli/cmd/channel_rm.go
@@ -13,7 +13,7 @@ func (r *runners) InitChannelRemove(parent *cobra.Command) {
 		Short: "Remove (archive) a channel",
 		Long:  "Remove (archive) a channel",
 	}
-	cmd.Hidden=true; // Not supported in KOTS (ch #22646)
+	cmd.Hidden=true; // Not supported in KOTS 
 	parent.AddCommand(cmd)
 	cmd.RunE = r.channelRemove
 }

--- a/cli/cmd/channel_rm.go
+++ b/cli/cmd/channel_rm.go
@@ -13,7 +13,7 @@ func (r *runners) InitChannelRemove(parent *cobra.Command) {
 		Short: "Remove (archive) a channel",
 		Long:  "Remove (archive) a channel",
 	}
-
+	cmd.Hidden=true; // Not supported in KOTS (ch #22646)
 	parent.AddCommand(cmd)
 	cmd.RunE = r.channelRemove
 }

--- a/cli/cmd/collector_create.go
+++ b/cli/cmd/collector_create.go
@@ -13,7 +13,7 @@ func (r *runners) InitCollectorCreate(parent *cobra.Command) {
 		Short: "Create a new collector",
 		Long:  "Create a new collector by providing a name and YAML configuration",
 	}
-
+	cmd.Hidden=true; // Not supported in KOTS (ch #22646)
 	parent.AddCommand(cmd)
 
 	cmd.Flags().StringVar(&r.args.createCollectorYaml, "yaml", "", "The YAML config for this collector. Use '-' to read from stdin.  Cannot be used with the `yaml-file` falg.")

--- a/cli/cmd/collector_create.go
+++ b/cli/cmd/collector_create.go
@@ -13,7 +13,7 @@ func (r *runners) InitCollectorCreate(parent *cobra.Command) {
 		Short: "Create a new collector",
 		Long:  "Create a new collector by providing a name and YAML configuration",
 	}
-	cmd.Hidden=true; // Not supported in KOTS (ch #22646)
+	cmd.Hidden=true; // Not supported in KOTS 
 	parent.AddCommand(cmd)
 
 	cmd.Flags().StringVar(&r.args.createCollectorYaml, "yaml", "", "The YAML config for this collector. Use '-' to read from stdin.  Cannot be used with the `yaml-file` falg.")

--- a/cli/cmd/collector_inspect.go
+++ b/cli/cmd/collector_inspect.go
@@ -15,7 +15,7 @@ func (r *runners) InitCollectorInspect(parent *cobra.Command) {
 		Short: "Print the YAML config for a collector",
 		Long:  "Print the YAML config for a collector",
 	}
-	cmd.Hidden=true; // Not supported in KOTS (ch #22646)
+	cmd.Hidden=true; // Not supported in KOTS 
 	parent.AddCommand(cmd)
 	cmd.RunE = r.collectorInspect
 }

--- a/cli/cmd/collector_inspect.go
+++ b/cli/cmd/collector_inspect.go
@@ -15,7 +15,7 @@ func (r *runners) InitCollectorInspect(parent *cobra.Command) {
 		Short: "Print the YAML config for a collector",
 		Long:  "Print the YAML config for a collector",
 	}
-
+	cmd.Hidden=true; // Not supported in KOTS (ch #22646)
 	parent.AddCommand(cmd)
 	cmd.RunE = r.collectorInspect
 }

--- a/cli/cmd/collector_ls.go
+++ b/cli/cmd/collector_ls.go
@@ -11,7 +11,7 @@ func (r *runners) InitCollectorList(parent *cobra.Command) {
 		Short: "List all of an app's collectors",
 		Long:  "List all of an app's collectors",
 	}
-
+	cmd.Hidden=true; // Not supported in KOTS (ch #22646)
 	parent.AddCommand(cmd)
 	cmd.RunE = r.collectorList
 }

--- a/cli/cmd/collector_ls.go
+++ b/cli/cmd/collector_ls.go
@@ -11,7 +11,7 @@ func (r *runners) InitCollectorList(parent *cobra.Command) {
 		Short: "List all of an app's collectors",
 		Long:  "List all of an app's collectors",
 	}
-	cmd.Hidden=true; // Not supported in KOTS (ch #22646)
+	cmd.Hidden=true; // Not supported in KOTS 
 	parent.AddCommand(cmd)
 	cmd.RunE = r.collectorList
 }

--- a/cli/cmd/collector_promote.go
+++ b/cli/cmd/collector_promote.go
@@ -15,7 +15,7 @@ func (r *runners) InitCollectorPromote(parent *cobra.Command) {
 
   Example: replicated collectors promote skd204095829040 fe4901690971757689f022f7a460f9b2`,
 	}
-	cmd.Hidden=true; // Not supported in KOTS (ch #22646)
+	cmd.Hidden=true; // Not supported in KOTS 
 	parent.AddCommand(cmd)
 
 	cmd.RunE = r.collectorPromote

--- a/cli/cmd/collector_promote.go
+++ b/cli/cmd/collector_promote.go
@@ -15,7 +15,7 @@ func (r *runners) InitCollectorPromote(parent *cobra.Command) {
 
   Example: replicated collectors promote skd204095829040 fe4901690971757689f022f7a460f9b2`,
 	}
-
+	cmd.Hidden=true; // Not supported in KOTS (ch #22646)
 	parent.AddCommand(cmd)
 
 	cmd.RunE = r.collectorPromote

--- a/cli/cmd/collector_update.go
+++ b/cli/cmd/collector_update.go
@@ -14,7 +14,7 @@ func (r *runners) InitCollectorUpdate(parent *cobra.Command) {
 		Short: "Update a collector's name or yaml config",
 		Long:  "Update a collector's name or yaml config",
 	}
-	cmd.Hidden=true; // Not supported in KOTS (ch #22646)
+	cmd.Hidden=true; // Not supported in KOTS 
 	parent.AddCommand(cmd)
 
 	cmd.Flags().StringVar(&r.args.updateCollectorYaml, "yaml", "", "The new YAML config for this collector. Use '-' to read from stdin.  Cannot be used with the `yaml-file` flag.")

--- a/cli/cmd/collector_update.go
+++ b/cli/cmd/collector_update.go
@@ -14,7 +14,7 @@ func (r *runners) InitCollectorUpdate(parent *cobra.Command) {
 		Short: "Update a collector's name or yaml config",
 		Long:  "Update a collector's name or yaml config",
 	}
-
+	cmd.Hidden=true; // Not supported in KOTS (ch #22646)
 	parent.AddCommand(cmd)
 
 	cmd.Flags().StringVar(&r.args.updateCollectorYaml, "yaml", "", "The new YAML config for this collector. Use '-' to read from stdin.  Cannot be used with the `yaml-file` flag.")

--- a/cli/cmd/collectors.go
+++ b/cli/cmd/collectors.go
@@ -5,15 +5,16 @@ import (
 )
 
 func (r *runners) InitCollectorsCommand(parent *cobra.Command) *cobra.Command {
-	collectorsCmd := &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "collector",
 		Short: "Manage customer collectors",
 		Long:  `The collector command allows vendors to create, display, modify entitlement values for end customer licensing.`,
 	}
-	parent.AddCommand(collectorsCmd)
+	cmd.Hidden=true; // Not supported in KOTS (ch #22646)
+	parent.AddCommand(cmd)
 
 	var tmp bool
-	collectorsCmd.Flags().BoolVar(&tmp, "active", false, "Only show active collectors")
+	cmd.Flags().BoolVar(&tmp, "active", false, "Only show active collectors")
 
-	return collectorsCmd
+	return cmd
 }

--- a/cli/cmd/collectors.go
+++ b/cli/cmd/collectors.go
@@ -10,7 +10,7 @@ func (r *runners) InitCollectorsCommand(parent *cobra.Command) *cobra.Command {
 		Short: "Manage customer collectors",
 		Long:  `The collector command allows vendors to create, display, modify entitlement values for end customer licensing.`,
 	}
-	cmd.Hidden=true; // Not supported in KOTS (ch #22646)
+	cmd.Hidden=true; // Not supported in KOTS 
 	parent.AddCommand(cmd)
 
 	var tmp bool

--- a/cli/cmd/entitlements.go
+++ b/cli/cmd/entitlements.go
@@ -10,7 +10,7 @@ func (r *runners) InitEntitlementsCommand(parent *cobra.Command) *cobra.Command 
 		Short: "Manage customer entitlements",
 		Long:  `The entitlements command allows vendors to create, display, modify entitlement values for end customer licensing.`,
 	}
-	cmd.Hidden=true; // Not supported in KOTS (ch #22646)
+	cmd.Hidden=true; // Not supported in KOTS 
 	parent.AddCommand(cmd)
 
 	cmd.PersistentFlags().StringVar(&r.args.entitlementsAPIServer, "replicated-api-server", "https://g.replicated.com/graphql", "upstream g. address")

--- a/cli/cmd/entitlements.go
+++ b/cli/cmd/entitlements.go
@@ -5,15 +5,16 @@ import (
 )
 
 func (r *runners) InitEntitlementsCommand(parent *cobra.Command) *cobra.Command {
-	entitlementsCmd := &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "entitlements",
 		Short: "Manage customer entitlements",
 		Long:  `The entitlements command allows vendors to create, display, modify entitlement values for end customer licensing.`,
 	}
-	parent.AddCommand(entitlementsCmd)
+	cmd.Hidden=true; // Not supported in KOTS (ch #22646)
+	parent.AddCommand(cmd)
 
-	entitlementsCmd.PersistentFlags().StringVar(&r.args.entitlementsAPIServer, "replicated-api-server", "https://g.replicated.com/graphql", "upstream g. address")
-	entitlementsCmd.PersistentFlags().BoolVarP(&r.args.entitlementsVerbose, "verbose", "p", false, "verbose logging")
+	cmd.PersistentFlags().StringVar(&r.args.entitlementsAPIServer, "replicated-api-server", "https://g.replicated.com/graphql", "upstream g. address")
+	cmd.PersistentFlags().BoolVarP(&r.args.entitlementsVerbose, "verbose", "p", false, "verbose logging")
 
-	return entitlementsCmd
+	return cmd
 }

--- a/cli/cmd/entitlements_definefields.go
+++ b/cli/cmd/entitlements_definefields.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (r *runners) InitEntitlementsDefineFields(parent *cobra.Command) {
-	entitlementsDefineFields := &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "define-fields",
 		Short: "Define entitlements fields",
 		Long: `Define the fields that can be assigned on a per customer
@@ -19,10 +19,10 @@ basis and delivered securely to your on-prem application`,
 		RunE: r.entitlementsDefineFields,
 	}
 
-	entitlementsDefineFields.Flags().StringVar(&r.args.entitlementsDefineFieldsFile, "file", "entitlements.yaml", "definitions file to promote")
-	entitlementsDefineFields.Flags().StringVar(&r.args.entitlementsDefineFieldsName, "name", "", "name for this definition")
-
-	parent.AddCommand(entitlementsDefineFields)
+	cmd.Flags().StringVar(&r.args.entitlementsDefineFieldsFile, "file", "entitlements.yaml", "definitions file to promote")
+	cmd.Flags().StringVar(&r.args.entitlementsDefineFieldsName, "name", "", "name for this definition")
+	cmd.Hidden=true; // Not supported in KOTS (ch #22646)
+	parent.AddCommand(cmd)
 }
 
 func (r *runners) entitlementsDefineFields(cmd *cobra.Command, args []string) error {

--- a/cli/cmd/entitlements_definefields.go
+++ b/cli/cmd/entitlements_definefields.go
@@ -21,7 +21,7 @@ basis and delivered securely to your on-prem application`,
 
 	cmd.Flags().StringVar(&r.args.entitlementsDefineFieldsFile, "file", "entitlements.yaml", "definitions file to promote")
 	cmd.Flags().StringVar(&r.args.entitlementsDefineFieldsName, "name", "", "name for this definition")
-	cmd.Hidden=true; // Not supported in KOTS (ch #22646)
+	cmd.Hidden=true; // Not supported in KOTS 
 	parent.AddCommand(cmd)
 }
 

--- a/cli/cmd/entitlements_getcustomerrelease.go
+++ b/cli/cmd/entitlements_getcustomerrelease.go
@@ -14,19 +14,19 @@ import (
 )
 
 func (r *runners) InitEntitlementsGetCustomerReleaseCommand(parent *cobra.Command) {
-	var entitlementsGetCustomerRelease = &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "get-customer-release",
 		Short: "Preview the end customer release view",
 		Long:  `Preview the end customer release view for a given customer ID + installation ID`,
 		RunE:  r.entitlementsGetCustomerRelease,
 	}
 
-	entitlementsGetCustomerRelease.Flags().StringVar(&r.args.entitlementsGetReleaseCustomerID, "customer-id", "", "customer id")
-	entitlementsGetCustomerRelease.Flags().StringVar(&r.args.entitlementsGetReleaseInstallationID, "installation-id", "", "installation id")
+	cmd.Flags().StringVar(&r.args.entitlementsGetReleaseCustomerID, "customer-id", "", "customer id")
+	cmd.Flags().StringVar(&r.args.entitlementsGetReleaseInstallationID, "installation-id", "", "installation id")
 	// change the default from g.replicated.com to pg.replicated.com
-	entitlementsGetCustomerRelease.Flags().StringVar(&r.args.entitlementsGetReleaseAPIServer, "replicated-api-server", "https://pg.replicated.com/graphql", "Upstream api server")
-
-	parent.AddCommand(entitlementsGetCustomerRelease)
+	cmd.Flags().StringVar(&r.args.entitlementsGetReleaseAPIServer, "replicated-api-server", "https://pg.replicated.com/graphql", "Upstream api server")
+	cmd.Hidden=true; // Not supported in KOTS (ch #22646)
+	parent.AddCommand(cmd)
 }
 
 func (r *runners) entitlementsGetCustomerRelease(cmd *cobra.Command, args []string) error {

--- a/cli/cmd/entitlements_getcustomerrelease.go
+++ b/cli/cmd/entitlements_getcustomerrelease.go
@@ -25,7 +25,7 @@ func (r *runners) InitEntitlementsGetCustomerReleaseCommand(parent *cobra.Comman
 	cmd.Flags().StringVar(&r.args.entitlementsGetReleaseInstallationID, "installation-id", "", "installation id")
 	// change the default from g.replicated.com to pg.replicated.com
 	cmd.Flags().StringVar(&r.args.entitlementsGetReleaseAPIServer, "replicated-api-server", "https://pg.replicated.com/graphql", "Upstream api server")
-	cmd.Hidden=true; // Not supported in KOTS (ch #22646)
+	cmd.Hidden=true; // Not supported in KOTS 
 	parent.AddCommand(cmd)
 }
 

--- a/cli/cmd/entitlements_setvalue.go
+++ b/cli/cmd/entitlements_setvalue.go
@@ -8,24 +8,25 @@ import (
 )
 
 func (r *runners) InitEntitlementsSetValueCommand(parent *cobra.Command) {
-	entitlementsSetValue := &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "set-value",
 		Short: "Set a customer value for an entitlement field defined via 'replicated entitlements define-fields'",
 		Long:  `Set a customer value for an entitlement field defined via 'replicated entitlements define-fields'`,
 		RunE:  r.entitlementsSetValue,
 	}
-	parent.AddCommand(entitlementsSetValue)
+	cmd.Hidden=true; // Not supported in KOTS (ch #22646)
+	parent.AddCommand(cmd)
 
-	entitlementsSetValue.Flags().StringVar(&r.args.entitlementsSetValueDefinitionsID, "definitions-id", "", "definitions id created with define-fields command")
-	entitlementsSetValue.Flags().StringVar(&r.args.entitlementsSetValueCustomerID, "customer-id", "", "customer id to assign the value to")
-	entitlementsSetValue.Flags().StringVar(&r.args.entitlementsSetValueKey, "key", "", "field key")
-	entitlementsSetValue.Flags().StringVar(&r.args.entitlementsSetValueValue, "value", "", "value to set")
-	entitlementsSetValue.Flags().StringVar(&r.args.entitlementsSetValueType, "type", "string", "type of data. Much match 'type' in the field definition. Defaults to 'string'.")
+	cmd.Flags().StringVar(&r.args.entitlementsSetValueDefinitionsID, "definitions-id", "", "definitions id created with define-fields command")
+	cmd.Flags().StringVar(&r.args.entitlementsSetValueCustomerID, "customer-id", "", "customer id to assign the value to")
+	cmd.Flags().StringVar(&r.args.entitlementsSetValueKey, "key", "", "field key")
+	cmd.Flags().StringVar(&r.args.entitlementsSetValueValue, "value", "", "value to set")
+	cmd.Flags().StringVar(&r.args.entitlementsSetValueType, "type", "string", "type of data. Much match 'type' in the field definition. Defaults to 'string'.")
 
-	entitlementsSetValue.MarkFlagRequired("definitions-id")
-	entitlementsSetValue.MarkFlagRequired("customer-id")
-	entitlementsSetValue.MarkFlagRequired("key")
-	entitlementsSetValue.MarkFlagRequired("value")
+	cmd.MarkFlagRequired("definitions-id")
+	cmd.MarkFlagRequired("customer-id")
+	cmd.MarkFlagRequired("key")
+	cmd.MarkFlagRequired("value")
 }
 
 func (r *runners) entitlementsSetValue(cmd *cobra.Command, args []string) error {

--- a/cli/cmd/entitlements_setvalue.go
+++ b/cli/cmd/entitlements_setvalue.go
@@ -14,7 +14,7 @@ func (r *runners) InitEntitlementsSetValueCommand(parent *cobra.Command) {
 		Long:  `Set a customer value for an entitlement field defined via 'replicated entitlements define-fields'`,
 		RunE:  r.entitlementsSetValue,
 	}
-	cmd.Hidden=true; // Not supported in KOTS (ch #22646)
+	cmd.Hidden=true; // Not supported in KOTS 
 	parent.AddCommand(cmd)
 
 	cmd.Flags().StringVar(&r.args.entitlementsSetValueDefinitionsID, "definitions-id", "", "definitions id created with define-fields command")

--- a/cli/cmd/release_inspect.go
+++ b/cli/cmd/release_inspect.go
@@ -16,7 +16,7 @@ func (r *runners) InitReleaseInspect(parent *cobra.Command) {
 		Short: "Print the YAML config for a release",
 		Long:  "Print the YAML config for a release",
 	}
-
+	cmd.Hidden=true; // Not supported in KOTS (ch #22646)
 	parent.AddCommand(cmd)
 	cmd.RunE = r.releaseInspect
 }

--- a/cli/cmd/release_inspect.go
+++ b/cli/cmd/release_inspect.go
@@ -16,7 +16,7 @@ func (r *runners) InitReleaseInspect(parent *cobra.Command) {
 		Short: "Print the YAML config for a release",
 		Long:  "Print the YAML config for a release",
 	}
-	cmd.Hidden=true; // Not supported in KOTS (ch #22646)
+	cmd.Hidden=true; // Not supported in KOTS 
 	parent.AddCommand(cmd)
 	cmd.RunE = r.releaseInspect
 }

--- a/cli/cmd/release_lint.go
+++ b/cli/cmd/release_lint.go
@@ -14,7 +14,7 @@ func (r *runners) InitReleaseLint(parent *cobra.Command) {
 		Short: "Lint a YAML",
 		Long:  "Lint a YAML",
 	}
-	cmd.Hidden=true; // Not supported in KOTS (ch #22646)
+	cmd.Hidden=true; // Not supported in KOTS 
 	parent.AddCommand(cmd)
 
 	cmd.Flags().StringVar(&r.args.lintReleaseYaml, "yaml", "", "The YAML config to lint. Use '-' to read from stdin.  Cannot be used with the `yaml-file` flag.")

--- a/cli/cmd/release_lint.go
+++ b/cli/cmd/release_lint.go
@@ -14,7 +14,7 @@ func (r *runners) InitReleaseLint(parent *cobra.Command) {
 		Short: "Lint a YAML",
 		Long:  "Lint a YAML",
 	}
-
+	cmd.Hidden=true; // Not supported in KOTS (ch #22646)
 	parent.AddCommand(cmd)
 
 	cmd.Flags().StringVar(&r.args.lintReleaseYaml, "yaml", "", "The YAML config to lint. Use '-' to read from stdin.  Cannot be used with the `yaml-file` flag.")

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -99,13 +99,13 @@ func Execute(rootCmd *cobra.Command, stdin io.Reader, stdout io.Writer, stderr i
 
 	channelCmd := &cobra.Command{
 		Use:   "channel",
-		Short: "Manage and review channels",
-		Long:  "Manage and review channels",
+		Short: "List channels",
+		Long:  "List channels",
 	}
 	var releaseCmd = &cobra.Command{
 		Use:   "release",
 		Short: "Manage app releases",
-		Long:  `The release command allows vendors to create, display, modify, and archive their releases.`,
+		Long:  `The release command allows vendors to create, display, and promote their releases.`,
 	}
 
 	runCmds.rootCmd.AddCommand(channelCmd)


### PR DESCRIPTION
Acceptance: Only the following commands show when typing the --help command (at root) or the <command> --help command.
release ls
release create
release create --promote
release promote
release update
channel ls
customer ls
customer create