### PR TITLE
add filenames to linting

### DIFF
--- a/cli/print/lint.go
+++ b/cli/print/lint.go
@@ -7,9 +7,9 @@ import (
 	"github.com/replicatedhq/replicated/pkg/types"
 )
 
-var lintTmplSrc = `RULE	TYPE	LINE	MESSAGE	
+var lintTmplSrc = `RULE	TYPE	FILENAME	LINE	MESSAGE
 {{ range . -}}
-{{ .Rule }}	{{ .Type }}	{{with .Positions}}{{ (index . 0).Start.Line }}{{else}}	{{end}}	{{ .Message}}
+{{ .Rule }}	{{ .Type }}	{{ .Path }}	{{with .Positions}}{{ (index . 0).Start.Line }}{{else}}	{{end}}	{{ .Message}}	
 {{ end }}`
 
 var lintTmpl = template.Must(template.New("lint").Parse(lintTmplSrc))

--- a/client/release.go
+++ b/client/release.go
@@ -160,7 +160,7 @@ func (c *Client) PromoteRelease(appID string, appType string, sequence int64, la
 func (c *Client) LintRelease(appID string, appType string, yamlOrJSON string) ([]types.LintMessage, error) {
 
 	if appType == "platform" {
-		return nil, errors.New("Linting is not yet supported for Platform applications")
+		return nil, errors.New("Linting is not yet supported in this CLI, please install github.com/replicatedhq/replicated-lint to lint this application")
 		// return c.PlatformClient.LintRelease(appID, yamlOrJSON)
 	} else if appType == "ship" {
 		return c.ShipClient.LintRelease(appID, yamlOrJSON)

--- a/pkg/types/release.go
+++ b/pkg/types/release.go
@@ -15,12 +15,13 @@ type ReleaseInfo struct {
 type LintMessage struct {
 	Rule      string          `json:"rule"`
 	Type      string          `json:"type"`
+	Path      string          `json:"path"`
 	Message   string          `json:"message"`
 	Positions []*LintPosition `json:"positions"`
 }
 
 type LintPosition struct {
-	Path  string            `json:"path"`
+	Path  string           `json:"path"`
 	Start LintLinePosition `json:"start"`
 	End   LintLinePosition `json:"end"`
 }


### PR DESCRIPTION
```
RULE                           TYPE    FILENAME                    LINE    MESSAGE
replicas-1                     info    cron-deployment.yaml        11      Found Replicas 1
replicas-1                     info    redis-deployment-2.yaml     12      Found Replicas 1
replicas-1                     info    web-deployment.yaml         11      Found Replicas 1
container-resources            info    init-job.yaml               16      Missing container resources
container-resources            info    redis-deployment-2.yaml     24      Missing container resources
container-resources            info    redis-statefulset.yaml      24      Missing container resources
container-resources            info    usercreate-job.yaml         16      Missing container resources
container-resource-limits      info    postgres-deployment.yaml    63      Missing resource limits
may-contain-secrets            info    redis-secret.yaml           9       It looks like there might be secrets in this file
```

cc @austinchambers @aj-jester @Vwampage 