### PR TITLE
Update for credits system design

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ test:
 	docker build -t replicated-cli-test -f hack/Dockerfile.testing .
 	docker run --rm --name replicated-cli-tests \
 		-v `pwd`:/go/src/github.com/replicatedhq/replicated \
-		replicated-cli-test \
+		replicated-cli-test
 
 .PHONY: publish-pact
 publish-pact:
@@ -128,7 +128,7 @@ gen-models:
 		-Dmodels -DmodelsDocs=false \
 		-i /local/gen/spec/v3.json \
 		-l go \
-		-o /local/gen/go/v3; \
+		-o /local/gen/go/v3;
 
 .PHONY: build
 build:
@@ -136,6 +136,10 @@ build:
     		${LDFLAGS} \
     		-o bin/replicated \
     		cli/main.go
+
+.PHONY: vet
+vet:
+	go vet ${LDFLAGS} ./pkg/... ./cli/... ./client/...
 
 .PHONY: docs
 docs:

--- a/cli/cmd/cluster_create.go
+++ b/cli/cmd/cluster_create.go
@@ -31,6 +31,7 @@ func (r *runners) InitClusterCreate(parent *cobra.Command) *cobra.Command {
 	cmd.Flags().StringVar(&r.args.createClusterDiskType, "disk-class", "nvme", "Disk performance type to request (not used on all distributions)")
 	cmd.Flags().StringVar(&r.args.createClusterTTL, "ttl", "1h", "Cluster TTL (duration)")
 	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
+	cmd.Flags().BoolVar(&r.args.createClusterDryRun, "dry-run", false, "Clusters will not be created")
 
 	return cmd
 }
@@ -48,6 +49,7 @@ func (r *runners) createCluster(_ *cobra.Command, args []string) error {
 		MemoryMiB:              r.args.createClusterMemoryMiB,
 		DiskMiB:                r.args.createClusterDiskMiB,
 		DiskType:               r.args.createClusterDiskType,
+		DryRun:                 r.args.createClusterDryRun,
 		TTL:                    r.args.createClusterTTL,
 	}
 	cl, err := kotsRestClient.CreateCluster(opts)

--- a/cli/cmd/cluster_create.go
+++ b/cli/cmd/cluster_create.go
@@ -25,7 +25,10 @@ func (r *runners) InitClusterCreate(parent *cobra.Command) *cobra.Command {
 	cmd.Flags().StringVar(&r.args.createClusterKubernetesVersion, "kubernetes-version", "v1.25.3", "Kubernetes version to provision (format is distribution dependent)")
 	cmd.Flags().IntVar(&r.args.createClusterNodeCount, "node-count", int(1), "Node count")
 	cmd.Flags().Int64Var(&r.args.createClusterVCpus, "vcpus", int64(4), "vCPUs to request per node")
+	cmd.Flags().StringVar(&r.args.createClusterVCpuType, "vcpus-class", "latest", "vCPUs performance type to request (not used on all distributions)")
 	cmd.Flags().Int64Var(&r.args.createClusterMemoryMiB, "memory-mib", int64(4096), "Memory (MiB) to request per node")
+	cmd.Flags().Int64Var(&r.args.createClusterDiskMiB, "disk-mib", int64(4096), "Disk space (MiB) to request per node")
+	cmd.Flags().StringVar(&r.args.createClusterDiskType, "disk-class", "nvme", "Disk performance type to request (not used on all distributions)")
 	cmd.Flags().StringVar(&r.args.createClusterTTL, "ttl", "1h", "Cluster TTL (duration)")
 	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
 
@@ -41,7 +44,10 @@ func (r *runners) createCluster(_ *cobra.Command, args []string) error {
 		KubernetesVersion:      r.args.createClusterKubernetesVersion,
 		NodeCount:              r.args.createClusterNodeCount,
 		VCpus:                  r.args.createClusterVCpus,
+		VCpuType:               r.args.createClusterVCpuType,
 		MemoryMiB:              r.args.createClusterMemoryMiB,
+		DiskMiB:                r.args.createClusterDiskMiB,
+		DiskType:               r.args.createClusterDiskType,
 		TTL:                    r.args.createClusterTTL,
 	}
 	cl, err := kotsRestClient.CreateCluster(opts)

--- a/cli/cmd/cluster_ls.go
+++ b/cli/cmd/cluster_ls.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"time"
+
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/replicated/cli/print"
 	"github.com/replicatedhq/replicated/pkg/kotsclient"
@@ -19,6 +21,9 @@ func (r *runners) InitClusterList(parent *cobra.Command) *cobra.Command {
 	parent.AddCommand(cmd)
 
 	cmd.Flags().BoolVar(&r.args.lsClusterHideTerminated, "hide-terminated", false, "when set, do not show terminated clusters")
+	cmd.Flags().StringVar(&r.args.lsClusterStartTime, "start-time", "", "limit output to clusters that exist during or after this date time (optional)")
+	cmd.Flags().StringVar(&r.args.lsClusterEndTime, "end-time", "", "limit output to clusters that exist during or before this date time (optional)")
+	cmd.Flags().StringSliceVar(&r.args.lsClusterIDs, "cluster-ids", nil, "cluster ids to request data for (optional, overrides start-time and end-time)")
 	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
 
 	return cmd
@@ -27,7 +32,31 @@ func (r *runners) InitClusterList(parent *cobra.Command) *cobra.Command {
 func (r *runners) listClusters(_ *cobra.Command, args []string) error {
 	kotsRestClient := kotsclient.VendorV3Client{HTTPClient: *r.platformAPI}
 
-	clusters, err := kotsRestClient.ListClusters(!r.args.lsClusterHideTerminated)
+	opts := kotsclient.ListClustersOpts{
+		IncludeTerminated: !r.args.lsClusterHideTerminated,
+	}
+
+	if len(r.args.lsClusterIDs) > 0 {
+		opts.ClusterIDs = r.args.lsClusterIDs
+	} else {
+		if r.args.lsClusterStartTime != "" {
+			startTime, err := time.Parse(time.RFC3339, r.args.lsClusterStartTime)
+			if err != nil {
+				return errors.Wrap(err, "invalid startTime")
+			}
+			opts.StartTime = startTime
+		}
+
+		if r.args.lsClusterEndTime != "" {
+			endTime, err := time.Parse(time.RFC3339, r.args.lsClusterEndTime)
+			if err != nil {
+				return errors.Wrap(err, "invalid endTime format")
+			}
+			opts.EndTime = endTime
+		}
+	}
+
+	clusters, err := kotsRestClient.ListClusters(opts)
 	if err == platformclient.ErrForbidden {
 		return errors.New("This command is not available for your account or team. Please contact your customer success representative for more information.")
 	}

--- a/cli/cmd/cluster_ls.go
+++ b/cli/cmd/cluster_ls.go
@@ -23,7 +23,6 @@ func (r *runners) InitClusterList(parent *cobra.Command) *cobra.Command {
 	cmd.Flags().BoolVar(&r.args.lsClusterHideTerminated, "hide-terminated", false, "when set, do not show terminated clusters")
 	cmd.Flags().StringVar(&r.args.lsClusterStartTime, "start-time", "", "limit output to clusters that exist during or after this date time (optional)")
 	cmd.Flags().StringVar(&r.args.lsClusterEndTime, "end-time", "", "limit output to clusters that exist during or before this date time (optional)")
-	cmd.Flags().StringSliceVar(&r.args.lsClusterIDs, "cluster-ids", nil, "cluster ids to request data for (optional, overrides start-time and end-time)")
 	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
 
 	return cmd
@@ -36,24 +35,20 @@ func (r *runners) listClusters(_ *cobra.Command, args []string) error {
 		IncludeTerminated: !r.args.lsClusterHideTerminated,
 	}
 
-	if len(r.args.lsClusterIDs) > 0 {
-		opts.ClusterIDs = r.args.lsClusterIDs
-	} else {
-		if r.args.lsClusterStartTime != "" {
-			startTime, err := time.Parse(time.RFC3339, r.args.lsClusterStartTime)
-			if err != nil {
-				return errors.Wrap(err, "invalid startTime")
-			}
-			opts.StartTime = startTime
+	if r.args.lsClusterStartTime != "" {
+		startTime, err := time.Parse(time.RFC3339, r.args.lsClusterStartTime)
+		if err != nil {
+			return errors.Wrap(err, "invalid startTime")
 		}
+		opts.StartTime = startTime
+	}
 
-		if r.args.lsClusterEndTime != "" {
-			endTime, err := time.Parse(time.RFC3339, r.args.lsClusterEndTime)
-			if err != nil {
-				return errors.Wrap(err, "invalid endTime format")
-			}
-			opts.EndTime = endTime
+	if r.args.lsClusterEndTime != "" {
+		endTime, err := time.Parse(time.RFC3339, r.args.lsClusterEndTime)
+		if err != nil {
+			return errors.Wrap(err, "invalid endTime format")
 		}
+		opts.EndTime = endTime
 	}
 
 	clusters, err := kotsRestClient.ListClusters(opts)

--- a/cli/cmd/cluster_ls.go
+++ b/cli/cmd/cluster_ls.go
@@ -21,8 +21,8 @@ func (r *runners) InitClusterList(parent *cobra.Command) *cobra.Command {
 	parent.AddCommand(cmd)
 
 	cmd.Flags().BoolVar(&r.args.lsClusterHideTerminated, "hide-terminated", false, "when set, do not show terminated clusters")
-	cmd.Flags().StringVar(&r.args.lsClusterStartTime, "start-time", "", "limit output to clusters that exist during or after this date time (optional)")
-	cmd.Flags().StringVar(&r.args.lsClusterEndTime, "end-time", "", "limit output to clusters that exist during or before this date time (optional)")
+	cmd.Flags().StringVar(&r.args.lsClusterStartTime, "start-time", "", "limit output to clusters that exist during or after this date time format: 2022-02-02T20:22:02Z RFC3339 (optional)")
+	cmd.Flags().StringVar(&r.args.lsClusterEndTime, "end-time", "", "limit output to clusters that exist during or before this date time format: 2022-02-02T20:22:02Z RFC3339 (optional)")
 	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
 
 	return cmd

--- a/cli/cmd/runner.go
+++ b/cli/cmd/runner.go
@@ -186,7 +186,6 @@ type runnerArgs struct {
 	lsClusterHideTerminated bool
 	lsClusterStartTime      string
 	lsClusterEndTime        string
-	lsClusterIDs            []string
 
 	loginEndpoint string
 }

--- a/cli/cmd/runner.go
+++ b/cli/cmd/runner.go
@@ -172,14 +172,21 @@ type runnerArgs struct {
 	createClusterKubernetesVersion      string
 	createClusterNodeCount              int
 	createClusterVCpus                  int64
+	createClusterVCpuType               string
 	createClusterMemoryMiB              int64
+	createClusterDiskMiB                int64
+	createClusterDiskType               string
 	createClusterTTL                    string
+	createClusterDryRun                 bool
 
 	kubeconfigClusterID string
 
 	removeClusterForce bool
 
 	lsClusterHideTerminated bool
+	lsClusterStartTime      string
+	lsClusterEndTime        string
+	lsClusterIDs            []string
 
 	loginEndpoint string
 }

--- a/cli/print/clusters.go
+++ b/cli/print/clusters.go
@@ -9,9 +9,9 @@ import (
 )
 
 // TODO: implement a -o wide, and expose nodecount, vcpus and memory also?
-var clustersTmplSrc = `ID	NAME	K8S DISTRO	K8S VERSION	STATUS	CREATED	EXPIRES
+var clustersTmplSrc = `ID	NAME	K8S DISTRO	K8S VERSION	STATUS	CREATED	EXPIRES	CREDITS
 {{ range . -}}
-{{ .ID }}	{{ .Name }}	{{ .KubernetesDistribution}}	{{ .KubernetesVersion	}}	{{ .Status }}	{{ .CreatedAt}}	{{ .ExpiresAt }}
+{{ .ID }}	{{ .Name }}	{{ .KubernetesDistribution}}	{{ .KubernetesVersion	}}	{{ .Status }}	{{ .CreatedAt}}	{{ .ExpiresAt }}	{{ .CreditRate }}
 {{ end }}`
 
 var clustersTmpl = template.Must(template.New("clusters").Funcs(funcs).Parse(clustersTmplSrc))

--- a/pkg/kotsclient/cluster_create.go
+++ b/pkg/kotsclient/cluster_create.go
@@ -12,8 +12,12 @@ type CreateClusterRequest struct {
 	KubernetesVersion      string `json:"kubernetes_version"`
 	NodeCount              int    `json:"node_count"`
 	VCpus                  int64  `json:"vcpus"`
+	VCpuType               string `json:"vcpu_type"`
 	MemoryMiB              int64  `json:"memory_mib"`
+	DiskMiB                int64  `json:"disk_mib"`
+	DiskType               string `json:"disk_type"`
 	TTL                    string `json:"ttl"`
+	DryRun                 bool   `json:"dry_run"`
 }
 
 type CreateClusterResponse struct {
@@ -26,8 +30,12 @@ type CreateClusterOpts struct {
 	KubernetesVersion      string
 	NodeCount              int
 	VCpus                  int64
+	VCpuType               string
 	MemoryMiB              int64
+	DiskMiB                int64
+	DiskType               string
 	TTL                    string
+	DryRun                 bool
 }
 
 var defaultCreateClusterOpts = CreateClusterOpts{
@@ -36,7 +44,10 @@ var defaultCreateClusterOpts = CreateClusterOpts{
 	KubernetesVersion:      "v1.25.3",
 	NodeCount:              int(1),
 	VCpus:                  int64(4),
+	VCpuType:               "latest",
 	MemoryMiB:              int64(4096),
+	DiskMiB:                int64(65536),
+	DiskType:               "nvme",
 	TTL:                    "2h",
 }
 
@@ -54,9 +65,18 @@ func (c *VendorV3Client) CreateCluster(opts CreateClusterOpts) (*types.Cluster, 
 	if opts.VCpus == int64(0) {
 		opts.VCpus = defaultCreateClusterOpts.VCpus
 	}
+	if opts.VCpuType == "" {
+		opts.VCpuType = defaultCreateClusterOpts.VCpuType
+	}
 	if opts.MemoryMiB == int64(0) {
 		opts.MemoryMiB = defaultCreateClusterOpts.MemoryMiB
 	}
+	if opts.DiskMiB == int64(0) {
+		opts.DiskMiB = defaultCreateClusterOpts.DiskMiB
+	}
+	if opts.DiskType == "" {
+		opts.DiskType = defaultCreateClusterOpts.DiskType
+		}
 	if opts.TTL == "" {
 		opts.TTL = defaultCreateClusterOpts.TTL
 	}
@@ -67,8 +87,12 @@ func (c *VendorV3Client) CreateCluster(opts CreateClusterOpts) (*types.Cluster, 
 		KubernetesVersion:      opts.KubernetesVersion,
 		NodeCount:              opts.NodeCount,
 		VCpus:                  opts.VCpus,
+		VCpuType:               opts.VCpuType,
 		MemoryMiB:              opts.MemoryMiB,
+		DiskMiB:                opts.DiskMiB,
+		DiskType:               opts.DiskType,
 		TTL:                    opts.TTL,
+		DryRun:                 opts.DryRun,
 	}
 	cluster := CreateClusterResponse{}
 	err := c.DoJSON("POST", "/v3/cluster", http.StatusCreated, reqBody, &cluster)

--- a/pkg/kotsclient/cluster_list.go
+++ b/pkg/kotsclient/cluster_list.go
@@ -1,40 +1,30 @@
 package kotsclient
 
 import (
+	"fmt"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/replicatedhq/replicated/pkg/types"
 )
 
-type ListClustersRequest struct {
-	IncludeTerminated bool     `json:"include_terminated"`
-	ClusterIDs        []string `json:"cluster_ids"`
-	StartTime         int64    `json:"start_time"`
-	EndTime           int64    `json:"end_time"`
-}
+type ListClusterRequest struct{}
 
 type ListClustersResponse struct {
-	Continue bool             `json:"continue"`
 	Clusters []*types.Cluster `json:"clusters"`
 }
 
 type ListClustersOpts struct {
 	IncludeTerminated bool
-	ClusterIDs        []string
 	StartTime         time.Time
 	EndTime           time.Time
 }
 
 func (c *VendorV3Client) ListClusters(opts ListClustersOpts) ([]*types.Cluster, error) {
-	reqBody := &ListClustersRequest{
-		IncludeTerminated: opts.IncludeTerminated,
-		ClusterIDs:        opts.ClusterIDs,
-		StartTime:         opts.StartTime.Unix(),
-		EndTime:           opts.EndTime.Unix(),
-	}
+	reqBody := ListClusterRequest{}
 	clusters := ListClustersResponse{}
-	err := c.DoJSON("GET", "/v3/clusters", http.StatusOK, reqBody, &clusters)
+	err := c.DoJSON("GET", fmt.Sprintf("/v3/clusters?include-terminated=%s&start-time=%s&end-time=%s", strconv.FormatBool(opts.IncludeTerminated), strconv.FormatInt(opts.StartTime.Unix(), 10), strconv.FormatInt(opts.EndTime.Unix(), 10)), http.StatusOK, reqBody, &clusters)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kotsclient/cluster_list.go
+++ b/pkg/kotsclient/cluster_list.go
@@ -1,24 +1,40 @@
 package kotsclient
 
 import (
-	"fmt"
 	"net/http"
-	"strconv"
+	"time"
 
 	"github.com/replicatedhq/replicated/pkg/types"
 )
 
 type ListClustersRequest struct {
+	IncludeTerminated bool     `json:"include_terminated"`
+	ClusterIDs        []string `json:"cluster_ids"`
+	StartTime         int64    `json:"start_time"`
+	EndTime           int64    `json:"end_time"`
 }
 
 type ListClustersResponse struct {
+	Continue bool             `json:"continue"`
 	Clusters []*types.Cluster `json:"clusters"`
 }
 
-func (c *VendorV3Client) ListClusters(includeTerminated bool) ([]*types.Cluster, error) {
-	reqBody := &ListClustersRequest{}
+type ListClustersOpts struct {
+	IncludeTerminated bool
+	ClusterIDs        []string
+	StartTime         time.Time
+	EndTime           time.Time
+}
+
+func (c *VendorV3Client) ListClusters(opts ListClustersOpts) ([]*types.Cluster, error) {
+	reqBody := &ListClustersRequest{
+		IncludeTerminated: opts.IncludeTerminated,
+		ClusterIDs:        opts.ClusterIDs,
+		StartTime:         opts.StartTime.Unix(),
+		EndTime:           opts.EndTime.Unix(),
+	}
 	clusters := ListClustersResponse{}
-	err := c.DoJSON("GET", fmt.Sprintf("/v3/clusters?include-terminated=%s", strconv.FormatBool(includeTerminated)), http.StatusOK, reqBody, &clusters)
+	err := c.DoJSON("GET", "/v3/clusters", http.StatusOK, reqBody, &clusters)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kotsclient/installer.go
+++ b/pkg/kotsclient/installer.go
@@ -23,7 +23,7 @@ func (c *VendorV3Client) ListInstallers(appID string) ([]types.InstallerSpec, er
 		if err != nil {
 			return nil, errors.Wrap(err, "parsing time string to CreatedAt time")
 		}
-		response.Body[i].CreatedAt = util.Time{createdAtTime}
+		response.Body[i].CreatedAt = util.Time{Time: createdAtTime}
 	}
 
 	return response.Body, nil

--- a/pkg/types/cluster.go
+++ b/pkg/types/cluster.go
@@ -9,8 +9,12 @@ type Cluster struct {
 	KubernetesVersion      string    `json:"kubernetes_version"`
 	NodeCount              int       `json:"node_count"`
 	VCpus                  int64     `json:"vcpus"`
+	VCpuType               string    `json:"vcpu_type"`
 	MemoryMiB              int64     `json:"memory_mib"`
+	DiskMiB                int64     `json:"disk_mib"`
+	DiskType               string    `json:"disk_type"`
 	Status                 string    `json:"status"`
+	CreditRate             float64   `json:"credit_rate"`
 	CreatedAt              time.Time `json:"created_at"`
 	ExpiresAt              time.Time `json:"expires_at"`
 }


### PR DESCRIPTION
Update the replicated cli commands `cluster create` and `cluster ls` for the credit system changes to the vendor-api.

`cluster create` has added parameters for resources needed for credit calculations and also outputs the credit cost

`cluster ls` has added optional parameters for limiting the query