### PR TITLE
Fix 'release update --yaml-dir'

### DIFF
--- a/cli/cmd/release_update.go
+++ b/cli/cmd/release_update.go
@@ -59,7 +59,7 @@ func (r *runners) releaseUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	if r.args.updateReleaseYamlDir != "" {
-		r.args.updateReleaseYaml, err = readYAMLDir(r.args.createReleaseYamlDir)
+		r.args.updateReleaseYaml, err = readYAMLDir(r.args.updateReleaseYamlDir)
 		if err != nil {
 			return errors.Wrap(err, "read yaml dir")
 		}


### PR DESCRIPTION
Uses the correct variable name to get the `--yaml-dir` argument. Previously it would always try to walk an empty string path.

Fixes #101.

Signed-off-by: Michael Smith <michael.smith@puppet.com>