### PR TITLE
add installer commands to kots channel inspect

### DIFF
--- a/cli/cmd/channel_create.go
+++ b/cli/cmd/channel_create.go
@@ -24,7 +24,7 @@ func (r *runners) InitChannelCreate(parent *cobra.Command) {
 }
 
 func (r *runners) channelCreate(cmd *cobra.Command, args []string) error {
-	allChannels, err := r.api.CreateChannel(r.appID, r.appType, r.args.channelCreateName, r.args.channelCreateDescription)
+	allChannels, err := r.api.CreateChannel(r.appID, r.appType, r.appSlug, r.args.channelCreateName, r.args.channelCreateDescription)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/channel_inspect.go
+++ b/cli/cmd/channel_inspect.go
@@ -19,13 +19,13 @@ func (r *runners) InitChannelInspect(parent *cobra.Command) {
 	cmd.RunE = r.channelInspect
 }
 
-func (r *runners) channelInspect(cmd *cobra.Command, args []string) error {
+func (r *runners) channelInspect(_ *cobra.Command, args []string) error {
 	if len(args) != 1 {
-		return errors.New("channel ID is required")
+		return errors.New("channel name or ID is required")
 	}
-	chanID := args[0]
 
-	appChan, _, err := r.api.GetChannel(r.appID, r.appType, chanID)
+	channelNameOrID := args[0]
+	appChan, err := r.api.GetChannelByName(r.appID, r.appType, r.appSlug, channelNameOrID)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/channel_ls.go
+++ b/cli/cmd/channel_ls.go
@@ -17,7 +17,7 @@ func (r *runners) InitChannelList(parent *cobra.Command) {
 }
 
 func (r *runners) channelList(cmd *cobra.Command, args []string) error {
-	channels, err := r.api.ListChannels(r.appID, r.appType)
+	channels, err := r.api.ListChannels(r.appID, r.appType, r.appSlug)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/customer_create.go
+++ b/cli/cmd/customer_create.go
@@ -9,10 +9,10 @@ import (
 
 func (r *runners) InitCustomersCreateCommand(parent *cobra.Command) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "create",
-		Short: "create a customer",
-		Long:  `create a customer`,
-		RunE:  r.createCustomer,
+		Use:          "create",
+		Short:        "create a customer",
+		Long:         `create a customer`,
+		RunE:         r.createCustomer,
 		SilenceUsage: true,
 	}
 	parent.AddCommand(cmd)
@@ -26,9 +26,10 @@ func (r *runners) InitCustomersCreateCommand(parent *cobra.Command) *cobra.Comma
 
 func (r *runners) createCustomer(_ *cobra.Command, _ []string) error {
 
-	channel, err := r.api.GetChannelByName(
+	channel, err := r.api.GetOrCreateChannelByName(
 		r.appID,
 		r.appType,
+		r.appSlug,
 		r.args.customerCreateChannel,
 		"",
 		r.args.customerCreateEnsureChannel,

--- a/cli/cmd/customer_download_license.go
+++ b/cli/cmd/customer_download_license.go
@@ -8,10 +8,10 @@ import (
 
 func (r *runners) InitCustomersDownloadLicenseCommand(parent *cobra.Command) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "download-license",
-		Short: "download a customer license",
-		Long:  `download a customer license`,
-		RunE:  r.downloadCustomerLicense,
+		Use:          "download-license",
+		Short:        "download a customer license",
+		Long:         `download a customer license`,
+		RunE:         r.downloadCustomerLicense,
 		SilenceUsage: true,
 	}
 	parent.AddCommand(cmd)

--- a/cli/cmd/release_create.go
+++ b/cli/cmd/release_create.go
@@ -12,10 +12,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
 )
 
 const (
@@ -269,9 +269,10 @@ func (r *runners) getOrCreateChannelForPromotion(channelName string, createIfAbs
 
 	description := "" // todo: do we want a flag for the desired channel description
 
-	channel, err := r.api.GetChannelByName(
+	channel, err := r.api.GetOrCreateChannelByName(
 		r.appID,
 		r.appType,
+		r.appSlug,
 		channelName,
 		description,
 		createIfAbsent,

--- a/cli/cmd/release_promote.go
+++ b/cli/cmd/release_promote.go
@@ -39,7 +39,7 @@ func (r *runners) releasePromote(cmd *cobra.Command, args []string) error {
 
 	if r.appType != "ship" {
 		// try to turn chanID into an actual id if it was a channel name
-		newID, err := r.api.GetChannelByName(r.appID, r.appType, chanID, "", false)
+		newID, err := r.api.GetOrCreateChannelByName(r.appID, r.appType, r.appSlug, chanID, "", false)
 		if err != nil {
 			return errors.Wrapf(err, "unable to get channel ID from name")
 		}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -225,18 +225,21 @@ func Execute(rootCmd *cobra.Command, stdin io.Reader, stdout io.Writer, stderr i
 				return err
 			}
 			runCmds.appID = app.Id
+			runCmds.appSlug = app.Slug
 		} else if appType == "ship" {
 			app, err := shipAPI.GetApp(appSlugOrID)
 			if err != nil {
 				return err
 			}
 			runCmds.appID = app.ID
+			runCmds.appSlug = app.Slug
 		} else if appType == "kots" {
 			app, err := kotsAPI.GetApp(appSlugOrID)
 			if err != nil {
 				return err
 			}
 			runCmds.appID = app.ID
+			runCmds.appSlug = app.Slug
 		}
 
 		return nil

--- a/cli/cmd/runner.go
+++ b/cli/cmd/runner.go
@@ -20,6 +20,7 @@ import (
 // commands, which are defined as methods on this type.
 type runners struct {
 	appID            string
+	appSlug          string
 	appType          string
 	api              client.Client
 	enterpriseClient *enterpriseclient.HTTPClient

--- a/cli/print/channel_attributes.go
+++ b/cli/print/channel_attributes.go
@@ -1,22 +1,33 @@
 package print
 
 import (
+	"github.com/replicatedhq/replicated/pkg/types"
 	"text/tabwriter"
 	"text/template"
-
-	channels "github.com/replicatedhq/replicated/gen/go/v1"
 )
 
-var channelAttrsTmplSrc = `ID:	{{ .Id }}
+var channelAttrsTmplSrc = `ID:	{{ .ID }}
 NAME:	{{ .Name }}
 DESCRIPTION:	{{ .Description }}
 RELEASE:	{{ if ge .ReleaseSequence 1 }}{{ .ReleaseSequence }}{{else}}	{{end}}
-VERSION:	{{ .ReleaseLabel }}
+VERSION:	{{ .ReleaseLabel }}{{ with .InstallCommands }}
+EXISTING:
+
+{{ .Existing }}
+
+EMBEDDED:
+
+{{ .Embedded }}
+
+AIRGAP:
+
+{{ .Airgap }}
+{{end}}
 `
 
 var channelAttrsTmpl = template.Must(template.New("ChannelAttributes").Parse(channelAttrsTmplSrc))
 
-func ChannelAttrs(w *tabwriter.Writer, appChan *channels.AppChannel) error {
+func ChannelAttrs(w *tabwriter.Writer, appChan *types.Channel) error {
 	if err := channelAttrsTmpl.Execute(w, appChan); err != nil {
 		return err
 	}

--- a/cli/print/logger.go
+++ b/cli/print/logger.go
@@ -12,7 +12,7 @@ import (
 )
 
 type Logger struct {
-	w io.Writer
+	w             io.Writer
 	spinnerStopCh chan bool
 	spinnerMsg    string
 	spinnerArgs   []interface{}

--- a/cli/test/kots_release_create_test.go
+++ b/cli/test/kots_release_create_test.go
@@ -1,0 +1,74 @@
+package test
+
+import (
+	"bytes"
+	"github.com/replicatedhq/replicated/pkg/kotsclient"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/replicatedhq/replicated/cli/cmd"
+	"github.com/replicatedhq/replicated/pkg/platformclient"
+	"github.com/stretchr/testify/assert"
+)
+
+var _ = Describe("kots release create", func() {
+	t := GinkgoT()
+	req := assert.New(t) // using assert since it plays nicer with ginkgo
+	params, err := GetParams()
+	req.NoError(err)
+
+	httpClient := platformclient.NewHTTPClient(params.APIOrigin, params.APIToken)
+	kotsRestClient := kotsclient.VendorV3Client{HTTPClient: *httpClient}
+	kotsGraphqlClient := kotsclient.NewGraphQLClient(params.GraphqlOrigin, params.APIToken, params.KurlOrigin)
+
+	var app *kotsclient.KotsApp
+	var tmpdir string
+
+
+	BeforeEach(func() {
+		var err error
+		app, err = kotsRestClient.CreateKOTSApp(mustToken(8))
+		req.NoError(err)
+		tmpdir, err = ioutil.TempDir("", "replicated-cli-test")
+		req.NoError(err)
+
+	})
+
+	AfterEach(func() {
+		err := kotsGraphqlClient.DeleteKOTSApp(app.ID)
+		req.NoError(err)
+		err = os.RemoveAll(tmpdir)
+		req.NoError(err)
+	})
+
+	Context("with valid --yaml-dir in an app with no releases", func() {
+		It("should create release 1", func() {
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+
+			configMap := `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fake
+data:
+  fake: yep it's fake
+`
+			err := ioutil.WriteFile(filepath.Join(tmpdir, "config.yaml"), []byte(configMap), 0644)
+			req.NoError(err)
+
+			rootCmd := cmd.GetRootCmd()
+			rootCmd.SetArgs([]string{"release", "create", "--yaml-dir", tmpdir, "--app", app.Slug})
+			rootCmd.SetOut(&stdout)
+			rootCmd.SetErr(&stderr)
+
+			err = cmd.Execute(rootCmd, nil, &stdout, &stderr)
+			req.NoError(err)
+
+			req.Empty(stderr.String(), "Expected no stderr output")
+			req.NotEmpty(stdout.String(), "Expected stdout output")
+			req.Contains(stdout.String(), "SEQUENCE: 1")
+		})
+	})
+})

--- a/client/channel.go
+++ b/client/channel.go
@@ -118,7 +118,7 @@ func (c *Client) findChannel(channels []types.Channel, name string) (*types.Chan
 	matchingChannels := make([]*types.Channel, 0)
 	for _, channel := range channels {
 		if channel.ID == name || channel.Name == name {
-			matchingChannels = append(matchingChannels, &channel)
+			matchingChannels = append(matchingChannels, channel.Copy())
 		}
 	}
 	if len(matchingChannels) == 0 {

--- a/client/channel.go
+++ b/client/channel.go
@@ -103,10 +103,10 @@ func (c *Client) GetOrCreateChannelByName(appID string, appType string, appSlug 
 		// for some reason CreateChannel returns the list of all channels,
 		// so now we gotta go find the channel we just created
 		channel, _, err := c.findChannel(updatedListOfChannels, name)
-		return channel, errors.Wrapf(err, "find channel %q")
+		return channel, errors.Wrapf(err, "find channel %q", name)
 	}
 
-	return foundChannel, errors.Wrapf(err, "find channel %q")
+	return foundChannel, errors.Wrapf(err, "find channel %q", name)
 }
 
 func (c *Client) GetChannelByName(appID string, appType string, appSlug string, name string) (*types.Channel, error) {

--- a/client/channel.go
+++ b/client/channel.go
@@ -1,13 +1,14 @@
 package client
 
 import (
-	"errors"
+	"fmt"
+	"github.com/pkg/errors"
 
 	channels "github.com/replicatedhq/replicated/gen/go/v1"
 	"github.com/replicatedhq/replicated/pkg/types"
 )
 
-func (c *Client) ListChannels(appID string, appType string) ([]types.Channel, error) {
+func (c *Client) ListChannels(appID string, appType string, appSlug string) ([]types.Channel, error) {
 
 	if appType == "platform" {
 		platformChannels, err := c.PlatformClient.ListChannels(appID)
@@ -32,7 +33,7 @@ func (c *Client) ListChannels(appID string, appType string) ([]types.Channel, er
 	} else if appType == "ship" {
 		return c.ShipClient.ListChannels(appID)
 	} else if appType == "kots" {
-		return c.KotsClient.ListChannels(appID)
+		return c.KotsHTTPClient.ListChannels(appID, appSlug)
 	}
 
 	return nil, errors.New("unknown app type")
@@ -64,13 +65,13 @@ func (c *Client) ArchiveChannel(appID string, appType string, channelID string) 
 
 }
 
-func (c *Client) CreateChannel(appID string, appType string, name string, description string) ([]types.Channel, error) {
+func (c *Client) CreateChannel(appID string, appType string, appSlug string, name string, description string) ([]types.Channel, error) {
 
 	if appType == "platform" {
 		if err := c.PlatformClient.CreateChannel(appID, name, description); err != nil {
 			return nil, err
 		}
-		return c.ListChannels(appID, appType)
+		return c.ListChannels(appID, appType, appSlug)
 	} else if appType == "ship" {
 		if _, err := c.ShipClient.CreateChannel(appID, name, description); err != nil {
 			return nil, err
@@ -80,21 +81,52 @@ func (c *Client) CreateChannel(appID string, appType string, name string, descri
 		if _, err := c.KotsClient.CreateChannel(appID, name, description); err != nil {
 			return nil, err
 		}
-		return c.KotsClient.ListChannels(appID)
+		return c.KotsHTTPClient.ListChannels(appID, appSlug)
 	}
 
 	return nil, errors.New("unknown app type")
 }
 
-func (c *Client) GetChannelByName(appID string, appType string, name string, description string, createIfAbsent bool) (*types.Channel, error) {
-
-	if appType == "platform" {
-		return c.PlatformClient.GetChannelByName(appID, name, description, createIfAbsent)
-	} else if appType == "ship" {
-		return c.ShipClient.GetChannelByName(appID, name, description, createIfAbsent)
-	} else if appType == "kots" {
-		return c.KotsClient.GetChannelByName(appID, name, description, createIfAbsent)
+func (c *Client) GetOrCreateChannelByName(appID string, appType string, appSlug string, name string, description string, createIfAbsent bool) (*types.Channel, error) {
+	allChannels, err := c.ListChannels(appID, appType, appSlug)
+	if err != nil {
+		return nil, err
 	}
 
-	return nil, errors.New("unknown app type")
+	foundChannel, numMatching, err := c.findChannel(allChannels, name)
+
+	if numMatching == 0 && createIfAbsent {
+		updatedListOfChannels, err := c.CreateChannel(appID, appType, appSlug, name, description)
+		if err != nil {
+			return nil, errors.Wrapf(err, "create channel %q ", name)
+		}
+		// for some reason CreateChannel returns the list of all channels,
+		// so now we gotta go find the channel we just created
+		channel, _, err := c.findChannel(updatedListOfChannels, name)
+		return channel, errors.Wrapf(err, "find channel %q")
+	}
+
+	return foundChannel, errors.Wrapf(err, "find channel %q")
+}
+
+func (c *Client) GetChannelByName(appID string, appType string, appSlug string, name string) (*types.Channel, error) {
+	return c.GetOrCreateChannelByName(appID, appType, appSlug, name, "", false)
+}
+
+func (c *Client) findChannel(channels []types.Channel, name string) (*types.Channel, int, error) {
+
+	matchingChannels := make([]*types.Channel, 0)
+	for _, channel := range channels {
+		if channel.ID == name || channel.Name == name {
+			matchingChannels = append(matchingChannels, &channel)
+		}
+	}
+	if len(matchingChannels) == 0 {
+		return nil, 0, errors.Errorf("No channel %q ", name)
+	}
+
+	if len(matchingChannels) > 1 {
+		return nil, len(matchingChannels), fmt.Errorf("channel %q is ambiguous, please use channel ID", name)
+	}
+	return matchingChannels[0], 1, nil
 }

--- a/client/client.go
+++ b/client/client.go
@@ -10,7 +10,7 @@ type Client struct {
 	PlatformClient *platformclient.HTTPClient
 	ShipClient     *shipclient.GraphQLClient
 	KotsClient     *kotsclient.GraphQLClient
-	KotsHTTPClient *kotsclient.HTTPClient
+	KotsHTTPClient *kotsclient.VendorV3Client
 }
 
 func NewClient(platformOrigin string, graphqlOrigin string, apiToken string, kurlOrigin string) Client {
@@ -19,7 +19,7 @@ func NewClient(platformOrigin string, graphqlOrigin string, apiToken string, kur
 		PlatformClient: httpClient,
 		ShipClient:     shipclient.NewGraphQLClient(graphqlOrigin, apiToken),
 		KotsClient:     kotsclient.NewGraphQLClient(graphqlOrigin, apiToken, kurlOrigin),
-		KotsHTTPClient: &kotsclient.HTTPClient{HTTPClient: *httpClient},
+		KotsHTTPClient: &kotsclient.VendorV3Client{HTTPClient: *httpClient},
 	}
 
 	return client

--- a/go.mod
+++ b/go.mod
@@ -27,4 +27,5 @@ require (
 	golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de
 	golang.org/x/sys v0.0.0-20200413165638-669c56c373c4 // indirect
 	gopkg.in/yaml.v2 v2.3.0 // indirect
+        github.com/ulikunitz/xz v0.5.8
 )

--- a/go.mod
+++ b/go.mod
@@ -24,8 +24,8 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/testify v1.6.1
 	github.com/tj/go-spin v1.1.0
+	github.com/ulikunitz/xz v0.5.8 // indirect
 	golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de
 	golang.org/x/sys v0.0.0-20200413165638-669c56c373c4 // indirect
 	gopkg.in/yaml.v2 v2.3.0 // indirect
-        github.com/ulikunitz/xz v0.5.8
 )

--- a/go.sum
+++ b/go.sum
@@ -381,6 +381,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ulikunitz/xz v0.5.6 h1:jGHAfXawEGZQ3blwU5wnWKQJvAraT7Ftq9EXjnXYgt8=
 github.com/ulikunitz/xz v0.5.6/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
+github.com/ulikunitz/xz v0.5.8 h1:ERv8V6GKqVi23rgu5cj9pVfVzJbOqAY2Ntl88O6c2nQ=
+github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/xanzy/ssh-agent v0.2.1 h1:TCbipTQL2JiiCprBWx9frJ2eJlCYT00NmctrHxVAr70=

--- a/pkg/kotsclient/app.go
+++ b/pkg/kotsclient/app.go
@@ -107,3 +107,4 @@ func (c *GraphQLClient) GetApp(appID string) (*types.App, error) {
 
 	return nil, errors.New("App not found")
 }
+

--- a/pkg/kotsclient/app_create.go
+++ b/pkg/kotsclient/app_create.go
@@ -1,0 +1,47 @@
+package kotsclient
+
+import (
+	"github.com/replicatedhq/replicated/pkg/graphql"
+	"net/http"
+)
+
+type CreateKOTSAppRequest struct {
+	Name string `json:"name"`
+}
+
+type CreateKOTSAppResponse struct {
+	App *KotsApp `json:"app"`
+}
+
+func (c *VendorV3Client) CreateKOTSApp(name string) (*KotsApp, error) {
+	reqBody := &CreateKOTSAppRequest{Name: name}
+	app := CreateKOTSAppResponse{}
+	err := c.DoJSON("POST", "/v3/app", http.StatusCreated, reqBody, &app)
+	if err != nil {
+		return nil, err
+	}
+	return app.App, nil
+}
+
+const deleteAppMutation = `
+mutation deleteKotsApplication($appId: ID!, $password: String) {
+  deleteKotsApplication(appId: $appId, password: $password)
+}
+`
+
+func (c *GraphQLClient) DeleteKOTSApp(id string) error {
+	response := graphql.ResponseErrorOnly{}
+
+	request := graphql.Request{
+		Query: deleteAppMutation,
+		Variables: map[string]interface{}{
+			"appId": id,
+		},
+	}
+
+	if err := c.ExecuteRequest(request, &response); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/kotsclient/channel.go
+++ b/pkg/kotsclient/channel.go
@@ -94,7 +94,7 @@ type ListChannelsResponse struct {
 	Channels []*KotsChannel `json:"channels"`
 }
 
-func (c *HTTPClient) ListChannels(appID string, appSlug string) ([]types.Channel, error) {
+func (c *VendorV3Client) ListChannels(appID string, appSlug string) ([]types.Channel, error) {
 	var response = ListChannelsResponse{}
 	url := fmt.Sprintf("/v3/app/%s/channels", appID)
 	err := c.DoJSON("GET", url, http.StatusOK, nil, &response)

--- a/pkg/kotsclient/channel.go
+++ b/pkg/kotsclient/channel.go
@@ -72,8 +72,9 @@ func (c *KotsChannel) EmbeddedAirgapInstallCommand(appSlug string) string {
 	kurlURL := fmt.Sprintf("%s/bundle/%s.tar.gz", kurlBaseURL, slug)
 
 	return fmt.Sprintf(`    curl -fsSL -o %s.tar.gz %s
+    # ... scp or sneakernet %s.tar.gz to airgapped machine, then
     tar xvf %s.tar.gz
-    sudo bash ./install.sh airgap`, slug, kurlURL, slug)
+    sudo bash ./install.sh airgap`, slug, kurlURL, slug, slug)
 
 }
 

--- a/pkg/kotsclient/channel.go
+++ b/pkg/kotsclient/channel.go
@@ -71,7 +71,7 @@ func (c *KotsChannel) EmbeddedAirgapInstallCommand(appSlug string) string {
 	}
 	kurlURL := fmt.Sprintf("%s/bundle/%s.tar.gz", kurlBaseURL, slug)
 
-	return fmt.Sprintf(`    curl -fsSL -o %s.tar.gz %s
+	return fmt.Sprintf(`    curl -fSL -o %s.tar.gz %s
     # ... scp or sneakernet %s.tar.gz to airgapped machine, then
     tar xvf %s.tar.gz
     sudo bash ./install.sh airgap`, slug, kurlURL, slug, slug)

--- a/pkg/kotsclient/channel.go
+++ b/pkg/kotsclient/channel.go
@@ -6,12 +6,9 @@ import (
 	channels "github.com/replicatedhq/replicated/gen/go/v1"
 	"github.com/replicatedhq/replicated/pkg/graphql"
 	"github.com/replicatedhq/replicated/pkg/types"
+	"net/http"
+	"os"
 )
-
-type GraphQLResponseListChannels struct {
-	Data   *KotsChannelData   `json:"data,omitempty"`
-	Errors []graphql.GQLError `json:"errors,omitempty"`
-}
 
 type GraphQLResponseGetChannel struct {
 	Data   *KotsGetChannelData `json:"data,omitempty"`
@@ -30,9 +27,6 @@ type KotsGetChannelData struct {
 type KotsCreateChannelData struct {
 	KotsChannel *KotsChannel `json:"createKotsChannel"`
 }
-type KotsChannelData struct {
-	KotsChannels []*KotsChannel `json:"getKotsAppChannels"`
-}
 
 type KotsChannel struct {
 	ID              string `json:"id"`
@@ -41,82 +35,84 @@ type KotsChannel struct {
 	ChannelSequence int64  `json:"channelSequence"`
 	ReleaseSequence int64  `json:"releaseSequence"`
 	CurrentVersion  string `json:"currentVersion"`
+	ChannelSlug     string `json:"channelSlug"`
 }
 
-const listChannelsQuery = `
-query getKotsAppChannels($appId: ID!) {
-	getKotsAppChannels(appId: $appId) {
-	id
-	appId
-	name
-	currentVersion
-	channelSequence
-	releaseSequence
-	currentReleaseDate
-	numReleases
-	description
-	channelIcon
-	created
-	updated
-	isDefault
-	isArchived
-	adoptionRate {
-		releaseSequence
-		semver
-		count
-		percent
-		totalOnChannel
+const embeddedInstallBaseURL = "https://k8s.kurl.sh"
+
+var embeddedInstallOverrideURL = os.Getenv("EMBEDDED_INSTALL_BASE_URL")
+
+// this is not client logic, but sure, let's go with it
+func (c *KotsChannel) EmbeddedInstallCommand(appSlug string) string {
+
+	kurlBaseURL := embeddedInstallBaseURL
+	if embeddedInstallOverrideURL != "" {
+		kurlBaseURL = embeddedInstallOverrideURL
 	}
-	customers {
-		id
-		name
-		avatar
-		shipInstallStatus {
-		status
-		}
+
+	kurlURL := fmt.Sprintf("%s/%s-%s", kurlBaseURL, appSlug, c.ChannelSlug)
+	if c.ChannelSlug == "stable" {
+		kurlURL = fmt.Sprintf("%s/%s", kurlBaseURL, appSlug)
 	}
-	githubRef {
-		owner
-		repoFullName
-		branch
-		path
-	}
-	releases {
-		semver
-		releaseNotes
-		created
-		updated
-		releasedAt
-		sequence
-		channelSequence
-		airgapBuildStatus
-	}
-	}
+	return fmt.Sprintf(`    curl -fsSL %s | sudo bash`, kurlURL)
+
 }
-`
 
-func (c *GraphQLClient) ListChannels(appID string) ([]types.Channel, error) {
-	response := GraphQLResponseListChannels{}
+func (c *KotsChannel) EmbeddedAirgapInstallCommand(appSlug string) string {
 
-	request := graphql.Request{
-		Query: listChannelsQuery,
-
-		Variables: map[string]interface{}{
-			"appId": appID,
-		},
+	kurlBaseURL := embeddedInstallBaseURL
+	if embeddedInstallOverrideURL != "" {
+		kurlBaseURL = embeddedInstallOverrideURL
 	}
 
-	if err := c.ExecuteRequest(request, &response); err != nil {
-		return nil, err
+	slug := fmt.Sprintf("%s-%s", appSlug, c.ChannelSlug)
+	if c.ChannelSlug == "stable" {
+		slug = appSlug
+	}
+	kurlURL := fmt.Sprintf("%s/bundle/%s.tar.gz", kurlBaseURL, slug)
+
+	return fmt.Sprintf(`    curl -fsSL -o %s.tar.gz %s
+    tar xvf %s.tar.gz
+    sudo bash ./install.sh airgap`, slug, kurlURL, slug)
+
+}
+
+// this is not client logic, but sure, let's go with it
+func (c *KotsChannel) ExistingInstallCommand(appSlug string) string {
+
+	slug := appSlug
+	if c.ChannelSlug != "stable" {
+		slug = fmt.Sprintf("%s/%s", appSlug, c.ChannelSlug)
+	}
+
+	return fmt.Sprintf(`    curl -fsSL https://kots.io/install | bash
+    kubectl kots install %s`, slug)
+}
+
+type ListChannelsResponse struct {
+	Channels []*KotsChannel `json:"channels"`
+}
+
+func (c *HTTPClient) ListChannels(appID string, appSlug string) ([]types.Channel, error) {
+	var response = ListChannelsResponse{}
+	url := fmt.Sprintf("/v3/app/%s/channels", appID)
+	err := c.DoJSON("GET", url, http.StatusOK, nil, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, "list channels")
 	}
 
 	channels := make([]types.Channel, 0, 0)
-	for _, kotsChannel := range response.Data.KotsChannels {
+	for _, kotsChannel := range response.Channels {
 		channel := types.Channel{
 			ID:              kotsChannel.ID,
 			Name:            kotsChannel.Name,
 			ReleaseLabel:    kotsChannel.CurrentVersion,
 			ReleaseSequence: kotsChannel.ReleaseSequence,
+			InstallCommands: &types.InstallCommands{
+				Existing: kotsChannel.ExistingInstallCommand(appSlug),
+				Embedded: kotsChannel.EmbeddedInstallCommand(appSlug),
+				Airgap:   kotsChannel.EmbeddedAirgapInstallCommand(appSlug),
+			},
 		}
 
 		channels = append(channels, channel)
@@ -166,10 +162,6 @@ func (c *GraphQLClient) CreateChannel(appID string, name string, description str
 		ReleaseLabel:    response.Data.KotsChannel.CurrentVersion,
 	}, nil
 
-}
-
-func ArchiveChannel(appID string, channelID string) error {
-	return nil
 }
 
 const getKotsChannel = `
@@ -255,39 +247,3 @@ func (c *GraphQLClient) GetChannel(appID string, channelID string) (*channels.Ap
 	return &channelDetail, nil, nil
 }
 
-func (c *GraphQLClient) GetChannelByName(appID string, name string, description string, create bool) (*types.Channel, error) {
-	allChannels, err := c.ListChannels(appID)
-	if err != nil {
-		return nil, err
-	}
-
-	matchingChannels := make([]*types.Channel, 0)
-	for _, channel := range allChannels {
-		if channel.ID == name || channel.Name == name {
-			matchingChannels = append(matchingChannels, &types.Channel{
-				ID:              channel.ID,
-				Name:            channel.Name,
-				Description:     channel.Description,
-				ReleaseSequence: channel.ReleaseSequence,
-				ReleaseLabel:    channel.ReleaseLabel,
-			})
-		}
-	}
-
-	if len(matchingChannels) == 0 {
-		if create {
-			channel, err := c.CreateChannel(appID, name, description)
-			if err != nil {
-				return nil, errors.Wrapf(err, "create channel %q ", name)
-			}
-			return channel, nil
-		}
-
-		return nil, fmt.Errorf("could not find channel %q", name)
-	}
-
-	if len(matchingChannels) > 1 {
-		return nil, fmt.Errorf("channel %q is ambiguous, please use channel ID", name)
-	}
-	return matchingChannels[0], nil
-}

--- a/pkg/kotsclient/client.go
+++ b/pkg/kotsclient/client.go
@@ -39,6 +39,6 @@ func (c *GraphQLClient) ExecuteRequest(requestObj graphql.Request, deserializeTa
 //
 // we should think more about how we want to organize these going forward, but
 // I'm inclined to wait until after everything has been moved off of GQL before deciding
-type HTTPClient struct {
+type VendorV3Client struct {
 	platformclient.HTTPClient
 }

--- a/pkg/kotsclient/client.go
+++ b/pkg/kotsclient/client.go
@@ -42,4 +42,3 @@ func (c *GraphQLClient) ExecuteRequest(requestObj graphql.Request, deserializeTa
 type HTTPClient struct {
 	platformclient.HTTPClient
 }
-

--- a/pkg/kotsclient/customer_create.go
+++ b/pkg/kotsclient/customer_create.go
@@ -19,7 +19,7 @@ type CreateCustomerResponse struct {
 	Customer *types.Customer `json:"customer"`
 }
 
-func (c *HTTPClient) CreateCustomer(name string, appID string, channelID string, expiresIn time.Duration) (*types.Customer, error) {
+func (c *VendorV3Client) CreateCustomer(name string, appID string, channelID string, expiresIn time.Duration) (*types.Customer, error) {
 	request := &CreateCustomerRequest{
 		Name:      name,
 		ChannelID: channelID,

--- a/pkg/kotsclient/customer_license_download.go
+++ b/pkg/kotsclient/customer_license_download.go
@@ -14,4 +14,3 @@ func (c *HTTPClient) DownloadLicense(appID string, customerID string) ([]byte, e
 	}
 	return licenseBytes, nil
 }
-

--- a/pkg/kotsclient/customer_license_download.go
+++ b/pkg/kotsclient/customer_license_download.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 )
 
-func (c *HTTPClient) DownloadLicense(appID string, customerID string) ([]byte, error) {
+func (c *VendorV3Client) DownloadLicense(appID string, customerID string) ([]byte, error) {
 	path := fmt.Sprintf("/v3/app/%s/customer/%s/license-download", appID, customerID)
 	licenseBytes, err := c.HTTPGet(path, http.StatusOK)
 	if err != nil {

--- a/pkg/kotsclient/customer_list.go
+++ b/pkg/kotsclient/customer_list.go
@@ -21,7 +21,7 @@ type CustomerListResponse struct {
 	Customers []types.Customer `json:"customers"`
 }
 
-func (c *HTTPClient) ListCustomers(appID string) ([]types.Customer, error) {
+func (c *VendorV3Client) ListCustomers(appID string) ([]types.Customer, error) {
 
 	path := fmt.Sprintf("/v3/app/%s/customers", appID)
 	var resp CustomerListResponse
@@ -33,7 +33,7 @@ func (c *HTTPClient) ListCustomers(appID string) ([]types.Customer, error) {
 
 }
 
-func (c *HTTPClient) GetCustomerByName(appID string, name string) (*types.Customer, error) {
+func (c *VendorV3Client) GetCustomerByName(appID string, name string) (*types.Customer, error) {
 	allCustomers, err := c.ListCustomers(appID)
 	if err != nil {
 		return nil, err

--- a/pkg/kotsclient/customer_list.go
+++ b/pkg/kotsclient/customer_list.go
@@ -8,9 +8,11 @@ import (
 )
 
 var _ error = ErrCustomerNotFound{}
+
 type ErrCustomerNotFound struct {
 	Name string
 }
+
 func (e ErrCustomerNotFound) Error() string {
 	return fmt.Sprintf("customer %q not found", e.Name)
 }

--- a/pkg/platformclient/channel.go
+++ b/pkg/platformclient/channel.go
@@ -5,9 +5,7 @@ import (
 	"net/http"
 	"sort"
 
-	"github.com/pkg/errors"
 	channels "github.com/replicatedhq/replicated/gen/go/v1"
-	"github.com/replicatedhq/replicated/pkg/types"
 )
 
 // AppChannels sorts []channels.AppChannel by Channel.Position
@@ -100,42 +98,4 @@ func (c *HTTPClient) GetChannel(appID, channelID string) (*channels.AppChannel, 
 	}
 	sort.Sort(ChannelReleases(respBody.Releases))
 	return respBody.Channel, respBody.Releases, nil
-}
-
-func (c *HTTPClient) GetChannelByName(appID string, name string, description string, create bool) (*types.Channel, error) {
-	allChannels, err := c.ListChannels(appID)
-	if err != nil {
-		return nil, err
-	}
-
-	matchingChannels := make([]*types.Channel, 0)
-	for _, channel := range allChannels {
-		if channel.Id == name || channel.Name == name {
-			matchingChannels = append(matchingChannels, &types.Channel{
-				ID:              channel.Id,
-				Name:            channel.Name,
-				Description:     channel.Description,
-				ReleaseSequence: channel.ReleaseSequence,
-				ReleaseLabel:    channel.ReleaseLabel,
-			})
-		}
-	}
-
-	if len(matchingChannels) == 0 {
-		if create {
-			err := c.CreateChannel(appID, name, description)
-			if err != nil {
-				return nil, errors.Wrapf(err, "create channel %q ", name)
-			}
-			// CreateChannel does not return the created channel, so we need to search for it
-			return c.GetChannelByName(appID, name, description, false)
-		}
-
-		return nil, fmt.Errorf("could not find channel %q", name)
-	}
-
-	if len(matchingChannels) > 1 {
-		return nil, fmt.Errorf("channel %q is ambiguous, please use channel ID", name)
-	}
-	return matchingChannels[0], nil
 }

--- a/pkg/platformclient/client.go
+++ b/pkg/platformclient/client.go
@@ -83,7 +83,6 @@ func (c *HTTPClient) DoJSON(method, path string, successStatus int, reqBody, res
 	return nil
 }
 
-
 // Minimal, simplified version of DoJSON for GET requests, just returns bytes
 func (c *HTTPClient) HTTPGet(path string, successStatus int) ([]byte, error) {
 

--- a/pkg/shipclient/channel.go
+++ b/pkg/shipclient/channel.go
@@ -1,9 +1,6 @@
 package shipclient
 
 import (
-	"fmt"
-
-	"github.com/pkg/errors"
 	channels "github.com/replicatedhq/replicated/gen/go/v1"
 	"github.com/replicatedhq/replicated/pkg/graphql"
 	"github.com/replicatedhq/replicated/pkg/types"
@@ -134,43 +131,6 @@ func (c *GraphQLClient) CreateChannel(appID string, name string, description str
 		ReleaseSequence: response.Data.ShipChannel.CurrentSequence,
 		ReleaseLabel:    response.Data.ShipChannel.CurrentVersion,
 	}, nil
-}
-
-func (c *GraphQLClient) GetChannelByName(appID string, name string, description string, create bool) (*types.Channel, error) {
-	allChannels, err := c.ListChannels(appID)
-	if err != nil {
-		return nil, err
-	}
-
-	matchingChannels := make([]*types.Channel, 0)
-	for _, channel := range allChannels {
-		if channel.ID == name || channel.Name == name {
-			matchingChannels = append(matchingChannels, &types.Channel{
-				ID:              channel.ID,
-				Name:            channel.Name,
-				Description:     channel.Description,
-				ReleaseSequence: channel.ReleaseSequence,
-				ReleaseLabel:    channel.ReleaseLabel,
-			})
-		}
-	}
-
-	if len(matchingChannels) == 0 {
-		if create {
-			channel, err := c.CreateChannel(appID, name, description)
-			if err != nil {
-				return nil, errors.Wrapf(err, "create channel %q ", name)
-			}
-			return channel, nil
-		}
-
-		return nil, fmt.Errorf("could not find channel %q", name)
-	}
-
-	if len(matchingChannels) > 1 {
-		return nil, fmt.Errorf("channel %q is ambiguous, please use channel ID", name)
-	}
-	return matchingChannels[0], nil
 }
 
 var getShipChannel = `

--- a/pkg/types/channel.go
+++ b/pkg/types/channel.go
@@ -12,6 +12,18 @@ type Channel struct {
 	InstallCommands *InstallCommands
 }
 
+func (c *Channel) Copy() *Channel {
+	return &Channel{
+		ID:              c.ID,
+		Name:            c.Name,
+		Description:     c.Description,
+		Slug:            c.Slug,
+		ReleaseSequence: c.ReleaseSequence,
+		ReleaseLabel:    c.ReleaseLabel,
+		InstallCommands: c.InstallCommands,
+	}
+}
+
 type InstallCommands struct {
 	Existing string
 	Embedded string

--- a/pkg/types/channel.go
+++ b/pkg/types/channel.go
@@ -4,7 +4,16 @@ type Channel struct {
 	ID          string
 	Name        string
 	Description string
+	Slug        string
 
 	ReleaseSequence int64
 	ReleaseLabel    string
+
+	InstallCommands *InstallCommands
+}
+
+type InstallCommands struct {
+	Existing string
+	Embedded string
+	Airgap   string
 }


### PR DESCRIPTION
this uses go template `with` to skip these on non-kots apps. I really want these install scripits to be sent down from the server side, but for now they are built by the client in vendor.replicated.com, so we'll build them in the client here as well.

```
$ replicated channel inspect dextestxxxxx
ID:             _-0LiRWGjBG2-VtJIr0F127QPiuR7T6M
NAME:           dextestxxxxx
DESCRIPTION:
RELEASE:        11
VERSION:        0.0.1
EXISTING:

    curl -fsSL https://kots.io/install | bash
    kubectl kots install kots-dex/dextestxxxxx

EMBEDDED:

    curl -fsSL https://k8s.kurl.sh/kots-dex-dextestxxxxx | sudo bash

AIRGAP:

   curl -fsSL -o kots-dex-dextestxxxxx.tar.gz https://k8s.kurl.sh/bundle/kots-dex-dextestxxxxx.tar.gz
   tar xvf kots-dex-dextestxxxxx.tar.gz
   sudo bash ./install.sh airgap

```

Other stuff
----------

- Move KOTS ListChannels call to vendor v3 API, this involved passing app slug down into a bunch of methods
- added appSlug to `*cmd.runner` during the Pre-Run function
- refactored the common "find channel by name" logic onto `Client` instead of duplicating it on each client impl