### PR TITLE
fix finding previous release sha

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release CLI
 
 on:
-  create:
+  push:
     tags:
       - 'v*'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,11 +69,19 @@ jobs:
             if (!previous) return;
             const {
               data: {
-                object: { sha },
+                object: { sha: tag_sha },
               },
             } = await github.rest.git.getRef({
               ...context.repo,
               ref: `tags/${previous.tag_name}`,
+            });
+            const {
+              data: {
+                object: { sha },
+              },
+            } = await github.rest.git.getTag({
+              ...context.repo,
+              tag_sha,
             });
             core.setOutput("sha", sha);
       - if: steps.previous-release.outputs.sha


### PR DESCRIPTION
One more layer of indirection was required to get back to the actual tag SHA

Also fixed the release event. `create` cannot be filtered; this would have fired any time someone created any tag or branch. `push` is the correct event to use here.