### PR TITLE
Add replicated login command

### DIFF
--- a/cli/cmd/login.go
+++ b/cli/cmd/login.go
@@ -1,0 +1,49 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/replicated/pkg/credentials"
+	"github.com/spf13/cobra"
+)
+
+func (r *runners) InitLoginCommand(parent *cobra.Command) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "login",
+		Short:        "Log in to Replicated",
+		Long:         `This command will open your browser to ask you authentication details and create / retrieve an API token for the CLI to use.`,
+		SilenceUsage: true,
+		RunE:         r.login,
+	}
+	parent.AddCommand(cmd)
+	cmd.Flags().StringVar(&r.args.loginEndpoint, "endpoint", "https://vendor.replicated.com", "The endpoint to use for the login process. Defaults to https://vendor.replicated.com")
+
+	return cmd
+}
+
+func (r *runners) login(_ *cobra.Command, _ []string) error {
+	endpoint := r.args.loginEndpoint
+
+	// if we are already logged in, just return
+	currentCredentials, err := credentials.GetCurrentCredentials()
+	if err == nil {
+		if currentCredentials.IsEnv {
+			return errors.New("REPLICATED_API_TOKEN is set. Please unset it to login with a different account.")
+		}
+		return errors.New("There are already credentials on this machine. Please run `replicated logout` to remove them.")
+	}
+	if err != credentials.ErrCredentialsNotFound {
+		return err
+	}
+
+	// open a browser to the login page
+	if err := credentials.Fetch(endpoint); err != nil {
+		if err == credentials.ErrNoBrowser {
+			return fmt.Errorf("No browser could be found. Please visit %s to login and create an API token.", endpoint)
+		}
+		return err
+	}
+
+	return nil
+}

--- a/cli/cmd/runner.go
+++ b/cli/cmd/runner.go
@@ -179,4 +179,6 @@ type runnerArgs struct {
 	removeClusterForce bool
 
 	lsClusterHideTerminated bool
+
+	loginEndpoint string
 }

--- a/go.mod
+++ b/go.mod
@@ -65,6 +65,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sergi/go-diff v1.1.0 // indirect
+	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/ulikunitz/xz v0.5.8 // indirect
 	github.com/xanzy/ssh-agent v0.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -472,6 +472,8 @@ github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNX
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
+github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966 h1:JIAuq3EEf9cgbU6AtGPK4CTG3Zf6CKMNqf0MHTggAUA=
+github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966/go.mod h1:sUM3LWHvSMaG192sy56D9F7CNvL7jUJVXoqM1QKLnog=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=

--- a/pkg/credentials/credentials.go
+++ b/pkg/credentials/credentials.go
@@ -1,0 +1,108 @@
+package credentials
+
+import (
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"os"
+	"path"
+
+	"github.com/replicatedhq/replicated/pkg/credentials/types"
+)
+
+var (
+	ErrCredentialsNotFound = errors.New("credentials not found")
+)
+
+func SetCurrentCredentials(token string) error {
+	configFileCredentials := &types.Credentials{
+		APIToken: token,
+	}
+
+	b, err := json.Marshal(configFileCredentials)
+	if err != nil {
+		return err
+	}
+
+	configFile := configFilePath()
+	if err := os.MkdirAll(path.Dir(configFile), 0755); err != nil {
+		return err
+	}
+
+	if err := ioutil.WriteFile(configFile, b, 0600); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func GetCurrentCredentials() (*types.Credentials, error) {
+	// priority order:
+	// 1. env vars
+	// 2. config file
+
+	envCredentials, err := getEnvCredentials()
+	if err != nil && err != ErrCredentialsNotFound {
+		return nil, err
+	}
+	if err == nil {
+		return envCredentials, nil
+	}
+
+	configFileCredentials, err := getConfigFileCredentials()
+	if err != nil && err != ErrCredentialsNotFound {
+		return nil, err
+	}
+
+	if err == nil {
+		return configFileCredentials, nil
+	}
+
+	return nil, ErrCredentialsNotFound
+}
+
+func getEnvCredentials() (*types.Credentials, error) {
+	if os.Getenv("REPLICATED_API_TOKEN") != "" {
+		return &types.Credentials{
+			APIToken: os.Getenv("REPLICATED_API_TOKEN"),
+			IsEnv:    true,
+		}, nil
+	}
+
+	return nil, ErrCredentialsNotFound
+}
+
+func getConfigFileCredentials() (*types.Credentials, error) {
+	configFile := configFilePath()
+	if _, err := os.Stat(configFile); err != nil {
+		if os.IsNotExist(err) {
+			return nil, ErrCredentialsNotFound
+		}
+
+		return nil, err
+	}
+
+	b, err := ioutil.ReadFile(configFile)
+	if err != nil {
+		return nil, err
+	}
+
+	credentials := types.Credentials{}
+	if err := json.Unmarshal(b, &credentials); err != nil {
+		return nil, err
+	}
+	credentials.IsConfigFile = true
+
+	return &credentials, nil
+}
+
+func configFilePath() string {
+	return path.Join(homeDir(), ".replicated", "config.yaml")
+}
+
+func homeDir() string {
+	if h := os.Getenv("HOME"); h != "" {
+		return h
+	}
+	return os.Getenv("USERPROFILE")
+}

--- a/pkg/credentials/fetch.go
+++ b/pkg/credentials/fetch.go
@@ -1,0 +1,160 @@
+package credentials
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/skratchdot/open-golang/open"
+)
+
+var (
+	ErrNoBrowser = errors.New("no browser could be found")
+)
+
+func Fetch(endpoint string) error {
+	// create a local web server with a single page
+	// vendor portal will redirect to this page with a token
+
+	localPort, err := getAvailablePort()
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	fullUri := fmt.Sprintf("%s/cli-login?redirect_uri=%s:%d/callback", endpoint, "http://localhost", localPort)
+	if err := open.Start(fullUri); err != nil {
+		if strings.Contains(err.Error(), "executable file not found in $PATH") {
+			return ErrNoBrowser
+		}
+		return err
+	}
+
+	token, err := startLocalWebServer(ctx, localPort)
+	if err != nil {
+		return err
+	}
+
+	if err := SetCurrentCredentials(token); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// startLocalWebServer handles the token redirect, returning the token
+func startLocalWebServer(ctx context.Context, port int) (string, error) {
+	errChan := make(chan error)
+	tokenChan := make(chan string)
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nonce := r.URL.Query().Get("nonce")
+		if nonce == "" {
+			errChan <- fmt.Errorf("no nonce found in response")
+		}
+
+		exchange := r.URL.Query().Get("exchange")
+		if exchange == "" {
+			errChan <- fmt.Errorf("no exchange found in response")
+		}
+
+		token, err := exchangeNonceForToken(exchange, nonce)
+		if err != nil {
+			errChan <- err
+		}
+
+		tokenChan <- token
+
+		w.Write([]byte("Authentication successful. You may close this window."))
+	})
+
+	go func() {
+		sm := http.NewServeMux()
+		sm.Handle("/callback", handler)
+		server := &http.Server{
+			Addr:              net.JoinHostPort("127.0.0.1", strconv.Itoa(port)),
+			Handler:           sm,
+			ReadHeaderTimeout: 3 * time.Second,
+		}
+
+		errChan <- server.ListenAndServe()
+	}()
+
+	timeout := time.NewTicker(5 * time.Minute)
+
+	select {
+	case <-timeout.C:
+		ctx.Done()
+		return "", fmt.Errorf("authentication timeout")
+	case token := <-tokenChan:
+		return token, nil
+	case e := <-errChan:
+		ctx.Done()
+		return "", e
+	}
+}
+
+func exchangeNonceForToken(uri string, nonce string) (string, error) {
+	req, err := http.NewRequest("GET", uri, nil)
+	if err != nil {
+		return "", err
+	}
+
+	q := req.URL.Query()
+	q.Add("nonce", nonce)
+	req.URL.RawQuery = q.Encode()
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	type tokenResponse struct {
+		Token string `json:"token"`
+	}
+	tr := &tokenResponse{}
+	if err := json.Unmarshal(b, tr); err != nil {
+		return "", err
+	}
+
+	return tr.Token, nil
+}
+
+func getAvailablePort() (int, error) {
+	address, err := net.ResolveTCPAddr("tcp", net.JoinHostPort("localhost", strconv.Itoa(0)))
+	if err != nil {
+		return 0, err
+	}
+
+	listener, err := net.ListenTCP("tcp", address)
+	if err != nil {
+		return 0, err
+	}
+
+	defer func() {
+		if err := listener.Close(); err != nil {
+			// ignore
+			fmt.Printf("error closing listener: %v", err)
+		}
+	}()
+
+	return listener.Addr().(*net.TCPAddr).Port, nil
+}

--- a/pkg/credentials/types/types.go
+++ b/pkg/credentials/types/types.go
@@ -1,0 +1,9 @@
+package types
+
+type Credentials struct {
+	// APIToken is the API token used to authenticate with the Replicated API
+	APIToken string `json:"token"`
+
+	IsEnv        bool `json:"-"`
+	IsConfigFile bool `json:"-"`
+}


### PR DESCRIPTION
Adds a `replicated login` command to make it easier to authenticate and get started with the replicated CLI. Will not overwrite existing `REPLICATED_API_TOKEN` credentials that are stored.

(internal story: https://app.shortcut.com/replicated/story/74465/add-a-replicated-login-command-to-the-cli)
