### PR TITLE
Now output human readable channel name when creating a release

### DIFF
--- a/cli/cmd/release_create.go
+++ b/cli/cmd/release_create.go
@@ -152,7 +152,7 @@ func (r *runners) setKOTSDefaultReleaseParams() error {
 
 	r.args.createReleasePromoteEnsureChannel = true
 	r.args.createReleaseLint = true
-	
+
 	return nil
 }
 
@@ -278,7 +278,7 @@ Prepared to create release with defaults:
 		log.FinishSpinner()
 
 		// ignore error since operation was successful
-		log.ChildActionWithoutSpinner("Channel %s successfully set to release %d\n", promoteChanID, release.Sequence)
+		log.ChildActionWithoutSpinner("Channel %s successfully set to release %d\n", r.args.createReleasePromote, release.Sequence)
 	}
 
 	return nil


### PR DESCRIPTION
Small fix to improve channel name readability (especially useful when creating new channels on the fly).
The `release create` command will now output the human-readable channel name:

```bash
replicated release create --yaml-dir ~/workspace/demo/demo-app/manifests --promote my-new-channel2 --ensure-channel

  • Reading manifests from /Users/todd/workspace/demo/demo-app/manifests ✓
  • Creating Release ✓
    • SEQUENCE: 60
  • Promoting ✓
    • Channel my-new-channel2 successfully set to release 60
```
 instead of the meaningless channel id:

```
replicated release create --yaml-dir ~/workspace/demo/demo-app/manifests --promote my-new-channel --ensure-channel

  • Reading manifests from /Users/todd/workspace/demo/demo-app/manifests ✓
  • Creating Release ✓
    • SEQUENCE: 53
  • Promoting ✓
    • Channel 1tDEhI7fScSCzyQ4Cf4LeExoN40 successfully set to release 53
```
