### PR TITLE
Download command supports releases with directories

### DIFF
--- a/cli/cmd/app_delete.go
+++ b/cli/cmd/app_delete.go
@@ -4,6 +4,7 @@ import (
 	"github.com/manifoldco/promptui"
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/replicated/cli/print"
+	"github.com/replicatedhq/replicated/pkg/logger"
 	"github.com/replicatedhq/replicated/pkg/types"
 	"github.com/spf13/cobra"
 )
@@ -23,7 +24,7 @@ func (r *runners) InitAppDelete(parent *cobra.Command) *cobra.Command {
 }
 
 func (r *runners) deleteApp(_ *cobra.Command, args []string) error {
-	log := print.NewLogger(r.w)
+	log := logger.NewLogger(r.w)
 	if len(args) != 1 {
 		return errors.New("missing app slug or id")
 	}

--- a/cli/cmd/installer_create.go
+++ b/cli/cmd/installer_create.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/replicatedhq/replicated/cli/print"
+	"github.com/replicatedhq/replicated/pkg/logger"
 	"github.com/spf13/cobra"
 )
 
@@ -58,7 +58,7 @@ func (r *runners) installerCreate(_ *cobra.Command, _ []string) error {
 		return errors.Errorf("Installer specs are only supported for KOTS applications, app %q has type %q", r.appID, r.appType)
 	}
 
-	log := print.NewLogger(r.w)
+	log := logger.NewLogger(r.w)
 	if r.args.createInstallerAutoDefaults {
 		log.ActionWithSpinner("Reading Environment")
 		err := r.setKOTSDefaultInstallerParams()

--- a/pkg/kots/release/save.go
+++ b/pkg/kots/release/save.go
@@ -1,0 +1,91 @@
+package release
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	releases "github.com/replicatedhq/replicated/gen/go/v1"
+	"github.com/replicatedhq/replicated/pkg/kots/release/types"
+	"github.com/replicatedhq/replicated/pkg/logger"
+)
+
+func Save(dstDir string, release *releases.AppRelease, log *logger.Logger) error {
+	var releaseYamls []types.KotsSingleSpec
+	if err := json.Unmarshal([]byte(release.Config), &releaseYamls); err != nil {
+		return errors.Wrap(err, "unmarshal release yamls")
+	}
+
+	if err := os.MkdirAll(dstDir, 0755); err != nil {
+		return errors.Wrapf(err, "create dir %q", dstDir)
+	}
+
+	if err := writeReleaseFiles(dstDir, releaseYamls, log); err != nil {
+		return errors.Wrap(err, "write release files")
+	}
+
+	return nil
+
+}
+
+func writeReleaseFiles(dstDir string, specs []types.KotsSingleSpec, log *logger.Logger) error {
+	for _, spec := range specs {
+		if len(spec.Children) > 0 {
+			err := writeReleaseDirectory(dstDir, spec, log)
+			if err != nil {
+				return errors.Wrapf(err, "write direcotry %s", filepath.Join(dstDir, spec.Path))
+			}
+		} else {
+			err := writeReleaseFile(dstDir, spec, log)
+			if err != nil {
+				return errors.Wrapf(err, "write file %s", filepath.Join(dstDir, spec.Path))
+			}
+		}
+	}
+
+	return nil
+}
+
+func writeReleaseDirectory(dstDir string, spec types.KotsSingleSpec, log *logger.Logger) error {
+	log.ChildActionWithoutSpinner(spec.Path)
+
+	if err := os.Mkdir(filepath.Join(dstDir, spec.Path), 0755); err != nil && !os.IsExist(err) {
+		return errors.Wrap(err, "create directory")
+	}
+
+	err := writeReleaseFiles(dstDir, spec.Children, log)
+	if err != nil {
+		return errors.Wrap(err, "write children")
+	}
+
+	return nil
+}
+
+func writeReleaseFile(dstDir string, spec types.KotsSingleSpec, log *logger.Logger) error {
+	log.ChildActionWithoutSpinner(spec.Path)
+
+	var content []byte
+
+	ext := filepath.Ext(spec.Path)
+	switch ext {
+	case ".tgz", ".gz":
+		decoded, err := base64.StdEncoding.DecodeString(spec.Content)
+		if err != nil {
+			content = []byte(spec.Content)
+		} else {
+			content = decoded
+		}
+	default:
+		content = []byte(spec.Content)
+	}
+
+	err := ioutil.WriteFile(filepath.Join(dstDir, spec.Path), content, 0644)
+	if err != nil {
+		return errors.Wrap(err, "write file")
+	}
+
+	return nil
+}

--- a/pkg/kots/release/save_test.go
+++ b/pkg/kots/release/save_test.go
@@ -1,0 +1,110 @@
+package release
+
+import (
+	_ "embed"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pkg/errors"
+	releases "github.com/replicatedhq/replicated/gen/go/v1"
+	"github.com/replicatedhq/replicated/pkg/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+//go:embed testdata/save/input/release.json
+var releaseToSave []byte
+
+func Test_Save(t *testing.T) {
+	// Just one test case for now
+
+	t.Run("compare Save() output", func(t *testing.T) {
+		dstDir, err := os.MkdirTemp("", "kots-release-save-test")
+		require.NoError(t, err)
+
+		defer os.RemoveAll(dstDir)
+
+		release := &releases.AppRelease{
+			Config: string(releaseToSave),
+		}
+		err = Save(dstDir, release, logger.NewLogger(os.Stdout))
+		require.NoError(t, err)
+
+		wantResultsDir := "./testdata/save/want"
+		err = filepath.Walk(wantResultsDir,
+			func(wantPath string, wantInfo os.FileInfo, err error) error {
+				if err != nil {
+					return err
+				}
+
+				relPath, err := filepath.Rel(wantResultsDir, wantPath)
+				if err != nil {
+					return errors.Wrap(err, "get rel path")
+				}
+
+				if relPath == "." {
+					return nil
+				}
+
+				gotPath := filepath.Join(dstDir, relPath)
+				gotInfo, err := os.Stat(gotPath)
+				if err != nil {
+					return errors.Wrap(err, "stat want path")
+				}
+
+				assert.Equal(t, wantInfo.IsDir(), gotInfo.IsDir(), "is dir", wantPath)
+
+				return nil
+			})
+
+		require.NoError(t, err)
+
+		err = filepath.Walk(dstDir,
+			func(gotPath string, gotInfo os.FileInfo, err error) error {
+				if err != nil {
+					return err
+				}
+
+				relPath, err := filepath.Rel(dstDir, gotPath)
+				if err != nil {
+					return errors.Wrap(err, "get rel path")
+				}
+
+				if relPath == "." {
+					return nil
+				}
+
+				wantPath := filepath.Join(wantResultsDir, relPath)
+				wantInfo, err := os.Stat(wantPath)
+				if err != nil {
+					return errors.Wrap(err, "stat want path")
+				}
+
+				assert.Equal(t, wantInfo.IsDir(), gotInfo.IsDir(), "is dir", wantPath)
+
+				if gotInfo.IsDir() {
+					return nil
+				}
+
+				gotContents, err := ioutil.ReadFile(gotPath)
+				if err != nil {
+					return errors.Wrap(err, "read got file")
+				}
+
+				wantContents, err := ioutil.ReadFile(wantPath)
+				if err != nil {
+					return errors.Wrap(err, "read want file")
+				}
+
+				contentsString := string(gotContents)
+				wantContentsString := string(wantContents)
+				assert.Equal(t, wantContentsString, contentsString, wantPath)
+
+				return nil
+			})
+
+		require.NoError(t, err)
+	})
+}

--- a/pkg/kots/release/testdata/save/input/release.json
+++ b/pkg/kots/release/testdata/save/input/release.json
@@ -1,0 +1,46 @@
+[
+    {
+      "name": "app",
+      "path": "app",
+      "content": "",
+      "children": [
+        {
+          "name": "example-configmap.yaml",
+          "path": "app/example-configmap.yaml",
+          "content": "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: example-configmap\ndata:\n    ENV_VAR_1: \"fake\"\n    ENV_VAR_2: \"faker\"",
+          "children": []
+        }
+      ]
+    },
+    {
+      "name": "example-service.yaml",
+      "path": "example-service.yaml",
+      "content": "apiVersion: v1\nkind: Service\nmetadata:\n  name: example-nginx\n  labels:\n    app: example\n    component: nginx\nspec:\n  type: ClusterIP\n  ports:\n  - port: 80\n  selector:\n    app: example\n    component: nginx\n",
+      "children": []
+    },
+    {
+      "name": "archive.tgz",
+      "path": "archive.tgz",
+      "content": "cHJldGVuZCB0aGlzIGlzIGJpbmFyeSBkYXRh",
+      "children": []
+    },
+    {
+      "name": "kots",
+      "path": "kots",
+      "content": "",
+      "children": [
+        {
+          "name": "kots-config.yaml",
+          "path": "kots/kots-config.yaml",
+          "content": "apiVersion: kots.io/v1beta1\nkind: Config\nmetadata:\n  name: example-config\nspec:\n  groups:\n    - name: example_settings\n      title: Test Config\n      description: Test configuration\n      items:\n        - name: use_ingress\n          title: Use Ingress?\n          help_text: An example\n          type: bool\n          default: \"0\"\n",
+          "children": []
+        }
+      ]
+    },
+    {
+      "name": "kots-app.yaml",
+      "path": "kots-app.yaml",
+      "content": "apiVersion: kots.io/v1beta1\nkind: Application\nmetadata:\n  name: app-slug\nspec:\n  title: App Name\n  icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/kubernetes/icon/color/kubernetes-icon-color.png\n  statusInformers:\n    - deployment/example-nginx\n  ports:\n    - serviceName: \"example-nginx\"\n      servicePort: 80\n      localPort: 8888\n      applicationUrl: \"http://example-nginx\"\n",
+      "children": []
+    }
+  ]

--- a/pkg/kots/release/testdata/save/want/app/example-configmap.yaml
+++ b/pkg/kots/release/testdata/save/want/app/example-configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example-configmap
+data:
+    ENV_VAR_1: "fake"
+    ENV_VAR_2: "faker"

--- a/pkg/kots/release/testdata/save/want/archive.tgz
+++ b/pkg/kots/release/testdata/save/want/archive.tgz
@@ -1,0 +1,1 @@
+pretend this is binary data

--- a/pkg/kots/release/testdata/save/want/example-service.yaml
+++ b/pkg/kots/release/testdata/save/want/example-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-nginx
+  labels:
+    app: example
+    component: nginx
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+  selector:
+    app: example
+    component: nginx

--- a/pkg/kots/release/testdata/save/want/kots-app.yaml
+++ b/pkg/kots/release/testdata/save/want/kots-app.yaml
@@ -1,0 +1,14 @@
+apiVersion: kots.io/v1beta1
+kind: Application
+metadata:
+  name: app-slug
+spec:
+  title: App Name
+  icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/kubernetes/icon/color/kubernetes-icon-color.png
+  statusInformers:
+    - deployment/example-nginx
+  ports:
+    - serviceName: "example-nginx"
+      servicePort: 80
+      localPort: 8888
+      applicationUrl: "http://example-nginx"

--- a/pkg/kots/release/testdata/save/want/kots/kots-config.yaml
+++ b/pkg/kots/release/testdata/save/want/kots/kots-config.yaml
@@ -1,0 +1,15 @@
+apiVersion: kots.io/v1beta1
+kind: Config
+metadata:
+  name: example-config
+spec:
+  groups:
+    - name: example_settings
+      title: Test Config
+      description: Test configuration
+      items:
+        - name: use_ingress
+          title: Use Ingress?
+          help_text: An example
+          type: bool
+          default: "0"

--- a/pkg/kots/release/types/types.go
+++ b/pkg/kots/release/types/types.go
@@ -1,0 +1,8 @@
+package types
+
+type KotsSingleSpec struct {
+	Name     string           `json:"name"`
+	Path     string           `json:"path"`
+	Content  string           `json:"content"`
+	Children []KotsSingleSpec `json:"children"`
+}

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -1,4 +1,4 @@
-package print
+package logger
 
 import (
 	"fmt"


### PR DESCRIPTION
Application archives can have nested directories, and directory children in the application archive are structured objects, not strings.

The main change is that
```
Children []string `json:"children"`
```
became
```
Children []KotsSingleSpec `json:"children"`
```

And recursion was added when saving downloaded archives.