### PR TITLE
Inconsistent channel info 63010

### DIFF
--- a/cli/cmd/channel_counts.go
+++ b/cli/cmd/channel_counts.go
@@ -25,7 +25,7 @@ func (r *runners) channelCounts(cmd *cobra.Command, args []string) error {
 	chanID := args[0]
 
 	if r.appType == "platform" {
-		appChan, _, err := r.api.GetChannel(r.appID, r.appType, chanID)
+		appChan, _, err := r.platformAPI.GetChannel(r.appID, chanID)
 		if err != nil {
 			return err
 		}

--- a/cli/cmd/channel_create.go
+++ b/cli/cmd/channel_create.go
@@ -24,7 +24,7 @@ func (r *runners) InitChannelCreate(parent *cobra.Command) {
 }
 
 func (r *runners) channelCreate(cmd *cobra.Command, args []string) error {
-	allChannels, err := r.api.CreateChannel(r.appID, r.appType, r.appSlug, r.args.channelCreateName, r.args.channelCreateDescription)
+	allChannels, err := r.api.CreateChannel(r.appID, r.appType, r.args.channelCreateName, r.args.channelCreateDescription)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/channel_inspect.go
+++ b/cli/cmd/channel_inspect.go
@@ -25,12 +25,12 @@ func (r *runners) channelInspect(_ *cobra.Command, args []string) error {
 	}
 
 	channelNameOrID := args[0]
-	appChan, err := r.api.GetChannelByName(r.appID, r.appType, r.appSlug, channelNameOrID)
+	appChan, err := r.api.GetChannelByName(r.appID, r.appType, channelNameOrID)
 	if err != nil {
 		return err
 	}
 
-	if err = print.ChannelAttrs(r.w, appChan); err != nil {
+	if err = print.ChannelAttrs(r.w, r.appSlug, appChan); err != nil {
 		return err
 	}
 

--- a/cli/cmd/channel_inspect.go
+++ b/cli/cmd/channel_inspect.go
@@ -30,7 +30,7 @@ func (r *runners) channelInspect(_ *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err = print.ChannelAttrs(r.w, r.appSlug, appChan); err != nil {
+	if err = print.ChannelAttrs(r.w, r.appType, r.appSlug, appChan); err != nil {
 		return err
 	}
 

--- a/cli/cmd/channel_ls.go
+++ b/cli/cmd/channel_ls.go
@@ -17,7 +17,7 @@ func (r *runners) InitChannelList(parent *cobra.Command) {
 }
 
 func (r *runners) channelList(cmd *cobra.Command, args []string) error {
-	channels, err := r.api.ListChannels(r.appID, r.appType, r.appSlug, "")
+	channels, err := r.api.ListChannels(r.appID, r.appType, "")
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/channel_releases.go
+++ b/cli/cmd/channel_releases.go
@@ -26,7 +26,7 @@ func (r *runners) channelReleases(cmd *cobra.Command, args []string) error {
 
 	if r.appType == "platform" {
 
-		_, releases, err := r.api.GetChannel(r.appID, r.appType, chanID)
+		_, releases, err := r.platformAPI.GetChannel(r.appID, chanID)
 		if err != nil {
 			return err
 		}

--- a/cli/cmd/customer_create.go
+++ b/cli/cmd/customer_create.go
@@ -31,7 +31,6 @@ func (r *runners) createCustomer(_ *cobra.Command, _ []string) error {
 	channel, err := r.api.GetOrCreateChannelByName(
 		r.appID,
 		r.appType,
-		r.appSlug,
 		r.args.customerCreateChannel,
 		"",
 		r.args.customerCreateEnsureChannel,

--- a/cli/cmd/release_create.go
+++ b/cli/cmd/release_create.go
@@ -320,7 +320,6 @@ func (r *runners) getOrCreateChannelForPromotion(channelName string, createIfAbs
 	channel, err := r.api.GetOrCreateChannelByName(
 		r.appID,
 		r.appType,
-		r.appSlug,
 		channelName,
 		description,
 		createIfAbsent,

--- a/cli/cmd/release_promote.go
+++ b/cli/cmd/release_promote.go
@@ -41,7 +41,7 @@ func (r *runners) releasePromote(cmd *cobra.Command, args []string) error {
 
 	if r.appType != "ship" {
 		// try to turn chanID into an actual id if it was a channel name
-		channelID, err := r.api.GetOrCreateChannelByName(r.appID, r.appType, r.appSlug, channelName, "", false)
+		channelID, err := r.api.GetOrCreateChannelByName(r.appID, r.appType, channelName, "", false)
 		if err != nil {
 			return errors.Wrapf(err, "unable to get channel ID from name")
 		}

--- a/cli/print/channel_attributes.go
+++ b/cli/print/channel_attributes.go
@@ -30,19 +30,26 @@ AIRGAP:
 
 var channelAttrsTmpl = template.Must(template.New("ChannelAttributes").Parse(channelAttrsTmplSrc))
 
-func ChannelAttrs(w *tabwriter.Writer, appSlug string, appChan *types.Channel) error {
-	channelAttrs := struct {
+func ChannelAttrs(
+	w *tabwriter.Writer,
+	appType string,
+	appSlug string,
+	appChan *types.Channel,
+) error {
+	attrs := struct {
 		Existing string
 		Embedded string
 		Airgap   string
 		Chan     *types.Channel
 	}{
-		existingInstallCommand(appSlug, appChan.Slug),
-		embeddedInstallCommand(appSlug, appChan.Slug),
-		embeddedAirgapInstallCommand(appSlug, appChan.Slug),
-		appChan,
+		Chan: appChan,
 	}
-	if err := channelAttrsTmpl.Execute(w, channelAttrs); err != nil {
+	if appType == "kots" {
+		attrs.Existing = existingInstallCommand(appSlug, appChan.Slug)
+		attrs.Embedded = embeddedInstallCommand(appSlug, appChan.Slug)
+		attrs.Airgap = embeddedAirgapInstallCommand(appSlug, appChan.Slug)
+	}
+	if err := channelAttrsTmpl.Execute(w, attrs); err != nil {
 		return err
 	}
 	return w.Flush()

--- a/client/channel.go
+++ b/client/channel.go
@@ -9,7 +9,7 @@ import (
 	"github.com/replicatedhq/replicated/pkg/types"
 )
 
-func (c *Client) ListChannels(appID string, appType string, appSlug string, channelName string) ([]types.Channel, error) {
+func (c *Client) ListChannels(appID string, appType string, channelName string) ([]types.Channel, error) {
 
 	if appType == "platform" {
 		platformChannels, err := c.PlatformClient.ListChannels(appID)
@@ -34,7 +34,7 @@ func (c *Client) ListChannels(appID string, appType string, appSlug string, chan
 	} else if appType == "ship" {
 		return c.ShipClient.ListChannels(appID)
 	} else if appType == "kots" {
-		return c.KotsClient.ListChannels(appID, appSlug, channelName)
+		return c.KotsClient.ListChannels(appID, channelName)
 	}
 
 	return nil, errors.New("unknown app type")
@@ -74,13 +74,13 @@ func (c *Client) ArchiveChannel(appID string, appType string, channelID string) 
 
 }
 
-func (c *Client) CreateChannel(appID string, appType string, appSlug string, name string, description string) ([]types.Channel, error) {
+func (c *Client) CreateChannel(appID string, appType string, name string, description string) ([]types.Channel, error) {
 
 	if appType == "platform" {
 		if err := c.PlatformClient.CreateChannel(appID, name, description); err != nil {
 			return nil, err
 		}
-		return c.ListChannels(appID, appType, appSlug, name)
+		return c.ListChannels(appID, appType, name)
 	} else if appType == "ship" {
 		if _, err := c.ShipClient.CreateChannel(appID, name, description); err != nil {
 			return nil, err
@@ -90,13 +90,13 @@ func (c *Client) CreateChannel(appID string, appType string, appSlug string, nam
 		if _, err := c.KotsClient.CreateChannel(appID, name, description); err != nil {
 			return nil, err
 		}
-		return c.KotsClient.ListChannels(appID, appSlug, name)
+		return c.KotsClient.ListChannels(appID, name)
 	}
 
 	return nil, errors.New("unknown app type")
 }
 
-func (c *Client) GetOrCreateChannelByName(appID string, appType string, appSlug string, nameOrID string, description string, createIfAbsent bool) (*types.Channel, error) {
+func (c *Client) GetOrCreateChannelByName(appID string, appType string, nameOrID string, description string, createIfAbsent bool) (*types.Channel, error) {
 	gqlNotFoundErr := fmt.Sprintf("channel %s not found", nameOrID)
 	channel, err := c.GetChannel(appID, appType, nameOrID)
 	if err == nil {
@@ -105,7 +105,7 @@ func (c *Client) GetOrCreateChannelByName(appID string, appType string, appSlug 
 		return nil, errors.Wrap(err, "get channel")
 	}
 
-	allChannels, err := c.ListChannels(appID, appType, appSlug, nameOrID)
+	allChannels, err := c.ListChannels(appID, appType, nameOrID)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +113,7 @@ func (c *Client) GetOrCreateChannelByName(appID string, appType string, appSlug 
 	foundChannel, numMatching, err := c.findChannel(allChannels, nameOrID)
 
 	if numMatching == 0 && createIfAbsent {
-		updatedListOfChannels, err := c.CreateChannel(appID, appType, appSlug, nameOrID, description)
+		updatedListOfChannels, err := c.CreateChannel(appID, appType, nameOrID, description)
 		if err != nil {
 			return nil, errors.Wrapf(err, "create channel %q ", nameOrID)
 		}
@@ -126,8 +126,8 @@ func (c *Client) GetOrCreateChannelByName(appID string, appType string, appSlug 
 	return foundChannel, errors.Wrapf(err, "find channel %q", nameOrID)
 }
 
-func (c *Client) GetChannelByName(appID string, appType string, appSlug string, name string) (*types.Channel, error) {
-	return c.GetOrCreateChannelByName(appID, appType, appSlug, name, "", false)
+func (c *Client) GetChannelByName(appID string, appType string, name string) (*types.Channel, error) {
+	return c.GetOrCreateChannelByName(appID, appType, name, "", false)
 }
 
 func (c *Client) findChannel(channels []types.Channel, name string) (*types.Channel, int, error) {

--- a/pkg/kotsclient/channel_test.go
+++ b/pkg/kotsclient/channel_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 
 	"github.com/pact-foundation/pact-go/dsl"
-	channels "github.com/replicatedhq/replicated/gen/go/v1"
 	"github.com/replicatedhq/replicated/pkg/platformclient"
+	"github.com/replicatedhq/replicated/pkg/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -113,11 +113,10 @@ func Test_GetChannel(t *testing.T) {
 		api := platformclient.NewHTTPClient(u, "replicated-cli-get-channel-token")
 		client := VendorV3Client{HTTPClient: *api}
 
-		channel, releases, err := client.GetChannel("replicated-cli-get-channel-app", "replicated-cli-get-channel-unstable")
+		channel, err := client.GetChannel("replicated-cli-get-channel-app", "replicated-cli-get-channel-unstable")
 		assert.Nil(t, err)
 
 		assert.Equal(t, "Unstable", channel.Name)
-		assert.Len(t, releases, 0) // we don't return the releases
 
 		return nil
 	}
@@ -219,9 +218,9 @@ func Test_AddRemoveSemver(t *testing.T) {
 		api := platformclient.NewHTTPClient(u, "replicated-cli-semver-channel-token")
 		client := VendorV3Client{HTTPClient: *api}
 
-		channel := channels.AppChannel{
+		channel := types.Channel{
 			Name: "Unstable",
-			Id:   "replicated-cli-semver-channel-unstable",
+			ID:   "replicated-cli-semver-channel-unstable",
 		}
 
 		err = client.UpdateSemanticVersioning("replicated-cli-semver-channel-app", &channel, true)

--- a/pkg/kotsclient/channel_test.go
+++ b/pkg/kotsclient/channel_test.go
@@ -66,7 +66,7 @@ func Test_ListChannels(t *testing.T) {
 		api := platformclient.NewHTTPClient(u, "replicated-cli-list-channels-token")
 		client := VendorV3Client{HTTPClient: *api}
 
-		channels, err := client.ListChannels("replicated-cli-list-channels-app", "", "")
+		channels, err := client.ListChannels("replicated-cli-list-channels-app", "")
 		assert.Nil(t, err)
 
 		assert.Len(t, channels, 1)
@@ -159,7 +159,7 @@ func Test_RemoveChannels(t *testing.T) {
 		err = client.ArchiveChannel("replicated-cli-rm-channel-app", "replicated-cli-rm-channel-beta")
 		assert.Nil(t, err)
 
-		channels, err := client.ListChannels("replicated-cli-rm-channel-app", "", "")
+		channels, err := client.ListChannels("replicated-cli-rm-channel-app", "")
 		assert.Nil(t, err)
 
 		assert.Len(t, channels, 1)

--- a/pkg/shipclient/channel.go
+++ b/pkg/shipclient/channel.go
@@ -1,7 +1,6 @@
 package shipclient
 
 import (
-	channels "github.com/replicatedhq/replicated/gen/go/v1"
 	"github.com/replicatedhq/replicated/pkg/graphql"
 	"github.com/replicatedhq/replicated/pkg/types"
 )
@@ -155,7 +154,7 @@ var getShipChannel = `
   }
 `
 
-func (c *GraphQLClient) GetChannel(appID string, channelID string) (*channels.AppChannel, []channels.ChannelRelease, error) {
+func (c *GraphQLClient) GetChannel(appID string, channelID string) (*types.Channel, error) {
 	response := GraphQLResponseGetChannel{}
 
 	request := graphql.Request{
@@ -166,14 +165,15 @@ func (c *GraphQLClient) GetChannel(appID string, channelID string) (*channels.Ap
 		},
 	}
 	if err := c.ExecuteRequest(request, &response); err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	channelDetail := channels.AppChannel{
-		Id:           response.Data.ShipChannel.ID,
-		Name:         response.Data.ShipChannel.Name,
-		Description:  response.Data.ShipChannel.Description,
-		ReleaseLabel: response.Data.ShipChannel.CurrentVersion,
+	channel := types.Channel{
+		ID:              response.Data.ShipChannel.ID,
+		Name:            response.Data.ShipChannel.Name,
+		Description:     response.Data.ShipChannel.Description,
+		ReleaseSequence: response.Data.ShipChannel.CurrentSequence,
+		ReleaseLabel:    response.Data.ShipChannel.CurrentVersion,
 	}
-	return &channelDetail, nil, nil
+	return &channel, nil
 }

--- a/pkg/types/channel.go
+++ b/pkg/types/channel.go
@@ -75,8 +75,6 @@ type Channel struct {
 	ReleaseLabel    string
 
 	IsArchived bool `json:"isArchived"`
-
-	InstallCommands *InstallCommands
 }
 
 func (c *Channel) Copy() *Channel {
@@ -87,12 +85,5 @@ func (c *Channel) Copy() *Channel {
 		Slug:            c.Slug,
 		ReleaseSequence: c.ReleaseSequence,
 		ReleaseLabel:    c.ReleaseLabel,
-		InstallCommands: c.InstallCommands,
 	}
-}
-
-type InstallCommands struct {
-	Existing string
-	Embedded string
-	Airgap   string
 }


### PR DESCRIPTION
See https://app.shortcut.com/replicated/story/63010/replicated-cli-channel-inspect-command-shows-inconsistent-channel-info

Inconsistency is due to `channel inspect` using a `types.Channel` (which has an `InstallCommands` field) for output in the Name lookup case and a `channels.AppChannel` (which does not have `InstallCommands`) for output in the ID lookup case.

1. Move install commands text from `types.Channel.InstallCommands` to template in `cli.print.ChannelAttrs()`. Commands are strictly derived from app and channel attributes (currently just the slugs) so don't really belong as additional channel attributes.
2. Make `client.GetChannel()` return `(*types.Channel, error)` instead of `(*channels.AppChannel, []channels.ChannelRelease)` for consistency with `ListChannel`. This implies that callers that need specific `AppChannel` or `ChannelRelease` information now have to call the v1 API directly. (We already did this in cli/cmd/channel_adoption.go.)