### PR TITLE
another refactor, add --fail-on flag, fix double-printing errors

### DIFF
--- a/cli/cmd/release_update.go
+++ b/cli/cmd/release_update.go
@@ -1,11 +1,8 @@
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"os"
-	"path/filepath"
 	"strconv"
 
 	"github.com/pkg/errors"
@@ -62,26 +59,10 @@ func (r *runners) releaseUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	if r.args.updateReleaseYamlDir != "" {
-		var allKotsReleaseSpecs []kotsSingleSpec
-		err := filepath.Walk(r.args.updateReleaseYamlDir, func(path string, info os.FileInfo, err error) error {
-			spec, err := encodeKotsFile(r.args.createReleaseYamlDir, path, info, err)
-			if err != nil {
-				return err
-			} else if spec == nil {
-				return nil
-			}
-			allKotsReleaseSpecs = append(allKotsReleaseSpecs, *spec)
-			return nil
-		})
+		r.args.updateReleaseYaml, err = readYAMLDir(r.args.createReleaseYamlDir)
 		if err != nil {
-			return errors.Wrapf(err, "walk %s", r.args.updateReleaseYamlDir)
+			return errors.Wrap(err, "read yaml dir")
 		}
-
-		jsonAllYamls, err := json.Marshal(allKotsReleaseSpecs)
-		if err != nil {
-			return errors.Wrap(err, "marshal spec")
-		}
-		r.args.updateReleaseYaml = string(jsonAllYamls)
 	}
 	if err := r.api.UpdateRelease(r.appID, r.appType, seq, r.args.updateReleaseYaml); err != nil {
 		return fmt.Errorf("Failure setting new yaml config for release: %v", err)

--- a/cli/cmd/runner.go
+++ b/cli/cmd/runner.go
@@ -56,8 +56,8 @@ type runnerArgs struct {
 	createReleasePromoteNotes         string
 	createReleasePromoteVersion       string
 	createReleasePromoteEnsureChannel bool
-	intReleaseYamlFile               string
 	lintReleaseYamlDir                string
+	lintReleaseFailOn            string
 	releaseOptional                   bool
 	releaseNotes                      string
 	releaseVersion                    string

--- a/cli/main.go
+++ b/cli/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/replicatedhq/replicated/cli/cmd"
@@ -9,7 +8,6 @@ import (
 
 func main() {
 	if err := cmd.Execute(nil, os.Stdin, os.Stdout, os.Stderr); err != nil {
-		fmt.Println(err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
CC @austinchambers  @aj-jester  @Vwampage for visibility


```
$ go run ./cli release lint --yaml-dir=../kots-sentry/manifests
RULE                           TYPE    LINE    MESSAGE    
config-option-password-type    warn    65      Config option "external_postgres_secretname" should have type "password"
$ echo $?
0
```

Failure with warning

```
$ go run ./cli release lint --yaml-dir=../kots-sentry/manifests --fail-on=warn
RULE                           TYPE    LINE    MESSAGE    
config-option-password-type    warn    65      Config option "external_postgres_secretname" should have type "password"
Error: One or more errors of severity "warn" or higher were found
$ echo $?
1
```

Unsupported threshold:

```
$ go run ./cli release lint --yaml-dir=../kots-sentry/manifests --fail-on=lol
Error: fail-on value "lol" not supported, supported values are [info, warn, error, none]
```

Using `""` or `none` when `error` level messages are present:

```
$ go run ./cli release lint --yaml-dir=../kots-sentry/manifests --fail-on=""
RULE                TYPE     LINE    MESSAGE    
msg-yaml-invalid    error    2       end of the stream or a document separator is expected at line 2, column 1:
    }
    ^
config-spec                warn              Missing config spec
config-option-not-found    warn    16    Config option "hostname" not found
config-option-not-found    warn    20    Config option "postgres_type" not found
config-option-not-found    warn    24    Config option "external_postgres_host" not found
config-option-not-found    warn    25    Config option "external_postgres_password" not found
config-option-not-found    warn    26    Config option "external_postgres_port" not found
$ echo $?
0
```