### PR TITLE
implement kots release linting

### DIFF
--- a/cli/cmd/release_lint.go
+++ b/cli/cmd/release_lint.go
@@ -3,8 +3,6 @@ package cmd
 import (
 	"fmt"
 	"github.com/pkg/errors"
-	"io/ioutil"
-
 	"github.com/replicatedhq/replicated/cli/print"
 	"github.com/spf13/cobra"
 )
@@ -12,53 +10,28 @@ import (
 func (r *runners) InitReleaseLint(parent *cobra.Command) {
 	cmd := &cobra.Command{
 		Use:   "lint",
-		Short: "Lint a YAML",
-		Long:  "Lint a YAML",
+		Short: "Lint a directory of KOTS manifests",
+		Long: "Lint a directory of KOTS manifests",
 		SilenceUsage: true,
 	}
 	parent.AddCommand(cmd)
 
-	cmd.Flags().StringVar(&r.args.lintReleaseYaml, "yaml", "", "The YAML config to lint. Use '-' to read from stdin.  Cannot be used with the `yaml-file` flag.")
-	cmd.Flags().StringVar(&r.args.lintReleaseYamlFile, "yaml-file", "", "The file name with YAML config to lint.  Cannot be used with the `yaml` flag.")
 	cmd.Flags().StringVar(&r.args.lintReleaseYamlDir, "yaml-dir", "", "The directory containing multiple yamls for a Kots release.  Cannot be used with the `yaml` flag.")
 
 	cmd.RunE = r.releaseLint
 }
 
 func (r *runners) releaseLint(cmd *cobra.Command, args []string) error {
-	if r.args.lintReleaseYaml == "" && r.args.lintReleaseYamlFile == "" && r.args.lintReleaseYamlDir == "" {
+	if  r.args.lintReleaseYamlDir == "" {
 		return fmt.Errorf("yaml is required")
 	}
 
-	if r.args.lintReleaseYaml != "" && r.args.lintReleaseYamlFile != "" {
-		return fmt.Errorf("only yaml or yaml-file has to be specified")
+	lintReleaseYAML, err := readYAMLDir(r.args.lintReleaseYamlDir)
+	if err != nil {
+		return errors.Wrap(err, "read yaml dir")
 	}
 
-	if r.args.lintReleaseYaml == "-" {
-		bytes, err := ioutil.ReadAll(r.stdin)
-		if err != nil {
-			return err
-		}
-		r.args.lintReleaseYaml = string(bytes)
-	}
-
-	if r.args.lintReleaseYamlFile != "" {
-		bytes, err := ioutil.ReadFile(r.args.lintReleaseYamlFile)
-		if err != nil {
-			return err
-		}
-		r.args.lintReleaseYaml = string(bytes)
-	}
-
-	if r.args.lintReleaseYamlDir != "" {
-		var err error
-		r.args.lintReleaseYaml, err = readYAMLDir(r.args.lintReleaseYamlDir)
-		if err != nil {
-			return errors.Wrap(err, "read yaml dir")
-		}
-	}
-
-	lintResult, err := r.api.LintRelease(r.appID, r.appType, r.args.lintReleaseYaml)
+	lintResult, err := r.api.LintRelease(r.appID, r.appType, lintReleaseYAML)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/release_lint.go
+++ b/cli/cmd/release_lint.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/pkg/errors"
 	"io/ioutil"
 
 	"github.com/replicatedhq/replicated/cli/print"
@@ -13,18 +14,19 @@ func (r *runners) InitReleaseLint(parent *cobra.Command) {
 		Use:   "lint",
 		Short: "Lint a YAML",
 		Long:  "Lint a YAML",
+		SilenceUsage: true,
 	}
-	cmd.Hidden=true; // Not supported in KOTS 
 	parent.AddCommand(cmd)
 
 	cmd.Flags().StringVar(&r.args.lintReleaseYaml, "yaml", "", "The YAML config to lint. Use '-' to read from stdin.  Cannot be used with the `yaml-file` flag.")
 	cmd.Flags().StringVar(&r.args.lintReleaseYamlFile, "yaml-file", "", "The file name with YAML config to lint.  Cannot be used with the `yaml` flag.")
+	cmd.Flags().StringVar(&r.args.lintReleaseYamlDir, "yaml-dir", "", "The directory containing multiple yamls for a Kots release.  Cannot be used with the `yaml` flag.")
 
 	cmd.RunE = r.releaseLint
 }
 
 func (r *runners) releaseLint(cmd *cobra.Command, args []string) error {
-	if r.args.lintReleaseYaml == "" && r.args.lintReleaseYamlFile == "" {
+	if r.args.lintReleaseYaml == "" && r.args.lintReleaseYamlFile == "" && r.args.lintReleaseYamlDir == "" {
 		return fmt.Errorf("yaml is required")
 	}
 
@@ -48,6 +50,14 @@ func (r *runners) releaseLint(cmd *cobra.Command, args []string) error {
 		r.args.lintReleaseYamlFile = string(bytes)
 	}
 
+	if r.args.lintReleaseYamlDir != "" {
+		var err error
+		r.args.lintReleaseYaml, err = readYAMLDir(r.args.lintReleaseYamlDir)
+		if err != nil {
+			return errors.Wrap(err, "read yaml dir")
+		}
+	}
+
 	lintResult, err := r.api.LintRelease(r.appID, r.appType, r.args.lintReleaseYaml)
 	if err != nil {
 		return err
@@ -55,6 +65,18 @@ func (r *runners) releaseLint(cmd *cobra.Command, args []string) error {
 
 	if err := print.LintErrors(r.w, lintResult); err != nil {
 		return err
+	}
+
+	var hasError bool
+	for _, msg := range lintResult {
+		if msg.Type == "error" {
+			hasError = true
+			break
+		}
+	}
+
+	if hasError {
+		return errors.New("one or more errors found")
 	}
 
 	return nil

--- a/cli/cmd/release_lint.go
+++ b/cli/cmd/release_lint.go
@@ -47,7 +47,7 @@ func (r *runners) releaseLint(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		r.args.lintReleaseYamlFile = string(bytes)
+		r.args.lintReleaseYaml = string(bytes)
 	}
 
 	if r.args.lintReleaseYamlDir != "" {

--- a/cli/cmd/runner.go
+++ b/cli/cmd/runner.go
@@ -58,6 +58,7 @@ type runnerArgs struct {
 	createReleasePromoteEnsureChannel bool
 	lintReleaseYaml                   string
 	lintReleaseYamlFile               string
+	lintReleaseYamlDir                string
 	releaseOptional                   bool
 	releaseNotes                      string
 	releaseVersion                    string
@@ -78,8 +79,8 @@ type runnerArgs struct {
 	entitlementsSetValueValue            string
 	entitlementsSetValueType             string
 
-	customerCreateName          string
-	customerCreateChannel       string
-	customerCreateEnsureChannel bool
+	customerCreateName           string
+	customerCreateChannel        string
+	customerCreateEnsureChannel  bool
 	customerCreateExpiryDuration time.Duration
 }

--- a/cli/cmd/runner.go
+++ b/cli/cmd/runner.go
@@ -56,8 +56,7 @@ type runnerArgs struct {
 	createReleasePromoteNotes         string
 	createReleasePromoteVersion       string
 	createReleasePromoteEnsureChannel bool
-	lintReleaseYaml                   string
-	lintReleaseYamlFile               string
+	intReleaseYamlFile               string
 	lintReleaseYamlDir                string
 	releaseOptional                   bool
 	releaseNotes                      string

--- a/cli/print/lint.go
+++ b/cli/print/lint.go
@@ -7,9 +7,9 @@ import (
 	"github.com/replicatedhq/replicated/pkg/types"
 )
 
-var lintTmplSrc = `RULE	TYPE	START LINE	END LINE
+var lintTmplSrc = `RULE	TYPE	START LINE	MESSAGE	
 {{ range . -}}
-{{ .Rule }}	{{ .Type }}	{{ (index .Positions 0).Start.Line }} 	{{ (index .Positions 0).End.Line }}
+{{ .Rule }}	{{ .Type }}	{{with .Positions}}{{with (index . 0)}}{{ .Start.Line }}{{end}}{{end}}	{{ .Message}}
 {{ end }}`
 
 var lintTmpl = template.Must(template.New("lint").Parse(lintTmplSrc))

--- a/cli/print/lint.go
+++ b/cli/print/lint.go
@@ -7,14 +7,19 @@ import (
 	"github.com/replicatedhq/replicated/pkg/types"
 )
 
-var lintTmplSrc = `RULE	TYPE	START LINE	MESSAGE	
+var lintTmplSrc = `RULE	TYPE	LINE	MESSAGE	
 {{ range . -}}
-{{ .Rule }}	{{ .Type }}	{{with .Positions}}{{with (index . 0)}}{{ .Start.Line }}{{end}}{{end}}	{{ .Message}}
+{{ .Rule }}	{{ .Type }}	{{with .Positions}}{{with (index . 0)}}{{ .Start.Line }}	{{else}}None	{{end}}{{else}}None	{{end}}{{ .Message}}
 {{ end }}`
 
 var lintTmpl = template.Must(template.New("lint").Parse(lintTmplSrc))
 
 func LintErrors(w *tabwriter.Writer, lintErrors []types.LintMessage) error {
+	for _, lintError := range lintErrors {
+		if len(lintError.Positions) > 0 {
+			lintError.Positions[0].Start.Line += 1
+		}
+	}
 	if err := lintTmpl.Execute(w, lintErrors); err != nil {
 		return err
 	}

--- a/cli/print/lint.go
+++ b/cli/print/lint.go
@@ -15,13 +15,22 @@ var lintTmplSrc = `RULE	TYPE	LINE	MESSAGE
 var lintTmpl = template.Must(template.New("lint").Parse(lintTmplSrc))
 
 func LintErrors(w *tabwriter.Writer, lintErrors []types.LintMessage) error {
+	lintErrors = incrementLineNumbersToOneIndexed(lintErrors)
+	if err := lintTmpl.Execute(w, lintErrors); err != nil {
+		return err
+	}
+	return w.Flush()
+}
+
+// line numbers come back zero-indexed from the API
+// Since we now attach messages from the yaml parser,
+// lets make this 1-indexed so they match if the message includes a line number
+// this is here because its primarily client logic, its about how we're displaying the data
+func incrementLineNumbersToOneIndexed(lintErrors []types.LintMessage) []types.LintMessage {
 	for _, lintError := range lintErrors {
 		if len(lintError.Positions) > 0 {
 			lintError.Positions[0].Start.Line += 1
 		}
 	}
-	if err := lintTmpl.Execute(w, lintErrors); err != nil {
-		return err
-	}
-	return w.Flush()
+	return lintErrors
 }

--- a/cli/print/lint.go
+++ b/cli/print/lint.go
@@ -9,7 +9,7 @@ import (
 
 var lintTmplSrc = `RULE	TYPE	LINE	MESSAGE	
 {{ range . -}}
-{{ .Rule }}	{{ .Type }}	{{with .Positions}}{{with (index . 0)}}{{ .Start.Line }}	{{else}}None	{{end}}{{else}}None	{{end}}{{ .Message}}
+{{ .Rule }}	{{ .Type }}	{{with .Positions}}{{ (index . 0).Start.Line }}{{else}}	{{end}}	{{ .Message}}
 {{ end }}`
 
 var lintTmpl = template.Must(template.New("lint").Parse(lintTmplSrc))

--- a/client/release.go
+++ b/client/release.go
@@ -155,15 +155,17 @@ func (c *Client) PromoteRelease(appID string, appType string, sequence int64, la
 	return errors.New("unknown app type")
 }
 
-func (c *Client) LintRelease(appID string, appType string, yaml string) ([]types.LintMessage, error) {
+// yamlOrJSON is either a single ship yaml file, or a serialized JSON object describing a yaml-dir, created by readYAMLDir()
+// this Client abstraction continue to spring more leaks :)
+func (c *Client) LintRelease(appID string, appType string, yamlOrJSON string) ([]types.LintMessage, error) {
 
 	if appType == "platform" {
 		return nil, errors.New("Linting is not yet supported for Platform applications")
-		// return c.PlatformClient.LintRelease(appID, yaml)
+		// return c.PlatformClient.LintRelease(appID, yamlOrJSON)
 	} else if appType == "ship" {
-		return c.ShipClient.LintRelease(appID, yaml)
+		return c.ShipClient.LintRelease(appID, yamlOrJSON)
 	} else if appType == "kots" {
-		return nil, errors.New("Linting is not yet supported for Kots applications")
+		return c.KotsClient.LintRelease(appID, yamlOrJSON)
 	}
 
 	return nil, errors.New("unknown app type")

--- a/pkg/kotsclient/client.go
+++ b/pkg/kotsclient/client.go
@@ -27,3 +27,4 @@ func NewGraphQLClient(origin string, apiKey string) *GraphQLClient {
 func (c *GraphQLClient) ExecuteRequest(requestObj graphql.Request, deserializeTarget interface{}) error {
 	return c.GraphQLClient.ExecuteRequest(requestObj, deserializeTarget)
 }
+

--- a/pkg/kotsclient/release_lint.go
+++ b/pkg/kotsclient/release_lint.go
@@ -1,0 +1,53 @@
+package kotsclient
+
+import (
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/replicated/pkg/graphql"
+	"github.com/replicatedhq/replicated/pkg/types"
+)
+
+type GraphQLResponseLintRelease struct {
+	Data   *KOTSReleaseLintData `json:"data,omitempty"`
+	Errors []graphql.GQLError   `json:"errors,omitempty"`
+}
+
+type KOTSReleaseLintData struct {
+	Messages []types.LintMessage `json:"lintKotsSpec"`
+}
+
+const lintKotsRelease = `
+query lintKotsSpec($appId: ID!, $spec: String!) {
+  lintKotsSpec(appId: $appId, spec: $spec) {
+    rule
+    type
+    message
+    path
+    positions {
+      start {
+        line
+      }
+    }
+  }
+}
+`
+
+func (c *GraphQLClient) LintRelease(appID, allKotsYamlsAsJson string) ([]types.LintMessage, error) {
+
+	response := GraphQLResponseLintRelease{}
+
+	request := graphql.Request{
+		Query:         lintKotsRelease,
+		OperationName: "lintKotsSpec",
+		Variables: map[string]interface{}{
+			"appId": appID,
+			"spec":  allKotsYamlsAsJson,
+		},
+	}
+
+	if err := c.ExecuteRequest(request, &response); err != nil {
+		return nil, errors.Wrap(err, "execute request")
+	}
+
+	return response.Data.Messages, nil
+
+}

--- a/pkg/shipclient/release.go
+++ b/pkg/shipclient/release.go
@@ -59,26 +59,9 @@ type GraphQLResponseLintRelease struct {
 }
 
 type ShipReleaseLintData struct {
-	Messages []*ShipLintMessage `json:"lintRelease"`
+	Messages []types.LintMessage `json:"lintRelease"`
 }
 
-type ShipLintMessage struct {
-	Rule      string              `json:"rule"`
-	Type      string              `json:"type"`
-	Positions []*ShipLintPosition `json:"positions"`
-}
-
-type ShipLintPosition struct {
-	Path  string                `json:"path"`
-	Start *ShipLintLinePosition `json:"start"`
-	End   *ShipLintLinePosition `json:"end"`
-}
-
-type ShipLintLinePosition struct {
-	Position int64 `json:"position"`
-	Line     int64 `json:"line"`
-	Column   int64 `json:"column"`
-}
 
 const listReleasesQuery = `
 query allReleases($appId: ID!) {
@@ -333,35 +316,5 @@ func (c *GraphQLClient) LintRelease(appID string, yaml string) ([]types.LintMess
 		return nil, err
 	}
 
-	lintMessages := make([]types.LintMessage, 0, 0)
-	for _, message := range response.Data.Messages {
-		positions := make([]*types.LintPosition, 0, 0)
-		for _, lintPosition := range message.Positions {
-			position := types.LintPosition{
-				Path: lintPosition.Path,
-				Start: &types.LintLinePosition{
-					Position: lintPosition.Start.Position,
-					Column:   lintPosition.Start.Column,
-					Line:     lintPosition.Start.Line,
-				},
-				End: &types.LintLinePosition{
-					Position: lintPosition.End.Position,
-					Column:   lintPosition.End.Column,
-					Line:     lintPosition.End.Line,
-				},
-			}
-
-			positions = append(positions, &position)
-		}
-
-		lintMessage := types.LintMessage{
-			Rule:      message.Rule,
-			Type:      message.Type,
-			Positions: positions,
-		}
-
-		lintMessages = append(lintMessages, lintMessage)
-	}
-
-	return lintMessages, nil
+	return response.Data.Messages, nil
 }

--- a/pkg/types/release.go
+++ b/pkg/types/release.go
@@ -13,19 +13,20 @@ type ReleaseInfo struct {
 }
 
 type LintMessage struct {
-	Rule      string
-	Type      string
-	Positions []*LintPosition
+	Rule      string          `json:"rule"`
+	Type      string          `json:"type"`
+	Message   string          `json:"message"`
+	Positions []*LintPosition `json:"positions"`
 }
 
 type LintPosition struct {
-	Path  string
-	Start *LintLinePosition
-	End   *LintLinePosition
+	Path  string            `json:"path"`
+	Start *LintLinePosition `json:"start"`
+	End   *LintLinePosition `json:"end"`
 }
 
 type LintLinePosition struct {
-	Position int64
-	Line     int64
-	Column   int64
+	Position int64 `json:"position"`
+	Line     int64 `json:"line"`
+	Column   int64 `json:"column"`
 }

--- a/pkg/types/release.go
+++ b/pkg/types/release.go
@@ -21,8 +21,8 @@ type LintMessage struct {
 
 type LintPosition struct {
 	Path  string            `json:"path"`
-	Start *LintLinePosition `json:"start"`
-	End   *LintLinePosition `json:"end"`
+	Start LintLinePosition `json:"start"`
+	End   LintLinePosition `json:"end"`
 }
 
 type LintLinePosition struct {


### PR DESCRIPTION
```
$ go run ./cli release lint --yaml-dir ../kots-sentry/manifests
RULE                           TYPE    START LINE    MESSAGE
config-option-password-type    warn    64            Config option "external_postgres_secretname" should have type "password"
```

For a dir with this malformed yaml file and nothing else:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: sentry
  labels:
    app: sentr
    {
data:
  config.yml: |-
    ...While a lot of configuration in Sentry can be changed via the UI, for all
```

```
$ go run ./cli release lint --yaml-dir ./manifests
RULE                TYPE     START LINE    MESSAGE
msg-yaml-invalid    error    8             missed comma between flow collection entries at line 9, column 13:
      config.yml: |-
                ^
preflight-spec       warn                  Missing preflight spec
config-spec          warn                  Missing config spec
troubleshoot-spec    warn                  Missing troubleshoot spec
application-spec     warn                  Missing application spec
Error: one or more errors found
```


### Regression Testing

Verified this works for Ship apps as well. I can't pull down the `message` field for ship apps because it doesn't exist in the graphql schema for that endpoint. A change for another time.

```
$ go run ./cli release lint --yaml-file ./ship.yaml --app ship-dex
RULE                   TYPE     LINE    MESSAGE
spec-require-render    error    59
Error: one or more errors found
```

For completeness, the message here should say something about `lifecycle should require at least one render step`, per this rule https://github.com/replicatedhq/replicated-lint/blob/master/projects/replicated-ship/rules.yaml#L4