### PR TITLE
Lists customers running a specific version of an application

### DIFF
--- a/cli/cmd/customer_by_app_version.go
+++ b/cli/cmd/customer_by_app_version.go
@@ -1,13 +1,14 @@
 package cmd
 
 import (
+	"sort"
+
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/replicated/cli/print"
 	"github.com/replicatedhq/replicated/pkg/kotsclient"
 	"github.com/spf13/cobra"
 )
 
-// replicated customer search-by-app-version APPID VERSION
 func (r *runners) InitCustomersByAppVersionCommand(parent *cobra.Command) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "search-by-app-version VERSION --app APPID",
@@ -18,7 +19,6 @@ func (r *runners) InitCustomersByAppVersionCommand(parent *cobra.Command) *cobra
 		Args:         cobra.MinimumNArgs(1),
 	}
 	parent.AddCommand(cmd)
-	//cmd.Flags().StringVar(&r.args.appID, "AppId", "", "ID of the application")
 	cmd.Flags().StringVar(&r.args.appVersion, "AppVersion", "", "Version of the application")
 
 	return cmd
@@ -41,6 +41,8 @@ func (r *runners) ListCustomersByAppVersion(_ *cobra.Command, args []string) err
 	if err != nil {
 		return errors.Wrap(err, "search-by-app-version")
 	}
+	// sort by customer name to ensure they are grouped together
+	sort.SliceStable(customers, func(i, j int) bool { return customers[i].Name < customers[j].Name })
 
-	return print.Customers(r.outputFormat, r.w, customers)
+	return print.CustomersWithInstances(r.outputFormat, r.w, customers)
 }

--- a/cli/cmd/customer_by_app_version.go
+++ b/cli/cmd/customer_by_app_version.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/replicated/cli/print"
+	"github.com/replicatedhq/replicated/pkg/kotsclient"
+	"github.com/spf13/cobra"
+)
+
+// replicated customer search-by-app-version APPID VERSION
+func (r *runners) InitCustomersByAppVersionCommand(parent *cobra.Command) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "search-by-app-version VERSION --app APPID",
+		Short:        "search-by-app-version VERSION --app APPID",
+		Long:         `Search for customers by app version`,
+		RunE:         r.ListCustomersByAppVersion,
+		SilenceUsage: true,
+		Args:         cobra.MinimumNArgs(1),
+	}
+	parent.AddCommand(cmd)
+	//cmd.Flags().StringVar(&r.args.appID, "AppId", "", "ID of the application")
+	cmd.Flags().StringVar(&r.args.appVersion, "AppVersion", "", "Version of the application")
+
+	return cmd
+}
+
+func (r *runners) ListCustomersByAppVersion(_ *cobra.Command, args []string) error {
+
+	kotsRestClient := kotsclient.VendorV3Client{HTTPClient: *r.platformAPI}
+
+	if len(args) != 1 {
+		return errors.New("This command requires a VERSION and APPID")
+	}
+	appVersion := args[0]
+
+	customers, err := kotsRestClient.ListCustomersByAppVersion(
+		r.appID,
+		appVersion,
+		r.appType,
+	)
+	if err != nil {
+		return errors.Wrap(err, "search-by-app-version")
+	}
+
+	return print.Customers(r.outputFormat, r.w, customers)
+}

--- a/cli/cmd/customer_by_app_version.go
+++ b/cli/cmd/customer_by_app_version.go
@@ -20,6 +20,7 @@ func (r *runners) InitCustomersByAppVersionCommand(parent *cobra.Command) *cobra
 	}
 	parent.AddCommand(cmd)
 	cmd.Flags().StringVar(&r.args.appVersion, "AppVersion", "", "Version of the application")
+	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
 
 	return cmd
 }

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -165,6 +165,8 @@ func Execute(rootCmd *cobra.Command, stdin io.Reader, stdout io.Writer, stderr i
 	runCmds.InitCustomersDownloadLicenseCommand(customersCmd)
 	runCmds.InitCustomersArchiveCommand(customersCmd)
 
+	runCmds.InitCustomersByAppVersionCommand(customersCmd)
+
 	installerCmd := runCmds.InitInstallerCommand(runCmds.rootCmd)
 	runCmds.InitInstallerCreate(installerCmd)
 	runCmds.InitInstallerList(installerCmd)

--- a/cli/cmd/runner.go
+++ b/cli/cmd/runner.go
@@ -181,5 +181,8 @@ type runnerArgs struct {
 
 	lsClusterHideTerminated bool
 
+	// Application Version String
+	appVersion string
+
 	loginEndpoint string
 }

--- a/cli/print/customers.go
+++ b/cli/print/customers.go
@@ -30,16 +30,13 @@ func Customers(outputFormat string, w *tabwriter.Writer, customers []types.Custo
 }
 
 func CustomersWithInstances(outputFormat string, w *tabwriter.Writer, customers []types.Customer) error {
-	println("--------------DEBUG-------------------------\n")
-	println("DEBUG: print:CustomersWithInstances")
-
-	// Define a new template
-	var customersTmplSrc = `CUSTOMER_NAME	INSTANCES_IDs	CHANNELS	EXPIRES	TYPE
+	// Define a new template for use in this function
+	var customersTmplSrc = `CUSTOMER NAME	INSTANCE ID	LAST ACTIVE	VERSION	
 {{ range . -}}
-{{ .Name }}	{{range .Instances}},{{.InstanceId}}{{end}}	{{range .Channels}} {{.Name}}{{end}}	{{if not .Expires}}Never{{else}}{{.Expires}}{{end}}	{{.Type}}
+{{ .Name }}	{{range .Instances}}{{.InstanceId}}	{{.LastActive}}	{{range .VersionHistory}}{{.VersionLabel}}{{end}}{{end}}
 {{ end }}`
 
-	var customersTmpl = template.Must(template.New("channels").Parse(customersTmplSrc))
+	var customersTmpl = template.Must(template.New("customers").Parse(customersTmplSrc))
 
 	if outputFormat == "table" {
 		if err := customersTmpl.Execute(w, customers); err != nil {

--- a/cli/print/customers.go
+++ b/cli/print/customers.go
@@ -29,6 +29,31 @@ func Customers(outputFormat string, w *tabwriter.Writer, customers []types.Custo
 	return w.Flush()
 }
 
+func CustomersWithInstances(outputFormat string, w *tabwriter.Writer, customers []types.Customer) error {
+	println("--------------DEBUG-------------------------\n")
+	println("DEBUG: print:CustomersWithInstances")
+
+	// Define a new template
+	var customersTmplSrc = `CUSTOMER_NAME	INSTANCES_IDs	CHANNELS	EXPIRES	TYPE
+{{ range . -}}
+{{ .Name }}	{{range .Instances}},{{.InstanceId}}{{end}}	{{range .Channels}} {{.Name}}{{end}}	{{if not .Expires}}Never{{else}}{{.Expires}}{{end}}	{{.Type}}
+{{ end }}`
+
+	var customersTmpl = template.Must(template.New("channels").Parse(customersTmplSrc))
+
+	if outputFormat == "table" {
+		if err := customersTmpl.Execute(w, customers); err != nil {
+			return err
+		}
+	} else if outputFormat == "json" {
+		cAsByte, _ := json.MarshalIndent(customers, "", "  ")
+		if _, err := w.Write(cAsByte); err != nil {
+			return err
+		}
+	}
+	return w.Flush()
+}
+
 func Customer(outputFormat string, w *tabwriter.Writer, customer *types.Customer) error {
 	if outputFormat == "table" {
 		if err := customersTmpl.Execute(w, []types.Customer{*customer}); err != nil {

--- a/client/customer.go
+++ b/client/customer.go
@@ -17,6 +17,17 @@ func (c *Client) ListCustomers(appID string, appType string) ([]types.Customer, 
 	return nil, errors.Errorf("unknown app type %q", appType)
 }
 
+func (c *Client) ListCustomersByAppVersion(appID string, appVersion string, appType string) ([]types.Customer, error) {
+
+	if appType == "platform" {
+		return nil, errors.New("searching customers by appId and vesion is not supported for platform applications")
+	} else if appType == "kots" {
+		return c.KotsClient.ListCustomersByAppVersion(appID, appVersion, appType)
+	}
+
+	return nil, errors.Errorf("unknown app type %q", appType)
+}
+
 func (c *Client) CreateCustomer(appType string, opts kotsclient.CreateCustomerOpts) (*types.Customer, error) {
 	if appType == "platform" {
 		return nil, errors.New("creating customers is not supported for platform applications")

--- a/pkg/kotsclient/customer_by_app_version.go
+++ b/pkg/kotsclient/customer_by_app_version.go
@@ -8,20 +8,10 @@ import (
 	"github.com/replicatedhq/replicated/pkg/types"
 )
 
-// var _ error = ErrAppVersionNotFound{}
-//
-// type ErrAppVersionNotFound struct {
-//Name string
-//}
-
-// func (e ErrAppVersionNotFound) Error() string {
-//return fmt.Sprintf("version %q not found", e.Name)
-//}
-
-//type CustomerListResponse struct {
-//Customers      []types.Customer `json:"customers"`
-//TotalCustomers int              `json:"totalCustomers"`
-//}
+type CustomerListWithInstancesResponse struct {
+	Customers      []types.Customer `json:"customers"`
+	TotalCustomers int              `json:"totalCustomers"`
+}
 
 func (c *VendorV3Client) ListCustomersByAppVersion(appID string, appVersion string, appType string) ([]types.Customer, error) {
 	println("--------------DEBUG-------------------------")
@@ -34,38 +24,53 @@ func (c *VendorV3Client) ListCustomersByAppVersion(appID string, appVersion stri
 	matchingCustomers := []types.Customer{}
 	page := 0
 	for {
-		resp := CustomerListResponse{}
+		resp := CustomerListWithInstancesResponse{}
 		path := fmt.Sprintf("/v3/app/%s/customers?currentPage=%d", appID, page)
 		err := c.DoJSON("GET", path, http.StatusOK, nil, &resp)
 		if err != nil {
-			return nil, errors.Wrapf(err, "list customers page %d", page)
+			return nil, errors.Wrapf(err, "List Customers By App Version page %d", page)
 		}
 
-		for index, customer := range resp.Customers {
-			fmt.Printf("DEBUG: customer.Name: %v\n", customer.Name)
-			// for each customer, print the instances
+		for customersIndex, customer := range resp.Customers {
+			fmt.Println("-----------------------------")
+			fmt.Printf("DEBUG: customer.Name:    %v\n", customer.Name)
+			fmt.Printf("DEBUG: customer.ID:      %v\n", customer.ID)
+			fmt.Printf("DEBUG: customersIndex:   %v\n", customersIndex)
 			for _, instance := range customer.Instances {
-				fmt.Printf("         instance.InstanceId: %v\n", instance.InstanceId)
-				// for each instance print the VersionHistory VersionLabel
-				for _, versionHistory := range instance.VersionHistory {
-					if versionHistory.VersionLabel == appVersion {
-						fmt.Printf("           versionHistory.VersionLabel: %v MATCH\n", versionHistory.VersionLabel)
-						matchingCustomers = append(matchingCustomers, resp.Customers[index])
+				fmt.Printf("      DEBUG: instance.InstanceId: %v\n", instance.InstanceId)
+				for versionIndex, versionHistory := range instance.VersionHistory {
+					fmt.Println("      DEBUG: versionHistory: ", versionHistory)
+					if versionHistory.VersionLabel == appVersion && versionIndex == 0 {
+						fmt.Printf("      DEBUG: versionHistory.VersionLabel: %v MATCH\n", versionHistory.VersionLabel)
+						// Append the customer to the matchingCustomers slice
+						// matchingCustomers = append(matchingCustomers, customer)
+						// Apppend the customer and
+						// the instance to the matchingCustomers slice
+						// matchingCustomers = append(matchingCustomers, customer, instance)
+						// Append the customer and
+						// the instance and
+						// the versionHistory to the matchingCustomers slice
+						tempCustomer := customer
+						tempCustomer.Instances = []types.Instance{instance}
+						tempCustomer.Instances[0].VersionHistory = []types.VersionHistory{versionHistory}
+						matchingCustomers = append(matchingCustomers, tempCustomer)
+						//matchingCustomers = append(matchingCustomers, customer, instance, versionHistory)
+
 					} else {
-						fmt.Printf("           versionHistory.VersionLabel: %v\n", versionHistory.VersionLabel)
+						fmt.Printf("      DEBUG: versionHistory.VersionLabel: %v\n", versionHistory.VersionLabel)
 					}
 				}
 			}
-
 		}
-
 		if len(matchingCustomers) == resp.TotalCustomers || len(resp.Customers) == 0 {
 			break
 		}
-
 		page = page + 1
 	}
 
 	println("--------------DEBUG-------------------------\n")
+	if len(matchingCustomers) == 0 {
+		return matchingCustomers, fmt.Errorf("no matching customers found for app %q and version %q ", appID, appVersion)
+	}
 	return matchingCustomers, nil
 }

--- a/pkg/kotsclient/customer_by_app_version.go
+++ b/pkg/kotsclient/customer_by_app_version.go
@@ -1,0 +1,71 @@
+package kotsclient
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/replicated/pkg/types"
+)
+
+// var _ error = ErrAppVersionNotFound{}
+//
+// type ErrAppVersionNotFound struct {
+//Name string
+//}
+
+// func (e ErrAppVersionNotFound) Error() string {
+//return fmt.Sprintf("version %q not found", e.Name)
+//}
+
+//type CustomerListResponse struct {
+//Customers      []types.Customer `json:"customers"`
+//TotalCustomers int              `json:"totalCustomers"`
+//}
+
+func (c *VendorV3Client) ListCustomersByAppVersion(appID string, appVersion string, appType string) ([]types.Customer, error) {
+	println("--------------DEBUG-------------------------")
+	println("DEBUG: kotsclient:ListCustomersByAppVersion")
+	println("DEBUG: appID:      " + appID)
+	println("DEBUG: appVersion: " + appVersion)
+	println("DEBUG: appType:    " + appType)
+	println("\n")
+
+	matchingCustomers := []types.Customer{}
+	page := 0
+	for {
+		resp := CustomerListResponse{}
+		path := fmt.Sprintf("/v3/app/%s/customers?currentPage=%d", appID, page)
+		err := c.DoJSON("GET", path, http.StatusOK, nil, &resp)
+		if err != nil {
+			return nil, errors.Wrapf(err, "list customers page %d", page)
+		}
+
+		for index, customer := range resp.Customers {
+			fmt.Printf("DEBUG: customer.Name: %v\n", customer.Name)
+			// for each customer, print the instances
+			for _, instance := range customer.Instances {
+				fmt.Printf("         instance.InstanceId: %v\n", instance.InstanceId)
+				// for each instance print the VersionHistory VersionLabel
+				for _, versionHistory := range instance.VersionHistory {
+					if versionHistory.VersionLabel == appVersion {
+						fmt.Printf("           versionHistory.VersionLabel: %v MATCH\n", versionHistory.VersionLabel)
+						matchingCustomers = append(matchingCustomers, resp.Customers[index])
+					} else {
+						fmt.Printf("           versionHistory.VersionLabel: %v\n", versionHistory.VersionLabel)
+					}
+				}
+			}
+
+		}
+
+		if len(matchingCustomers) == resp.TotalCustomers || len(resp.Customers) == 0 {
+			break
+		}
+
+		page = page + 1
+	}
+
+	println("--------------DEBUG-------------------------\n")
+	return matchingCustomers, nil
+}

--- a/pkg/types/customer.go
+++ b/pkg/types/customer.go
@@ -6,11 +6,12 @@ import (
 )
 
 type Customer struct {
-	ID       string     `json:"id"`
-	Name     string     `json:"name"`
-	Channels []Channel  `json:"channels"`
-	Type     string     `json:"type"`
-	Expires  *util.Time `json:"expiresAt"`
+	ID        string     `json:"id"`
+	Name      string     `json:"name"`
+	Channels  []Channel  `json:"channels"`
+	Type      string     `json:"type"`
+	Expires   *util.Time `json:"expiresAt"`
+	Instances []Instance `json:"instances"`
 }
 
 func (c Customer) WithExpiryTime(expiryTime string) (Customer, error) {

--- a/pkg/types/instance.go
+++ b/pkg/types/instance.go
@@ -1,0 +1,26 @@
+package types
+
+import "time"
+
+type Instance struct {
+	LicenseId      string           `json:"licenseId,omitempty"`
+	InstanceId     string           `json:"instanceId,omitempty"`
+	ClusterId      string           `json:"clusterId,omitempty"`
+	CreatedAt      time.Time        `json:"createdAt,omitempty"`
+	LastActive     time.Time        `json:"lastActive,omitempty"`
+	AppStatus      string           `json:"appStatus,omitempty"`
+	Active         bool             `json:"active,omitempty"`
+	VersionHistory []VersionHistory `json:"versionHistory,omitempty"`
+}
+
+type VersionHistory struct {
+	InstanceId                string    `json:"instanceId,omitempty"`
+	ClusterId                 string    `json:"clusterId,omitempty"`
+	VersionLabel              string    `json:"versionLabel,omitempty"`
+	DownStreamChannelId       string    `json:"downstreamChannelId,omitempty"`
+	DownStreamReleaseSequence int32     `json:"downstreamReleaseSequence,omitempty"`
+	IntervalStart             time.Time `json:"intervalStart,omitempty"`
+	IntervalLast              time.Time `json:"intervallast,omitempty"`
+	RepHelmCount              int32     `json:"repHelmCount,omitempty"`
+	NativeHelmCount           int32     `json:"nativeHelmCount,omitempty"`
+}


### PR DESCRIPTION
The already API provides instance data including the application version. However, its cumbersome to find which instances or customers that are running a specific software release. This subcommand allows you to use the CLI to report on customers (and their instances), which are running a specific version.

**Use Case**
A vendor wants to know which of their customers and instances are running a specific version of their software.

**Implementation**
- Use the existing Vendor API /v3/app/%s/customers? route to retrieve all customers
- Iterate the response json, looking at which customers are running the appID specified in the 
- Search the Instance versionHistory.VersionLabel for matching instances of the specified version
- Print the results to screen either table or json format (depending on if --output was provided. defaults to table if not provided)
- Utilizes all the existing Cobra, Runner, kotsclient, etc

**Usage**
Added a new sub command under customer called `search-by-app-version`. For example, the command can be called like:
`replicated customer search-by-app-version <VERSION> --app <APPID> --output json`

**Summary of Changes**
- New CLI command customer_by_app_version
- Extended the current `Customer` type to now include `Instances` and `VersionHistory`
- Added `appVersion` string to runner
- New print function `CustomersWithInstances` which shows customer, instance ID, Last Active, Version 

