### PR TITLE
Todd fix promote channel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ logs/
 .DS_Store
 bin/
 vendor/
+.idea

--- a/cli/cmd/release_promote.go
+++ b/cli/cmd/release_promote.go
@@ -35,23 +35,24 @@ func (r *runners) releasePromote(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("Failed to parse sequence argument %s", args[0])
 	}
-	chanID := args[1]
+	channelName := args[1]
+	newID := channelName
 
 	if r.appType != "ship" {
 		// try to turn chanID into an actual id if it was a channel name
-		newID, err := r.api.GetOrCreateChannelByName(r.appID, r.appType, r.appSlug, chanID, "", false)
+		channelID, err := r.api.GetOrCreateChannelByName(r.appID, r.appType, r.appSlug, channelName, "", false)
 		if err != nil {
 			return errors.Wrapf(err, "unable to get channel ID from name")
 		}
-		chanID = newID.ID
+		newID = channelID.ID
 	}
 
-	if err := r.api.PromoteRelease(r.appID, r.appType, seq, r.args.releaseVersion, r.args.releaseNotes, !r.args.releaseOptional, chanID); err != nil {
+	if err := r.api.PromoteRelease(r.appID, r.appType, seq, r.args.releaseVersion, r.args.releaseNotes, !r.args.releaseOptional, newID); err != nil {
 		return err
 	}
 
 	// ignore error since operation was successful
-	fmt.Fprintf(r.w, "Channel %s successfully set to release %d\n", chanID, seq)
+	fmt.Fprintf(r.w, "Channel %s successfully set to release %d\n", channelName, seq)
 	r.w.Flush()
 
 	return nil

--- a/pkg/kotsclient/app.go
+++ b/pkg/kotsclient/app.go
@@ -105,5 +105,5 @@ func (c *GraphQLClient) GetApp(appID string) (*types.App, error) {
 		}
 	}
 
-	return nil, errors.New("App not found")
+	return nil, errors.New("App not found" + appID)
 }

--- a/pkg/kotsclient/app.go
+++ b/pkg/kotsclient/app.go
@@ -105,5 +105,5 @@ func (c *GraphQLClient) GetApp(appID string) (*types.App, error) {
 		}
 	}
 
-	return nil, errors.New("App not found" + appID)
+	return nil, errors.New("App not found: " + appID)
 }


### PR DESCRIPTION
Small change so that the promote command:

`replicated release promote 14 todd --version 0.0.14`

will output human readable channel name:

`Channel todd successfully set to release 14`

instead of the current:

`Channel 1lTUjrHZchcezP6lUWhBwrdMcbg successfully set to release 14`