### PR TITLE
fix: return an error when a filename is used with the yaml flag

### DIFF
--- a/cli/cmd/release_create.go
+++ b/cli/cmd/release_create.go
@@ -41,9 +41,9 @@ func (r *runners) InitReleaseCreate(parent *cobra.Command) error {
 
 	parent.AddCommand(cmd)
 
-	cmd.Flags().StringVar(&r.args.createReleaseYaml, "yaml", "", "The YAML config for this release. Use '-' to read from stdin.  Cannot be used with the `yaml-file` flag.")
-	cmd.Flags().StringVar(&r.args.createReleaseYamlFile, "yaml-file", "", "The file name with YAML config for this release.  Cannot be used with the `yaml` flag.")
-	cmd.Flags().StringVar(&r.args.createReleaseYamlDir, "yaml-dir", "", "The directory containing multiple yamls for a Kots release.  Cannot be used with the `yaml` flag.")
+	cmd.Flags().StringVar(&r.args.createReleaseYaml, "yaml", "", "The YAML config for this release. Use '-' to read from stdin. Cannot be used with the --yaml-file flag.")
+	cmd.Flags().StringVar(&r.args.createReleaseYamlFile, "yaml-file", "", "The file name with YAML config for this release. Cannot be used with the --yaml flag.")
+	cmd.Flags().StringVar(&r.args.createReleaseYamlDir, "yaml-dir", "", "The directory containing multiple yamls for a Kots release. Cannot be used with the --yaml flag.")
 	cmd.Flags().StringVar(&r.args.createReleasePromote, "promote", "", "Channel name or id to promote this release to")
 	cmd.Flags().StringVar(&r.args.createReleasePromoteNotes, "release-notes", "", "When used with --promote <channel>, sets the **markdown** release notes")
 	cmd.Flags().StringVar(&r.args.createReleasePromoteVersion, "version", "", "When used with --promote <channel>, sets the version label for the release in this channel")
@@ -102,7 +102,6 @@ func (r *runners) gitSHABranch() (sha string, branch string, dirty bool, err err
 }
 
 func (r *runners) setKOTSDefaultReleaseParams() error {
-
 	if r.args.createReleaseYamlDir == "" {
 		r.args.createReleaseYamlDir = "./manifests"
 	}
@@ -152,12 +151,11 @@ func (r *runners) setKOTSDefaultReleaseParams() error {
 
 	r.args.createReleasePromoteEnsureChannel = true
 	r.args.createReleaseLint = true
-	
+
 	return nil
 }
 
 func (r *runners) releaseCreate(cmd *cobra.Command, args []string) error {
-
 	log := print.NewLogger(r.w)
 
 	if r.appType == "kots" && r.args.createReleaseAutoDefaults {
@@ -286,11 +284,16 @@ Prepared to create release with defaults:
 
 func (r *runners) validateReleaseCreateParams() error {
 	if r.args.createReleaseYaml == "" && r.args.createReleaseYamlFile == "" && r.appType != "kots" {
-		return errors.New("one of --yaml, --yaml-file must be provided")
+		return errors.New("one of --yaml or --yaml-file must be provided")
 	}
 
 	if r.args.createReleaseYaml != "" && r.args.createReleaseYamlFile != "" {
 		return errors.New("only one of --yaml or --yaml-file may be specified")
+	}
+
+	if (strings.HasSuffix(r.args.createReleaseYaml, ".yaml") || strings.HasSuffix(r.args.createReleaseYaml, ".yml")) &&
+		len(strings.Split(r.args.createReleaseYaml, " ")) == 1 {
+		return errors.New("use the --yaml-file flag when passing a yaml filename")
 	}
 
 	if r.args.createReleaseYamlDir == "" && r.appType == "kots" {
@@ -323,7 +326,6 @@ func (r *runners) validateReleaseCreateParams() error {
 }
 
 func (r *runners) getOrCreateChannelForPromotion(channelName string, createIfAbsent bool) (string, error) {
-
 	description := "" // todo: do we want a flag for the desired channel description
 
 	channel, err := r.api.GetOrCreateChannelByName(
@@ -384,7 +386,6 @@ func encodeKotsFile(prefix, path string, info os.FileInfo, err error) (*kotsSing
 }
 
 func readYAMLDir(yamlDir string) (string, error) {
-
 	var allKotsReleaseSpecs []kotsSingleSpec
 	err := filepath.Walk(yamlDir, func(path string, info os.FileInfo, err error) error {
 		spec, err := encodeKotsFile(yamlDir, path, info, err)
@@ -408,7 +409,6 @@ func readYAMLDir(yamlDir string) (string, error) {
 }
 
 func promptForConfirm() (string, error) {
-
 	prompt := promptui.Prompt{
 		Label:     "Create with these properties? (default Yes) [Y/n]",
 		Templates: templates,

--- a/cli/test/kots_installer_create_test.go
+++ b/cli/test/kots_installer_create_test.go
@@ -2,10 +2,11 @@ package test
 
 import (
 	"bytes"
-	"github.com/replicatedhq/replicated/pkg/kotsclient"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"github.com/replicatedhq/replicated/pkg/kotsclient"
 
 	. "github.com/onsi/ginkgo"
 	"github.com/replicatedhq/replicated/cli/cmd"
@@ -51,6 +52,8 @@ var _ = Describe("kots installer create", func() {
 kind: Installer
 metadata:
   name: 'myapp'
+help_text: |
+  Please check this file exists in root directory: config.yaml
 spec:
   kubernetes:
     version: latest
@@ -84,6 +87,24 @@ spec:
 
 			req.Contains(stdout.String(), `SEQUENCE: 2`)
 			req.Contains(stdout.String(), `successfully set to installer 2`)
+		})
+	})
+
+	Context("error case using --yaml flag with yaml filename", func() {
+		It("should return an error telling user to use --yaml-file flag", func() {
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+
+			rootCmd := cmd.GetRootCmd()
+			rootCmd.SetArgs([]string{"installer", "create", "--yaml", "installer.yaml", "--app", app.Slug, "--promote", "Unstable"})
+
+			err = cmd.Execute(rootCmd, nil, &stdout, &stderr)
+			assert.NotNil(t, err)
+
+			req.Empty(stderr.String(), "Expected no stderr output")
+			req.NotEmpty(stdout.String(), "Expected stdout output")
+
+			req.Contains(stdout.String(), `use the --yaml-file flag when passing a yaml filename`)
 		})
 	})
 })

--- a/cli/test/release_create_test.go
+++ b/cli/test/release_create_test.go
@@ -89,4 +89,22 @@ var _ = Describe("release create", func() {
 			assert.Contains(t, stdout.String(), "SEQUENCE: 1")
 		})
 	})
+
+	Context("error case using --yaml flag with yaml filename", func() {
+		It("should return an error telling user to use --yaml-file flag", func() {
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+
+			rootCmd := cmd.GetRootCmd()
+			rootCmd.SetArgs([]string{"release", "create", "--yaml", "installer.yaml", "--app", app.Slug})
+
+			err := cmd.Execute(rootCmd, nil, &stdout, &stderr)
+			assert.NotNil(t, err)
+
+			assert.Empty(t, stderr.String(), "Expected no stderr output")
+			assert.NotEmpty(t, stdout.String(), "Expected stdout output")
+
+			assert.Contains(t, stdout.String(), `use the --yaml-file flag when passing a yaml filename`)
+		})
+	})
 })

--- a/cli/test/release_update_test.go
+++ b/cli/test/release_update_test.go
@@ -86,4 +86,24 @@ var _ = Describe("release update", func() {
 			assert.True(t, r.Scan())
 		})
 	})
+
+	Context("error case using --yaml flag with yaml filename", func() {
+		It("should return an error telling user to use --yaml-file flag", func() {
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+
+			sequence := strconv.Itoa(int(release.Sequence))
+
+			rootCmd := cmd.GetRootCmd()
+			rootCmd.SetArgs([]string{"release", "update", sequence, "--yaml", "installer.yaml", "--app", app.Slug})
+
+			err := cmd.Execute(rootCmd, nil, &stdout, &stderr)
+			assert.NotNil(t, err)
+
+			assert.Empty(t, stderr.String(), "Expected no stderr output")
+			assert.NotEmpty(t, stdout.String(), "Expected stdout output")
+
+			assert.Contains(t, stdout.String(), `use the --yaml-file flag when passing a yaml filename`)
+		})
+	})
 })


### PR DESCRIPTION
Partial fix for this [issue](https://app.clubhouse.io/replicated/story/34321/replicated-vendor-cli-cannot-promote-installer-releases-to-a-channel). Added an error case when users pass a yaml file as the argument to the `--yaml` flag. Also updated some of the error handling (using `pkg/errors` exclusively instead of mixing it with Golang errors).