### PR TITLE
(Draft) Add a few instance commands

### DIFF
--- a/cli/cmd/customer_download_license.go
+++ b/cli/cmd/customer_download_license.go
@@ -29,7 +29,7 @@ func (r *runners) downloadCustomerLicense(_ *cobra.Command, _ []string) error {
 		return errors.Errorf("missing or invalid parameters: output")
 	}
 
-	customer, err := r.api.GetCustomerByName(r.appType, r.appID, r.args.customerLicenseInspectCustomer)
+	customer, err := r.api.GetCustomerByNameOrID(r.appType, r.appID, r.args.customerLicenseInspectCustomer)
 	if err != nil {
 		return errors.Wrapf(err, "find customer %q", r.args.customerLicenseInspectCustomer)
 	}

--- a/cli/cmd/customer_instance.go
+++ b/cli/cmd/customer_instance.go
@@ -1,0 +1,16 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func (r *runners) InitCustomerInstancesCommand(parent *cobra.Command) *cobra.Command {
+	customerInstancesCmd := &cobra.Command{
+		Use:   "instances",
+		Short: "Inspect customer instances",
+		Long:  `The customer instances command allows vendors to list and inspect running customer instances.`,
+	}
+	parent.AddCommand(customerInstancesCmd)
+
+	return customerInstancesCmd
+}

--- a/cli/cmd/customer_instance_inspect.go
+++ b/cli/cmd/customer_instance_inspect.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/replicated/cli/print"
+	"github.com/spf13/cobra"
+	"time"
+)
+
+func (r *runners) InitCustomerInstancesInspectCommand(parent *cobra.Command) *cobra.Command {
+	customerInstanceInspectCommand := &cobra.Command{
+		Use:   "inspect CUSTOMER INSTANCE",
+		Short: "inspect a customer instance",
+		Long:  `inspect a customer instance`,
+		RunE:  r.inspectCustomerInstance,
+	}
+	parent.AddCommand(customerInstanceInspectCommand)
+
+	return customerInstanceInspectCommand
+}
+
+func (r *runners) inspectCustomerInstance(_ *cobra.Command, args []string) error {
+
+	if r.appType != "kots" {
+		return errors.Errorf("unsupported app type: %q, only kots applications are supported", r.appType)
+	}
+
+	if len(args) != 2 {
+		return errors.Errorf("requires a customer name/id and exactly one instance ID or ID prefix")
+	}
+	customerNameOrID := args[0]
+
+	customer, err := r.api.GetCustomerByNameOrID(r.appType, r.appID, customerNameOrID)
+	if err != nil {
+		return errors.Wrapf(err, "get customer %q", customerNameOrID)
+	}
+
+	instanceIDPrefix := args[1]
+
+	instance, err := r.api.GetInstanceByIDPrefix(r.appType, *customer, instanceIDPrefix)
+	if err != nil {
+		return errors.Wrapf(err, "get instance %q", instanceIDPrefix)
+	}
+	uptimeInterval := 4 * time.Hour
+
+	startDate := time.Now().UTC().Add(-3 * 24 * time.Hour)
+	uptime, err := r.api.GetInstanceUptime(r.appType, *instance, startDate, uptimeInterval)
+	if err != nil {
+		return errors.Wrapf(err, "get instance uptime for %s", instance.Instance.ID)
+	}
+
+	return print.InstanceInspect(instance, uptime, uptimeInterval)
+}

--- a/cli/cmd/customer_instance_ls.go
+++ b/cli/cmd/customer_instance_ls.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/replicated/cli/print"
+	"github.com/spf13/cobra"
+)
+
+func (r *runners) InitCustomerInstancesLSCommand(parent *cobra.Command) *cobra.Command {
+	customerInstanceLSCommand := &cobra.Command{
+		Use:   "ls CUSTOMER",
+		Short: "list customer instances",
+		Long:  `list instances for a single customer`,
+		RunE:  r.listCustomerInstances,
+	}
+	parent.AddCommand(customerInstanceLSCommand)
+
+	// need to add this to the base runner
+	customerInstanceLSCommand.Flags().StringVarP(&r.args.output, "output", "o", "text", "options are text, json, wide")
+
+	return customerInstanceLSCommand
+}
+
+func (r *runners) listCustomerInstances(_ *cobra.Command, args []string) error {
+
+	if r.appType != "kots" {
+		return errors.Errorf("unsupported app type: %q, only kots applications are supported", r.appType)
+	}
+
+	if len(args) != 1 {
+		return errors.Errorf("requires exactly one customer name or ID")
+	}
+	customerNameOrID := args[0]
+
+	customer, err := r.api.GetCustomerByNameOrID(r.appType, r.appID, customerNameOrID)
+	if err != nil {
+		return errors.Wrapf(err, "get customer %q", customerNameOrID)
+	}
+
+	instances, err := r.api.ListCustomerInstances(r.appType, *customer)
+	if err != nil {
+		return errors.Wrap(err, "list customer instances")
+	}
+
+	template := print.CustomerInstancesTmplLite
+	if r.args.output == "wide" {
+		template = print.CustomerInstancesTmplWide
+	}
+
+	return r.Print(template, instances)
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -31,6 +31,7 @@ var platformOrigin = "https://api.replicated.com/vendor"
 var graphqlOrigin = "https://g.replicated.com/graphql"
 var kurlDotSHOrigin = "https://kurl.sh"
 var enterpriseOrigin = "https://api.replicated.com/enterprise"
+var unifiedAPIOrigin = "https://api.replicated.com"
 
 func init() {
 	originFromEnv := os.Getenv("REPLICATED_API_ORIGIN")
@@ -51,6 +52,11 @@ func init() {
 	graphqlOriginFromEnv := os.Getenv("REPLICATED_GRAPHQL_ORIGIN")
 	if graphqlOriginFromEnv != "" {
 		graphqlOrigin = graphqlOriginFromEnv
+	}
+
+	unifiedAPIOriginFromEnv := os.Getenv("REPLICATED_UNIFIED_API_ORIGIN")
+	if unifiedAPIOriginFromEnv != "" {
+		unifiedAPIOrigin = unifiedAPIOriginFromEnv
 	}
 }
 
@@ -103,6 +109,7 @@ func Execute(rootCmd *cobra.Command, stdin io.Reader, stdout io.Writer, stderr i
 	runCmds := &runners{
 		rootCmd: rootCmd,
 		stdin:   stdin,
+		stdout:  stdout,
 		w:       w,
 	}
 	if runCmds.rootCmd == nil {
@@ -165,6 +172,10 @@ func Execute(rootCmd *cobra.Command, stdin io.Reader, stdout io.Writer, stderr i
 	runCmds.InitCustomersLSCommand(customersCmd)
 	runCmds.InitCustomersCreateCommand(customersCmd)
 	runCmds.InitCustomersDownloadLicenseCommand(customersCmd)
+
+	customerInstancesCmd := runCmds.InitCustomerInstancesCommand(customersCmd)
+	runCmds.InitCustomerInstancesLSCommand(customerInstancesCmd)
+	runCmds.InitCustomerInstancesInspectCommand(customerInstancesCmd)
 
 	installerCmd := runCmds.InitInstallerCommand(runCmds.rootCmd)
 	runCmds.InitInstallerCreate(installerCmd)
@@ -237,7 +248,7 @@ func Execute(rootCmd *cobra.Command, stdin io.Reader, stdout io.Writer, stderr i
 		kotsAPI := &kotsclient.VendorV3Client{HTTPClient: *httpClient}
 		runCmds.kotsAPI = kotsAPI
 
-		commonAPI := client.NewClient(platformOrigin, graphqlOrigin, apiToken, kurlDotSHOrigin)
+		commonAPI := client.NewClient(platformOrigin, graphqlOrigin, apiToken, kurlDotSHOrigin, unifiedAPIOrigin)
 		runCmds.api = commonAPI
 		return nil
 	}

--- a/cli/print/customer_instance_inspect.go
+++ b/cli/print/customer_instance_inspect.go
@@ -1,0 +1,137 @@
+package print
+
+import (
+	"bytes"
+	"fmt"
+	ui "github.com/gizak/termui/v3"
+	"github.com/gizak/termui/v3/widgets"
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/replicated/pkg/types"
+	"log"
+	"text/template"
+	"time"
+)
+
+const appDetail = `App Status: {{.Instance.AppStatus}}
+App Version: {{.Instance.AppVersion}}
+Versions Behind: {{.Instance.VersionsBehind}}
+Version Age: {{.AgeAbsolute}} ({{.AgeRelative}} behind latest)
+Last Check-in: {{.Instance.LastCheckIn | Date}}
+`
+
+var appDetailTemplate = template.Must(
+	template.New("customer instance inspect app detail").
+		Funcs(template.FuncMap{"Date": NiceDate}).
+		Parse(appDetail),
+)
+
+const clusterInfo = `Cluster Type: {{.Instance.K8sDistribution}}
+K8s Version: {{.Instance.K8sVersion}}
+KOTS Version: {{.Instance.KOTSVersion}}
+First Seen: {{.Instance.FirstCheckinAt | Date}}
+`
+
+var clusterInfoTemplate = template.Must(
+	template.New("customer instance inspect cluster info").
+		Funcs(template.FuncMap{"Date": NiceDate}).
+		Parse(clusterInfo),
+)
+
+const insights = `Time to Install 
+
+Instance: {{.TTIInstance}}
+License: {{.TTILicense}}
+`
+
+var insightsTemplate = template.Must(
+	template.New("customer instance inspect insights").
+		Funcs(template.FuncMap{"Date": NiceDate}).
+		Parse(insights),
+)
+
+func InstanceInspect(instance *types.CustomerInstance, uptime *types.CustomerInstanceUptime, uptimeInterval time.Duration) error {
+	if err := ui.Init(); err != nil {
+		log.Fatalf("failed to initialize termui: %v", err)
+	}
+	defer ui.Close()
+
+	appDetails := &bytes.Buffer{}
+	if err := appDetailTemplate.Execute(appDetails, instance); err != nil {
+		return errors.Wrap(err, "template app info")
+	}
+
+	clusterInfo := &bytes.Buffer{}
+	if err := clusterInfoTemplate.Execute(clusterInfo, instance); err != nil {
+		return errors.Wrap(err, "template cluster info")
+	}
+
+	insights := &bytes.Buffer{}
+	if err := insightsTemplate.Execute(insights, instance); err != nil {
+		return errors.Wrap(err, "template insights")
+	}
+
+	xoffset := 39
+	appDetailsTile := widgets.NewParagraph()
+	appDetailsTile.Text = appDetails.String()
+	appDetailsTile.SetRect(0, 0, xoffset, 7)
+
+	clusterInfoTile := widgets.NewParagraph()
+	clusterInfoTile.Text = clusterInfo.String()
+	clusterInfoTile.SetRect(xoffset, 0, 2*xoffset, 7)
+
+	insightsTile := widgets.NewParagraph()
+	insightsTile.Text = insights.String()
+	insightsTile.SetRect(2*xoffset, 0, 3*xoffset, 7)
+
+	uptimeChart := widgets.NewStackedBarChart()
+	uptimeChart.Title = "Instance Uptime (last 3 days)"
+	uptimeChart.MaxVal = 110
+	uptimeChart.NumFormatter = func(f float64) string {
+		if f == 0 {
+			return ""
+		}
+
+		hours := f / 100 * uptimeInterval.Hours()
+		duration, _ := time.ParseDuration(fmt.Sprintf("%fh", hours))
+
+		return instance.FormatDuration(&duration)
+	}
+	uptimeChart.BarColors = []ui.Color{
+		ui.ColorBlack,
+		ui.ColorRed,
+		ui.ColorYellow,
+		ui.ColorGreen,
+	}
+	uptimeChart.LabelStyles = []ui.Style{
+		{Fg: ui.ColorWhite},
+	}
+	uptimeChart.NumStyles = []ui.Style{
+		{Fg: ui.ColorWhite, Modifier: ui.ModifierBold},
+		{Fg: ui.ColorWhite},
+	}
+
+	for _, interval := range uptime.Histogram {
+		uptimeChart.Labels = append(uptimeChart.Labels, fmt.Sprintf("-%.0fh", time.Now().Sub(interval.StartTime.Time).Hours()))
+		up := interval.Statuses.Ready + interval.Statuses.Updating
+		down := interval.Statuses.Unavailable + interval.Statuses.Missing
+		degraded := interval.Statuses.Degraded
+		unknown := interval.Statuses.Unknown
+		uptimeChart.Data = append(uptimeChart.Data, []float64{unknown, down, degraded, up})
+
+	}
+	uptimeChart.SetRect(0, 8, (3*xoffset)-1, 20)
+	uptimeChart.BarWidth = 5
+
+	ui.Render(uptimeChart)
+
+	ui.Render(appDetailsTile)
+	ui.Render(clusterInfoTile)
+	ui.Render(insightsTile)
+
+	for e := range ui.PollEvents() {
+		if e.Type == ui.KeyboardEvent {
+			break
+		}
+	}
+	return nil
+}

--- a/cli/print/customer_instances.go
+++ b/cli/print/customer_instances.go
@@ -1,0 +1,50 @@
+package print
+
+import (
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/replicated/pkg/util"
+	"text/template"
+	"time"
+)
+
+var customerInstancesTmplSrc = `ID	STATUS	VERSION	VERSIONS-BEHIND	VERSION-AGE	VERSION-AGE-RELATIVE	LAST-CHECKIN	TTI-LICENSE	TTI-INSTANCE	FIRST-SEEN	FIRST-READY	LICENSE-CREATED	LATEST-CHANNEL-RELEASE	FULL-ID
+{{ range . -}}
+{{ .ShortID }}	{{ .Instance.AppStatus }}	{{.Instance.AppVersion}}	{{.Instance.VersionsBehind}}	{{.AgeAbsolute}}	{{.AgeRelative}}	{{.Instance.LastCheckIn | Date}}	{{.TTILicense }}	{{.TTIInstance}}	{{.Instance.FirstCheckinAt | Date}}	{{.Instance.FirstReadyAt | Date}}	{{.Insights.LicenseCreatedAt | Date }}	{{.Instance.CurrentVersionReleasedAt | Date}}	{{.Instance.ID}}	
+{{ end }}`
+
+var customerInstancesTmplLiteSrc = `ID	STATUS	VERSION	VERSIONS-BEHIND	VERSION-AGE	VERSION-AGE-RELATIVE	LAST-CHECKIN	TTI-LICENSE	TTI-INSTANCE	FIRST-READY	
+{{ range . -}}
+{{ .ShortID }}	{{ .Instance.AppStatus }}	{{.Instance.AppVersion}}	{{.Instance.VersionsBehind}}	{{.AgeAbsolute}}	{{.AgeRelative}}	{{.Instance.LastCheckIn | Date}}	{{.TTILicense }}	{{.TTIInstance}}	{{.Instance.FirstReadyAt | Date}}	
+{{ end }}`
+
+func NiceDate(maybeTime interface{}) (string, error) {
+	var t time.Time
+	switch value := maybeTime.(type) {
+	case time.Time:
+		t = value
+	case *util.Time:
+		if value == nil {
+			return "--", nil
+		}
+		t = value.Time
+	default:
+		return "", errors.Errorf("invalid type %T", maybeTime)
+	}
+
+	if time.Now().Sub(t).Hours() < 1*24 {
+		return t.Format("2006-01-02 15:04"), nil
+	}
+
+	return t.Format("2006-01-02 00:00"), nil
+}
+
+var CustomerInstancesTmplWide = template.Must(
+	template.New("customer instances").
+		Funcs(template.FuncMap{"Date": NiceDate}).
+		Parse(customerInstancesTmplSrc),
+)
+var CustomerInstancesTmplLite = template.Must(
+	template.New("customer instances lite").
+		Funcs(template.FuncMap{"Date": NiceDate}).
+		Parse(customerInstancesTmplLiteSrc),
+)

--- a/client/client.go
+++ b/client/client.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"github.com/replicatedhq/replicated/pkg/instancesclient"
 	"github.com/replicatedhq/replicated/pkg/kotsclient"
 	"github.com/replicatedhq/replicated/pkg/platformclient"
 	"github.com/replicatedhq/replicated/pkg/shipclient"
@@ -8,17 +9,20 @@ import (
 )
 
 type Client struct {
-	PlatformClient *platformclient.HTTPClient
-	ShipClient     *shipclient.GraphQLClient
-	KotsClient     *kotsclient.VendorV3Client
+	PlatformClient  *platformclient.HTTPClient
+	ShipClient      *shipclient.GraphQLClient
+	KotsClient      *kotsclient.VendorV3Client
+	InstancesClient *instancesclient.InstancesClient
 }
 
-func NewClient(platformOrigin string, graphqlOrigin string, apiToken string, kurlOrigin string) Client {
+func NewClient(platformOrigin string, graphqlOrigin string, apiToken string, kurlOrigin string, unifiedAPIOrigin string) Client {
 	httpClient := platformclient.NewHTTPClient(platformOrigin, apiToken)
+	unifiedClient := platformclient.NewHTTPClient(unifiedAPIOrigin, apiToken)
 	client := Client{
-		PlatformClient: httpClient,
-		ShipClient:     shipclient.NewGraphQLClient(graphqlOrigin, apiToken),
-		KotsClient:     &kotsclient.VendorV3Client{HTTPClient: *httpClient},
+		PlatformClient:  httpClient,
+		ShipClient:      shipclient.NewGraphQLClient(graphqlOrigin, apiToken),
+		KotsClient:      &kotsclient.VendorV3Client{HTTPClient: *httpClient},
+		InstancesClient: &instancesclient.InstancesClient{HTTPClient: *unifiedClient},
 	}
 
 	return client

--- a/client/customer.go
+++ b/client/customer.go
@@ -34,13 +34,13 @@ func (c *Client) CreateCustomer(appID, appType string, name string, channelID st
 
 }
 
-func (c *Client) GetCustomerByName(appType string, appID, name string) (*types.Customer, error) {
+func (c *Client) GetCustomerByNameOrID(appType string, appID, name string) (*types.Customer, error) {
 	if appType == "platform" {
 		return nil, errors.New("listing customers is not supported for platform applications")
 	} else if appType == "ship" {
 		return nil, errors.New("listing customers is not supported for ship applications")
 	} else if appType == "kots" {
-		return c.KotsClient.GetCustomerByName(appID, name)
+		return c.KotsClient.GetCustomerByNameOrID(appID, name)
 	}
 
 	return nil, errors.Errorf("unknown app type %q", appType)

--- a/client/customer_instances.go
+++ b/client/customer_instances.go
@@ -1,0 +1,43 @@
+package client
+
+import (
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/replicated/pkg/types"
+	"time"
+)
+
+func (c *Client) ListCustomerInstances(appType string, customer types.Customer) ([]types.CustomerInstance, error) {
+	if appType == "platform" {
+		return nil, errors.New("customer instance inspection is not supported for platform applications")
+	} else if appType == "ship" {
+		return nil, errors.New("customer instance inspection is not supported for ship applications")
+	} else if appType == "kots" {
+		return c.InstancesClient.ListInstances(customer)
+	}
+	return nil, errors.Errorf("unknown app type %q", appType)
+}
+
+func (c *Client) GetInstanceByIDPrefix(appType string, customer types.Customer, idPrefix string) (*types.CustomerInstance, error) {
+	if appType == "platform" {
+		return nil, errors.New("listing instances is not supported for platform applications")
+	} else if appType == "ship" {
+		return nil, errors.New("listing instances is not supported for ship applications")
+	} else if appType == "kots" {
+		return c.InstancesClient.GetInstanceByIDPrefix(customer, idPrefix)
+	}
+
+	return nil, errors.Errorf("unknown app type %q", appType)
+
+}
+func (c *Client) GetInstanceUptime(appType string, instance types.CustomerInstance, startTime time.Time, uptimeInterval time.Duration) (*types.CustomerInstanceUptime, error) {
+	if appType == "platform" {
+		return nil, errors.New("listing instances is not supported for platform applications")
+	} else if appType == "ship" {
+		return nil, errors.New("listing instances is not supported for ship applications")
+	} else if appType == "kots" {
+		return c.InstancesClient.GetInstanceUptime(instance, startTime, uptimeInterval)
+	}
+
+	return nil, errors.Errorf("unknown app type %q", appType)
+
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/fatih/color v1.7.0
+	github.com/gizak/termui/v3 v3.1.0
 	github.com/go-git/go-git/v5 v5.1.0
 	github.com/go-kit/kit v0.10.0
 	github.com/hashicorp/go-multierror v1.1.0
@@ -46,7 +47,10 @@ require (
 	github.com/klauspost/pgzip v1.2.1 // indirect
 	github.com/lunixbochs/vtclean v0.0.0-20180621232353-2d01aacdc34a // indirect
 	github.com/mattn/go-colorable v0.1.6 // indirect
+	github.com/mattn/go-runewidth v0.0.2 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7 // indirect
+	github.com/nsf/termbox-go v0.0.0-20190121233118-02980233997d // indirect
 	github.com/nwaples/rardecode v1.0.0 // indirect
 	github.com/pierrec/lz4 v2.2.6+incompatible // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -106,6 +106,8 @@ github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeME
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-gonic/gin v1.6.3/go.mod h1:75u5sXoLsGZoRN5Sgbi1eraJ4GU3++wFwWzhwvtwp4M=
 github.com/gin-gonic/gin v1.7.7/go.mod h1:axIBovoeJpVj8S3BwE0uPMTeReE4+AfFtqpqaZ1qq1U=
+github.com/gizak/termui/v3 v3.1.0 h1:ZZmVDgwHl7gR7elfKf1xc4IudXZ5qqfDh4wExk4Iajc=
+github.com/gizak/termui/v3 v3.1.0/go.mod h1:bXQEBkJpzxUAKf0+xq9MSWAvWZlE7c+aidmyFlkYTrY=
 github.com/gliderlabs/ssh v0.2.2 h1:6zsha5zo/TWhRhwqCD3+EarCAgZ2yN28ipRnGPnwkI0=
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/go-git/gcfg v1.5.0 h1:Q5ViNfGF8zFgyJWPqYwA7qGFoMTEiBmdlkcfRmpIMa4=
@@ -292,6 +294,7 @@ github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNx
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
+github.com/mattn/go-runewidth v0.0.2 h1:UnlwIPBGaTZfPQ6T1IGzPI0EkYAQmT9fAEJ/poFC63o=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mholt/archiver/v3 v3.3.0 h1:vWjhY8SQp5yzM9P6OJ/eZEkmi3UAbRrxCq48MxjAzig=
@@ -302,6 +305,8 @@ github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrk
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
+github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7 h1:DpOJ2HYzCv8LZP15IdmG+YdwD2luVPHITV96TkirNBM=
+github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
@@ -320,6 +325,8 @@ github.com/nats-io/nkeys v0.1.3/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxzi
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
+github.com/nsf/termbox-go v0.0.0-20190121233118-02980233997d h1:x3S6kxmy49zXVVyhcnrFqxvNVCBPb2KZ9hV2RBdS840=
+github.com/nsf/termbox-go v0.0.0-20190121233118-02980233997d/go.mod h1:IuKpRQcYE1Tfu+oAQqaLisqDeXgjyyltCfsaoYN18NQ=
 github.com/nwaples/rardecode v1.0.0 h1:r7vGuS5akxOnR4JQSkko62RJ1ReCMXxQRPtxsiFMBOs=
 github.com/nwaples/rardecode v1.0.0/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=

--- a/pkg/instancesclient/.gitignore
+++ b/pkg/instancesclient/.gitignore
@@ -1,0 +1,2 @@
+logs/
+pacts/

--- a/pkg/instancesclient/client.go
+++ b/pkg/instancesclient/client.go
@@ -1,0 +1,9 @@
+package instancesclient
+
+import (
+	"github.com/replicatedhq/replicated/pkg/platformclient"
+)
+
+type InstancesClient struct {
+	platformclient.HTTPClient
+}

--- a/pkg/instancesclient/get_instance.go
+++ b/pkg/instancesclient/get_instance.go
@@ -1,0 +1,54 @@
+package instancesclient
+
+import (
+	"fmt"
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/replicated/pkg/types"
+	"strings"
+	"time"
+)
+
+const threeDaysAgo = -3 * 24 * time.Hour
+
+func (c InstancesClient) GetInstanceByIDPrefix(customer types.Customer, idPrefix string) (*types.CustomerInstance, error) {
+	allInstances, err := c.ListInstances(customer)
+	if err != nil {
+		return nil, errors.Wrap(err, "list instances")
+	}
+
+	matchingInstances := make([]types.CustomerInstance, 0)
+	for _, instance := range allInstances {
+		if strings.HasPrefix(instance.Instance.ID, idPrefix) {
+			matchingInstances = append(matchingInstances, instance)
+		}
+	}
+
+	if len(matchingInstances) == 0 {
+		return nil, errors.Errorf("no instance found with ID %q for customer %q", idPrefix, customer.Name)
+	}
+
+	if len(matchingInstances) > 1 {
+		return nil, fmt.Errorf("%d instances for customer %q have prefix %q, please use full ID",
+			len(matchingInstances), customer.Name, idPrefix)
+	}
+	return &matchingInstances[0], nil
+}
+
+func (c InstancesClient) GetInstanceUptime(instance types.CustomerInstance, startTime time.Time, uptimeInterval time.Duration) (*types.CustomerInstanceUptime, error) {
+	uptime := types.CustomerInstanceUptime{}
+	timeParam := startTime.Format(time.RFC3339)
+	urlPath := fmt.Sprintf("/v1/instance/%s/appstatus?startTime=%s&interval=%.0fh", instance.Instance.ID, timeParam, uptimeInterval.Hours())
+
+	err := c.HTTPClient.DoJSON(
+		"GET",
+		urlPath,
+		200,
+		nil,
+		&uptime,
+	)
+
+	if err != nil {
+		return nil, errors.Wrap(err, "get uptime")
+	}
+	return &uptime, nil
+}

--- a/pkg/instancesclient/get_instance_test.go
+++ b/pkg/instancesclient/get_instance_test.go
@@ -1,0 +1,63 @@
+package instancesclient
+
+import (
+	"fmt"
+	"github.com/pact-foundation/pact-go/dsl"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"testing"
+)
+
+var (
+	pact dsl.Pact
+)
+
+func TestMain(m *testing.M) {
+	pact = dsl.Pact{
+		Consumer: "webapp",
+		Provider: "api",
+	}
+
+	pact.Setup(true)
+
+	rc := m.Run()
+
+	pact.WritePact()
+	pact.Teardown()
+
+	os.Exit(rc)
+}
+
+func TestPactGetInstance(t *testing.T) {
+	pact.
+		AddInteraction().
+		UponReceiving("greeting").
+		WithRequest(dsl.Request{
+			Method: http.MethodGet,
+			Path:   dsl.String("/hello"),
+		}).
+		WillRespondWith(dsl.Response{
+			Status: http.StatusOK,
+			Headers: dsl.MapMatcher{
+				"Content-Type": dsl.String("text/plain"),
+			},
+			Body: dsl.String("hello"),
+		})
+
+	if err := pact.Verify(func() error {
+		resp, err := http.Get(fmt.Sprintf("http://%s:%d/%s", pact.Host, pact.Server.Port, "hello"))
+		if err != nil {
+			return err
+		}
+
+		b, _ := io.ReadAll(resp.Body)
+		if string(b) != "hello" {
+			return fmt.Errorf("got %s expected %s", string(b), "hello")
+		}
+		return nil
+	}); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/pkg/instancesclient/list_instances.go
+++ b/pkg/instancesclient/list_instances.go
@@ -1,0 +1,29 @@
+package instancesclient
+
+import (
+	"fmt"
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/replicated/pkg/types"
+)
+
+func (c InstancesClient) ListInstances(customer types.Customer) ([]types.CustomerInstance, error) {
+	var instancesRaw []types.CustomerInstanceRaw
+	err := c.HTTPClient.DoJSON(
+		"GET",
+		fmt.Sprintf("/v1/instances?customerSelector=%s&selectorType=id", customer.ID),
+		200,
+		nil,
+		&instancesRaw,
+	)
+
+	if err != nil {
+		return nil, errors.Wrap(err, "get instances from api")
+	}
+
+	var instances []types.CustomerInstance
+	for _, instance := range instancesRaw {
+		instances = append(instances, instance.WithInsights(customer.CreatedAt.Time))
+	}
+
+	return instances, nil
+}

--- a/pkg/kotsclient/customer_list.go
+++ b/pkg/kotsclient/customer_list.go
@@ -46,7 +46,7 @@ func (c *VendorV3Client) ListCustomers(appID string) ([]types.Customer, error) {
 	return allCustomers, nil
 }
 
-func (c *VendorV3Client) GetCustomerByName(appID string, name string) (*types.Customer, error) {
+func (c *VendorV3Client) GetCustomerByNameOrID(appID string, name string) (*types.Customer, error) {
 	allCustomers, err := c.ListCustomers(appID)
 	if err != nil {
 		return nil, err

--- a/pkg/types/customer.go
+++ b/pkg/types/customer.go
@@ -6,11 +6,12 @@ import (
 )
 
 type Customer struct {
-	ID       string     `json:"id"`
-	Name     string     `json:"name"`
-	Channels []Channel  `json:"channels"`
-	Type     string     `json:"type"`
-	Expires  *util.Time `json:"expiresAt"`
+	ID        string     `json:"id"`
+	Name      string     `json:"name"`
+	Channels  []Channel  `json:"channels"`
+	Type      string     `json:"type"`
+	Expires   *util.Time `json:"expiresAt"`
+	CreatedAt *util.Time `json:"createdAt"`
 }
 
 func (c Customer) WithExpiryTime(expiryTime string) (Customer, error) {

--- a/pkg/types/customer_instance.go
+++ b/pkg/types/customer_instance.go
@@ -1,0 +1,186 @@
+package types
+
+import (
+	"fmt"
+	"github.com/replicatedhq/replicated/pkg/util"
+	"math"
+	"time"
+)
+
+type CustomerInstanceRaw struct {
+	ID string `json:"id"`
+
+	//app info
+	AppStatus      string     `json:"appStatus"`
+	AppVersion     string     `json:"versionLabel"`
+	VersionsBehind int        `json:"numberVersionsBehind"`
+	LastCheckIn    *util.Time `json:"lastCheckinAt"`
+
+	// install info
+	K8sDistribution     string     `json:"k8sDistribution"`
+	K8sVersion          string     `json:"k8sVersion"`
+	KOTSVersion         string     `json:"kotsVersion"`
+	FirstCheckinAt      *util.Time `json:"firstCheckinAt"`
+	CloudProvider       string     `json:"cloudProvider"`
+	CloudProviderRegion string     `json:"cloudProviderRegion"`
+
+	// insights inputs
+	CurrentVersionReleasedAt *util.Time `json:"currentVersionReleasedAt"`
+	LatestVersionReleasedAt  *util.Time `json:"latestVersionReleasedAt"`
+	FirstReadyAt             *util.Time `json:"firstReadyAt"`
+}
+
+type CustomerInstanceInsights struct {
+	LicenseCreatedAt time.Time `json:"licenseCreatedAt"`
+
+	AbsoluteVersionAge    time.Duration  `json:"absoluteVersionAge"`
+	RelativeVersionAge    time.Duration  `json:"relativeVersionAge"`
+	InstanceTimeToInstall *time.Duration `json:"instanceTimeToInstall"`
+	LicenseTimeToInstall  *time.Duration `json:"licenseTimeToInstall"`
+	Uptime                float64        `json:"uptime"`
+	UpgradeSuccessRate    float64        `json:"upgradeSuccessRate"`
+	UpgradesCompleted     int            `json:"upgradesCompleted"`
+}
+
+type CustomerInstance struct {
+	Instance CustomerInstanceRaw      `json:"instance"`
+	Insights CustomerInstanceInsights `json:"insights"`
+}
+
+func (c *CustomerInstanceRaw) WithInsights(licenseCreated time.Time) CustomerInstance {
+	instance := CustomerInstance{
+		Instance: *c,
+		Insights: CustomerInstanceInsights{
+			LicenseCreatedAt:   licenseCreated,
+			AbsoluteVersionAge: time.Now().Sub(c.CurrentVersionReleasedAt.Time),
+			RelativeVersionAge: c.LatestVersionReleasedAt.Time.Sub(c.CurrentVersionReleasedAt.Time),
+		},
+	}
+
+	if c.FirstReadyAt != nil {
+		licenseTTI := c.FirstReadyAt.Time.Sub(licenseCreated)
+		instance.Insights.LicenseTimeToInstall = &licenseTTI
+		if c.FirstCheckinAt != nil {
+			instanceTTI := c.FirstReadyAt.Time.Sub(c.FirstCheckinAt.Time)
+			instance.Insights.InstanceTimeToInstall = &instanceTTI
+		}
+	}
+
+	return instance
+}
+
+func (c *CustomerInstance) ShortID() string {
+	return fmt.Sprintf("%.7s", c.Instance.ID)
+}
+
+func (c *CustomerInstance) AgeAbsolute() string {
+	return c.FormatDuration(&c.Insights.RelativeVersionAge)
+}
+func (c *CustomerInstance) AgeRelative() string {
+	return c.FormatDuration(&c.Insights.RelativeVersionAge)
+}
+
+func (c *CustomerInstance) TTILicense() string {
+	return c.FormatDuration(c.Insights.LicenseTimeToInstall)
+}
+
+func (c *CustomerInstance) TTIInstance() string {
+	return c.FormatDuration(c.Insights.InstanceTimeToInstall)
+}
+
+func (c *CustomerInstance) FormatDuration(d *time.Duration) string {
+	if d == nil {
+		return "--"
+	}
+
+	duration := *d
+	if duration == 0 {
+		return "0s"
+	}
+	if duration < 1*time.Hour {
+		minutes := math.Trunc(duration.Minutes())
+		seconds := duration.Seconds() - minutes*60
+		return fmt.Sprintf("%.0fm%.0fs", minutes, seconds)
+	}
+	if duration < 24*time.Hour {
+		hours := math.Trunc(duration.Hours())
+		minutes := duration.Minutes() - hours*60
+		return fmt.Sprintf("%.0fh%.0fm", hours, minutes)
+	}
+	if duration < 7*24*time.Hour {
+		days := math.Trunc(duration.Hours() / 24)
+		hours := duration.Hours() - (days * 24)
+		return fmt.Sprintf("%.0fd%.0fh", days, hours)
+	}
+
+	return fmt.Sprintf("%.1fd", duration.Hours()/24)
+}
+
+/*
+
+
+[{"id":"2JEmiplxi5hu5p2nNE1o8sFq3fd",
+"firstCheckinAt":"2022-12-21T19:43:54.277Z",
+"lastCheckinAt":"2022-12-23T17:15:00.722Z",
+"firstReadyAt":"2022-12-21T19:43:59.455Z",
+"licenseCreatedAt":"2022-12-21T19:32:37Z",
+"appStatus":"ready",
+"versionLabel":"1.0.2",
+"numberVersionsBehind":3,
+"currentVersionReleasedAt":"2022-12-21T17:03:31Z",
+"latestVersionReleasedAt":"2022-12-23T23:00:52Z",
+"isKurl":false,
+"k8sVersion":"v1.23.12-gke.1600",
+"k8sDistribution":"gke",
+"k8sVersionsBehind":0,
+"cloudProvider":"gcp",
+"cloudProviderRegion":"us-central1",
+"kotsInstanceId":"dxuhskgrddicjhtvvlfyxcrxxbhbvjvh",
+"kotsVersion":"v1.91.3",
+"isAirgap":false,
+"_embedded":{"app":{"id":"2C0OQyxiiA4pc3blK0cKs5VQS3N",
+"name":"wordpress-enterprise",
+"slug":"wordpress-enterprise",
+"createdAt":"2022-07-16T01:47:04Z",
+"customHostnames":{},
+"resourceUrls":{"_self":{"href":"/v4/app/2C0OQyxiiA4pc3blK0cKs5VQS3N",
+"method":"GET",
+"documentation":"https://help.replicated.com/api/vendor-api/#get-v4-app-appid"},
+"channels":{"list":{"href":"/v4/channels?appSelector=wordpress-enterprise",
+"method":"GET",
+"documentation":"https://help.replicated.com/api/vendor-api/#get-v4-apps-appid-channels"}}}},
+"channel":{"id":"2C0OR5HUAAge0xo2ggEwGwOHSG4",
+"name":"Stable",
+"slug":"stable",
+"createdAt":"2022-07-16T01:47:03Z",
+"isDefault":true,
+"_embedded":{"app":{"id":"2C0OQyxiiA4pc3blK0cKs5VQS3N",
+"name":"wordpress-enterprise",
+"slug":"wordpress-enterprise",
+"createdAt":"2022-07-16T01:47:04Z",
+"customHostnames":{},
+"resourceUrls":{"_self":{"href":"/v4/app/2C0OQyxiiA4pc3blK0cKs5VQS3N",
+"method":"GET",
+"documentation":"https://help.replicated.com/api/vendor-api/#get-v4-app-appid"},
+"channels":{"list":{"href":"/v4/channels?appSelector=wordpress-enterprise",
+"method":"GET",
+"documentation":"https://help.replicated.com/api/vendor-api/#get-v4-apps-appid-channels"}}}}},
+"_resources":{"_self":{"href":"/v4/channel/2C0OR5HUAAge0xo2ggEwGwOHSG4",
+"method":"GET",
+"documentation":"https://help.replicated.com/api/vendor-api/#get-v4-channel-channelid"},
+"releases":{"list":{"href":"/v4/releases?channelSelector=stable",
+"method":"GET",
+"documentation":"https://help.replicated.com/api/vendor-api/#get-v4-channels-channelid-releases"}}}}},
+"_resources":{"_self":{"href":"/v4/instance/2JEmiplxi5hu5p2nNE1o8sFq3fd",
+"method":"GET",
+"documentation":"https://replicated-vendor-api.readme.io/v4/reference/getinstance"},
+"events":{"href":"/v4/instance/2JEmiplxi5hu5p2nNE1o8sFq3fd/events",
+"method":"GET",
+"documentation":"https://replicated-vendor-api.readme.io/v4/reference/listinstanceevents"}}},
+{"id":"2JKZifK6EvX5vSL4b5vUVSgiqjC",
+"firstCheckinAt":"2022-12-23T20:55:45.551Z",
+"lastCheckinAt":"2022-12-24T16:54:00.944Z",
+"firstReadyAt":"2022-12-23T20:55:49.166Z","licenseCreatedAt":"2022-12-21T19:32:37Z","appStatus":"ready","versionLabel":"1.2.0","numberVersionsBehind":0,"currentVersionReleasedAt":"2022-12-23T23:00:52Z","latestVersionReleasedAt":"2022-12-23T23:00:52Z","isKurl":false,"k8sVersion":"v1.23.12-gke.1600","k8sDistribution":"gke","k8sVersionsBehind":0,"cloudProvider":"gcp","cloudProviderRegion":"us-central1","kotsInstanceId":"sywujpjnnoipmonrlrmxkdlshootdpsi","kotsVersion":"v1.91.3","isAirgap":false,"_embedded":{"app":{"id":"2C0OQyxiiA4pc3blK0cKs5VQS3N","name":"wordpress-enterprise","slug":"wordpress-enterprise","createdAt":"2022-07-16T01:47:04Z","customHostnames":{},"resourceUrls":{"_self":{"href":"/v4/app/2C0OQyxiiA4pc3blK0cKs5VQS3N","method":"GET","documentation":"https://help.replicated.com/api/vendor-api/#get-v4-app-appid"},"channels":{"list":{"href":"/v4/channels?appSelector=wordpress-enterprise","method":"GET","documentation":"https://help.replicated.com/api/vendor-api/#get-v4-apps-appid-channels"}}}},"channel":{"id":"2C0OR5HUAAge0xo2ggEwGwOHSG4","name":"Stable","slug":"stable","createdAt":"2022-07-16T01:47:03Z","isDefault":true,"_embedded":{"app":{"id":"2C0OQyxiiA4pc3blK0cKs5VQS3N","name":"wordpress-enterprise","slug":"wordpress-enterprise","createdAt":"2022-07-16T01:47:04Z","customHostnames":{},"resourceUrls":{"_self":{"href":"/v4/app/2C0OQyxiiA4pc3blK0cKs5VQS3N","method":"GET","documentation":"https://help.replicated.com/api/vendor-api/#get-v4-app-appid"},"channels":{"list":{"href":"/v4/channels?appSelector=wordpress-enterprise","method":"GET","documentation":"https://help.replicated.com/api/vendor-api/#get-v4-apps-appid-channels"}}}}},"_resources":{"_self":{"href":"/v4/channel/2C0OR5HUAAge0xo2ggEwGwOHSG4","method":"GET","documentation":"https://help.replicated.com/api/vendor-api/#get-v4-channel-channelid"},"releases":{"list":{"href":"/v4/releases?channelSelector=stable","method":"GET","documentation":"https://help.replicated.com/api/vendor-api/#get-v4-channels-channelid-releases"}}}}},"_resources":{"_self":{"href":"/v4/instance/2JKZifK6EvX5vSL4b5vUVSgiqjC","method":"GET","documentation":"https://replicated-vendor-api.readme.io/v4/reference/getinstance"},"events":{"href":"/v4/instance/2JKZifK6EvX5vSL4b5vUVSgiqjC/events","method":"GET","documentation":"https://replicated-vendor-api.readme.io/v4/reference/listinstanceevents"}}}]
+
+
+*/

--- a/pkg/types/customer_instance_uptime.go
+++ b/pkg/types/customer_instance_uptime.go
@@ -1,0 +1,73 @@
+package types
+
+import (
+	"github.com/replicatedhq/replicated/pkg/util"
+)
+
+type InstanceUptimeInterval struct {
+	StartTime *util.Time              `json:"startTime"`
+	EndTime   *util.Time              `json:"endTime"`
+	Interval  string                  `json:"interval"`
+	Statuses  *InstanceUptimeStatuses `json:"statuses"`
+}
+
+type InstanceUptimeStatuses struct {
+	Missing     float64 `json:"missing"`
+	Unavailable float64 `json:"unavailable"`
+	Degraded    float64 `json:"degraded"`
+	Updating    float64 `json:"updating"`
+	Ready       float64 `json:"ready"`
+	Unknown     float64 `json:"unknown"`
+}
+
+type CustomerInstanceUptime struct {
+	Histogram []InstanceUptimeInterval `json:"histogram"`
+}
+
+/*
+
+{
+  "histogram": [
+    {
+      "startTime": "2022-12-10T08:00:00Z",
+      "endTime": "2022-12-10T16:00:00Z",
+      "interval": "8h",
+      "statuses": {
+        "missing": 0,
+        "unavailable": 0,
+        "degraded": 0,
+        "updating": 0,
+        "ready": 0,
+        "unknown": 100
+      },
+      "_embedded": null,
+      "_resources": {
+        "_self": {
+          "href": "/v4/instance/2JK93avStGaNpwTfiHHUkc2iZ9p/appstatus?endTime=2022-12-10T16%3A00%3A00Z&interval=8h&startTime=2022-12-10T08%3A00%3A00Z",
+          "method": "GET",
+          "documentation": "https://replicated-vendor-api.readme.io/v4/reference/getinstanceappstatus"
+        }
+      }
+    },
+    {
+      "startTime": "2022-12-10T16:00:00Z",
+      "endTime": "2022-12-11T00:00:00Z",
+      "interval": "8h",
+      "statuses": {
+        "missing": 0,
+        "unavailable": 0,
+        "degraded": 0,
+        "updating": 0,
+        "ready": 0,
+        "unknown": 100
+      },
+      "_embedded": null,
+      "_resources": {
+        "_self": {
+          "href": "/v4/instance/2JK93avStGaNpwTfiHHUkc2iZ9p/appstatus?endTime=2022-12-11T00%3A00%3A00Z&interval=8h&startTime=2022-12-10T16%3A00%3A00Z",
+          "method": "GET",
+          "documentation": "https://replicated-vendor-api.readme.io/v4/reference/getinstanceappstatus"
+        }
+      }
+    },
+*/


### PR DESCRIPTION
Outstanding work to make this ready
- [ ] pact test for usage of `/instances` V4 API with `customerSelector`
- [ ] add more k8s info to instances list view

* * *

Right now you need a customer to make this work, because I couldn't get the `appSelector` to work with the v4 api. There's a few things we should add, including listing *all* instances, and a few k8s cluster details we can add in.

```
$ replicated customer instance ls Paypal
ID         STATUS     VERSION    VERSIONS-BEHIND    VERSION-AGE    VERSION-AGE-RELATIVE    LAST-CHECKIN        TTI-LICENSE    TTI-INSTANCE    FIRST-READY
2JByR1V    ready      1.0.2      4                  3d8h           3d8h                    2022-12-23 00:00    9m44s          0m4s            2022-12-20 00:00
2JK93av    ready      1.2.0      1                  1d2h           1d2h                    2022-12-28 15:05    2d22h          7m19s           2022-12-23 00:00
2JK9CVv    missing    1.0.2      4                  3d8h           3d8h                    2022-12-28 15:02    2d22h          1m50s           2022-12-23 00:00
2JMsKqo    ready      1.2.0      1                  1d2h           1d2h                    2022-12-25 00:00    4d1h           3h56m           2022-12-24 00:00
2JMsQiT    ready      1.2.0      1                  1d2h           1d2h                    2022-12-25 00:00    4d1h           1m31s           2022-12-24 00:00
```
Using the `-o wide` flag will give the following columns:

`ID         STATUS     VERSION    VERSIONS-BEHIND    VERSION-AGE    VERSION-AGE-RELATIVE    LAST-CHECKIN        TTI-LICENSE    TTI-INSTANCE    FIRST-SEEN          FIRST-READY         LICENSE-CREATED     LATEST-CHANNEL-RELEASE    FULL-ID`

`instance inspect` will show a mini terminal version of the instances page. This is a little goofy but I don't hate it. It gives a good way to test multiple consumers of the backend data.

```
replicated customer instance inspect Paypal 2Jvas53
```

<img width="937" alt="Screen Shot 2022-12-28 at 9 26 35 AM" src="https://user-images.githubusercontent.com/3730605/209835806-ba3a4902-9e28-4986-bcab-a1134d07beca.png">




