### PR TITLE
Add additional cluster management crud

### DIFF
--- a/cli/cmd/cluster_create.go
+++ b/cli/cmd/cluster_create.go
@@ -23,7 +23,7 @@ func (r *runners) InitClusterCreate(parent *cobra.Command) *cobra.Command {
 	cmd.MarkFlagRequired("name")
 
 	cmd.Flags().StringVar(&r.args.createClusterKubernetesDistribution, "kubernetes-distribution", "kind", "Kubernetes distribution of the cluster to provision")
-	cmd.Flags().StringVar(&r.args.createClusterKubernetesVersion, "kubernetes-version", "1.25.3", "Kubernetes version to provision (format is distribution dependent)")
+	cmd.Flags().StringVar(&r.args.createClusterKubernetesVersion, "kubernetes-version", "v1.25.3", "Kubernetes version to provision (format is distribution dependent)")
 	cmd.Flags().IntVar(&r.args.createClusterNodeCount, "node-count", int(1), "Node count")
 	cmd.Flags().Int64Var(&r.args.createClusterVCpus, "vcpus", int64(4), "vCPUs to request per node")
 	cmd.Flags().Int64Var(&r.args.createClusterMemoryMiB, "memory-mib", int64(4096), "Memory (MiB) to request per node")

--- a/cli/cmd/cluster_create.go
+++ b/cli/cmd/cluster_create.go
@@ -2,8 +2,10 @@ package cmd
 
 import (
 	"github.com/pkg/errors"
+	"github.com/replicatedhq/replicated/cli/print"
 	"github.com/replicatedhq/replicated/pkg/kotsclient"
 	"github.com/replicatedhq/replicated/pkg/platformclient"
+	"github.com/replicatedhq/replicated/pkg/types"
 	"github.com/spf13/cobra"
 )
 
@@ -42,7 +44,7 @@ func (r *runners) createCluster(_ *cobra.Command, args []string) error {
 		MemoryMiB:              r.args.createClusterMemoryMiB,
 		TTL:                    r.args.createClusterTTL,
 	}
-	_, err := kotsRestClient.CreateCluster(opts)
+	cl, err := kotsRestClient.CreateCluster(opts)
 	if errors.Cause(err) == platformclient.ErrForbidden {
 		return errors.New("This command is not available for your account or team. Please contact your customer success representative for more information.")
 	}
@@ -50,5 +52,5 @@ func (r *runners) createCluster(_ *cobra.Command, args []string) error {
 		return errors.Wrap(err, "create cluster")
 	}
 
-	return nil
+	return print.Clusters(r.w, []*types.Cluster{cl})
 }

--- a/pkg/kotsclient/cluster_create.go
+++ b/pkg/kotsclient/cluster_create.go
@@ -75,5 +75,6 @@ func (c *VendorV3Client) CreateCluster(opts CreateClusterOpts) (*types.Cluster, 
 	if err != nil {
 		return nil, err
 	}
+
 	return cluster.Cluster, nil
 }

--- a/pkg/kotsclient/cluster_create.go
+++ b/pkg/kotsclient/cluster_create.go
@@ -33,7 +33,7 @@ type CreateClusterOpts struct {
 var defaultCreateClusterOpts = CreateClusterOpts{
 	Name:                   "", // server will generate
 	KubernetesDistribution: "kind",
-	KubernetesVersion:      "1.25.3",
+	KubernetesVersion:      "v1.25.3",
 	NodeCount:              int(1),
 	VCpus:                  int64(4),
 	MemoryMiB:              int64(4096),


### PR DESCRIPTION
This continues the `cluster` subcommand for reliability matrix.

1. `cluster create` prints the output row from the clusters ls command to get the id, etc
2. version uses the `v` prefix 