### PR TITLE
include a timestamp and nonce in signed enterprise requests

### DIFF
--- a/pkg/enterpriseclient/auth.go
+++ b/pkg/enterpriseclient/auth.go
@@ -260,8 +260,8 @@ func combineTsNonceData(ts, nonce, data []byte) []byte {
 	return tsBytes
 }
 
-// ValidatePayload checks that the payload was signed by the provided public key
-// if fingerprintSigString is not empty, sigString is ignored and it is used instead, and the nonce will be returned if valid
+// ValidatePayload checks that the payload was signed by the private key associated with the provided public key
+// if fingerprintSigString is not empty, sigString is ignored and it is used instead, and the nonce will be returned if the signature was valid
 func ValidatePayload(pubkey ssh.PublicKey, sigString, fingerprintSigString string, data []byte) (bool, []byte, error) {
 	if !strings.HasPrefix(pubkey.Type(), "ecdsa-sha2-") {
 		return false, nil, fmt.Errorf("%q is not an accepted public key type", pubkey.Type())

--- a/pkg/enterpriseclient/auth.go
+++ b/pkg/enterpriseclient/auth.go
@@ -7,12 +7,15 @@ import (
 	"crypto/sha512"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/json"
 	"encoding/pem"
 	"fmt"
 	"io/ioutil"
 	"math/big"
 	"os"
 	"path/filepath"
+	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/ssh"
@@ -191,8 +194,23 @@ func homeDir() string {
 	return os.Getenv("USERPROFILE")
 }
 
+type SigBlock struct {
+	Nonce     []byte
+	Timestamp []byte
+	Signature []byte
+}
+
 // gets the (base64 encoded) signature and fingerprint for a given key and data
-func sigAndFingerprint(privateKey *ecdsa.PrivateKey, data []byte) (string, string, error) {
+// returns the signature with a nonce and timestamp, the signature of the data alone, the fingerprint, and error
+func sigAndFingerprint(privateKey *ecdsa.PrivateKey, data []byte) (string, string, string, error) {
+	// generate a timestamp and nonce
+	nonce := make([]byte, 512/8)        // 512 bits
+	_, _ = rand.Read(nonce)             // returns len, nil - neither of which we need
+	ts, err := time.Now().MarshalText() // marshals to RFC3339Nano
+	if err != nil {
+		return "", "", "", errors.Wrap(err, "failed to get timestamp")
+	}
+
 	// hash the body and sign the hash
 	// store the signature in an ecSig struct and marshal it with the ssh wire format
 	contentSha := sha512.Sum512(data)
@@ -200,17 +218,100 @@ func sigAndFingerprint(privateKey *ecdsa.PrivateKey, data []byte) (string, strin
 		R *big.Int
 		S *big.Int
 	}
-	var err error
 	ecSig.R, ecSig.S, err = ecdsa.Sign(rand.Reader, privateKey, contentSha[:])
 	if err != nil {
-		return "", "", errors.Wrap(err, "failed to sign content sha")
+		return "", "", "", errors.Wrap(err, "failed to sign content sha")
 	}
 	signatureString := base64.StdEncoding.EncodeToString(ssh.Marshal(ecSig))
+
+	// do the same for the data combined with the timestamp and nonce
+	contentSha = sha512.Sum512(combineTsNonceData(ts, nonce, data))
+	ecSig.R, ecSig.S, err = ecdsa.Sign(rand.Reader, privateKey, contentSha[:])
+	if err != nil {
+		return "", "", "", errors.Wrap(err, "failed to sign content sha")
+	}
+	tsSig := ssh.Marshal(ecSig)
 
 	// include the public key fingerprint as a hint to the server
 	fingerprint, err := getFingerprint(&privateKey.PublicKey)
 	if err != nil {
-		return "", "", errors.Wrap(err, "failed to get public key fingerprint")
+		return "", "", "", errors.Wrap(err, "failed to get public key fingerprint")
 	}
-	return signatureString, fingerprint, nil
+
+	sigBlock := SigBlock{
+		Timestamp: ts,
+		Nonce:     nonce,
+		Signature: tsSig,
+	}
+	sigBlockBytes, err := json.Marshal(sigBlock)
+	if err != nil {
+		return "", "", "", errors.Wrap(err, "failed to marshal signature block")
+	}
+	sigBlockString := base64.StdEncoding.EncodeToString(sigBlockBytes)
+
+	return sigBlockString, signatureString, fingerprint, nil
+}
+
+func combineTsNonceData(ts, nonce, data []byte) []byte {
+	tsBytes := []byte{}
+	tsBytes = append(tsBytes, nonce...)
+	tsBytes = append(tsBytes, ts...)
+	tsBytes = append(tsBytes, data...)
+	return tsBytes
+}
+
+// ValidatePayload checks that the payload was signed by the provided public key
+// if fingerprintSigString is not empty, sigString is ignored and it is used instead, and the nonce will be returned if valid
+func ValidatePayload(pubkey ssh.PublicKey, sigString, fingerprintSigString string, data []byte) (bool, []byte, error) {
+	if !strings.HasPrefix(pubkey.Type(), "ecdsa-sha2-") {
+		return false, nil, fmt.Errorf("%q is not an accepted public key type", pubkey.Type())
+	}
+
+	if fingerprintSigString != "" {
+		sigBlockBytes, err := base64.StdEncoding.DecodeString(fingerprintSigString)
+		if err != nil {
+			return false, nil, errors.Wrap(err, "invalid signature string")
+		}
+
+		decodedSig := SigBlock{}
+		err = json.Unmarshal(sigBlockBytes, &decodedSig)
+		if err != nil {
+			return false, nil, errors.Wrap(err, "invalid signature object")
+		}
+
+		err = pubkey.Verify(combineTsNonceData(decodedSig.Timestamp, decodedSig.Nonce, data), &ssh.Signature{
+			Format: pubkey.Type(),
+			Blob:   decodedSig.Signature,
+		})
+		if err != nil {
+			return false, nil, errors.Wrap(err, "invalid signature")
+		}
+
+		sentTime, err := time.Parse(time.RFC3339Nano, string(decodedSig.Timestamp))
+		if err != nil {
+			return false, nil, errors.Wrap(err, "invalid timestamp")
+		}
+		if !sentTime.Before(time.Now().Add(time.Hour)) {
+			return false, nil, fmt.Errorf("date %s is more than an hour after the current time %s", string(decodedSig.Timestamp), time.Now().Format(time.RFC3339Nano))
+		}
+		if !sentTime.After(time.Now().Add(-time.Hour)) {
+			return false, nil, fmt.Errorf("date %s is more than an hour before the current time %s", string(decodedSig.Timestamp), time.Now().Format(time.RFC3339Nano))
+		}
+		return true, decodedSig.Nonce, nil
+	}
+
+	sigBytes, err := base64.StdEncoding.DecodeString(sigString)
+	if err != nil {
+		return false, nil, errors.Wrap(err, "invalid signature string")
+	}
+
+	err = pubkey.Verify(data, &ssh.Signature{
+		Format: pubkey.Type(),
+		Blob:   sigBytes,
+	})
+	if err != nil {
+		return false, nil, errors.Wrap(err, "invalid signature")
+	}
+
+	return true, nil, nil
 }

--- a/pkg/enterpriseclient/auth_test.go
+++ b/pkg/enterpriseclient/auth_test.go
@@ -2,8 +2,9 @@ package enterpriseclient
 
 import (
 	"encoding/base64"
-	"strings"
+	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
@@ -27,7 +28,7 @@ func Test_sigAndFingerprint(t *testing.T) {
 	privateKey, err = decodePrivateKeyPEM(privateKeyBytes)
 	req.NoError(err)
 
-	sig, fingerprint, err := sigAndFingerprint(privateKey, []byte(testData))
+	_, sig, fingerprint, err := sigAndFingerprint(privateKey, []byte(testData))
 	req.NoError(err)
 
 	pubKey := encodePublicKey(&privateKey.PublicKey)
@@ -35,19 +36,79 @@ func Test_sigAndFingerprint(t *testing.T) {
 	// everything past this depends only on testData, sig, fingerprint, pubKey and req
 	// NOT privateKey
 
-	sigBytes, err := base64.StdEncoding.DecodeString(sig)
+	parsedPubKey, err := ssh.ParsePublicKey(pubKey)
 	req.NoError(err)
+
+	validated, _, err := ValidatePayload(parsedPubKey, sig, "", []byte(testData))
+	req.NoError(err)
+	req.True(validated)
+
+	req.Equal(fingerprint, ssh.FingerprintSHA256(parsedPubKey))
+
+	// test bad signatures/data
+
+	fakeSig, _, err := ValidatePayload(parsedPubKey, base64.StdEncoding.EncodeToString([]byte("fakesig")), "", []byte(testData))
+	req.Error(err)
+	req.False(fakeSig)
+
+	editData, _, err := ValidatePayload(parsedPubKey, sig, "", append([]byte(testData), []byte("malicious")...))
+	req.Error(err)
+	req.False(editData)
+}
+
+func Test_sigblockAndFingerprint(t *testing.T) {
+	req := require.New(t)
+
+	var testData string // just needs to be of sufficient length
+	for i := 0; i < 100; i++ {
+		testData = testData + "abcdefghijklmnopqurstuvwxyz123456789"
+	}
+
+	// make a new private key
+	privateKey, err := generatePrivateKey()
+	req.NoError(err)
+
+	// encode that private key to bytes
+	privateKeyBytes := encodePrivateKeyToPEM(privateKey)
+	// decode private key bytes
+	privateKey, err = decodePrivateKeyPEM(privateKeyBytes)
+	req.NoError(err)
+
+	sigBlock, _, fingerprint, err := sigAndFingerprint(privateKey, []byte(testData))
+	req.NoError(err)
+
+	pubKey := encodePublicKey(&privateKey.PublicKey)
+
+	// everything past this depends only on testData, sig, fingerprint, pubKey and req
+	// NOT privateKey
 
 	parsedPubKey, err := ssh.ParsePublicKey(pubKey)
 	req.NoError(err)
 
-	req.True(strings.HasPrefix(parsedPubKey.Type(), "ecdsa-sha2-"), parsedPubKey.Type())
-
-	err = parsedPubKey.Verify([]byte(testData), &ssh.Signature{
-		Format: parsedPubKey.Type(),
-		Blob:   sigBytes,
-	})
+	validated, nonce, err := ValidatePayload(parsedPubKey, "", sigBlock, []byte(testData))
 	req.NoError(err)
+	req.True(validated)
+	req.NotNil(nonce)
 
 	req.Equal(fingerprint, ssh.FingerprintSHA256(parsedPubKey))
+
+	// test bad signatures/data
+
+	badSig := SigBlock{
+		Timestamp: []byte(time.Now().Format(time.RFC3339Nano)),
+		Nonce:     nonce,
+		Signature: []byte("abcdefg"),
+	}
+	badSigBytes, err := json.Marshal(badSig)
+	req.NoError(err)
+
+	fakeSig, nonce, err := ValidatePayload(parsedPubKey, "", base64.StdEncoding.EncodeToString(badSigBytes), []byte(testData))
+	req.Error(err)
+	req.False(fakeSig)
+	req.Nil(nonce)
+
+	editData, nonce, err := ValidatePayload(parsedPubKey, "", sigBlock, append([]byte(testData), []byte("malicious")...))
+	req.Error(err)
+	req.False(editData)
+	req.Nil(nonce)
 }

--- a/pkg/enterpriseclient/client.go
+++ b/pkg/enterpriseclient/client.go
@@ -56,12 +56,13 @@ func (c *HTTPClient) doJSON(method, path string, successStatus int, reqBody inte
 	}
 
 	if c.privateKey != nil {
-		sig, fingerprint, err := sigAndFingerprint(c.privateKey, bodyBytes)
+		sigWithNonce, sig, fingerprint, err := sigAndFingerprint(c.privateKey, bodyBytes)
 		if err != nil {
 			return err
 		}
 		req.Header.Set("Signature", sig)
 		req.Header.Set("Authorization", fingerprint)
+		req.Header.Set("SignatureNonce", sigWithNonce)
 	}
 
 	req.Header.Set("Content-Type", "application/json")


### PR DESCRIPTION
the old signature format is also still provided to prevent breakage, and an exported function has been created to validate signatures