### PR TITLE
Fixed binary name?

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,4 @@
-project_name: cli
+project_name: replicated
 release:
   github:
     name: replicated


### PR DESCRIPTION
Some changes to fix the binary name from `cli` to `replicated`?