### PR TITLE
cleanup for cluster command

### DIFF
--- a/cli/cmd/cluster_create.go
+++ b/cli/cmd/cluster_create.go
@@ -21,11 +21,11 @@ func (r *runners) InitClusterCreate(parent *cobra.Command) *cobra.Command {
 	cmd.Flags().StringVar(&r.args.createClusterName, "name", "", "cluster name")
 	cmd.MarkFlagRequired("name")
 
-	cmd.Flags().StringVar(&r.args.createClusterKubernetesDistribution, "kubernetes-distribution", "kind", "Kubernetes distribution of the cluster to provision")
-	cmd.Flags().StringVar(&r.args.createClusterKubernetesVersion, "kubernetes-version", "v1.25.3", "Kubernetes version to provision (format is distribution dependent)")
-	cmd.Flags().IntVar(&r.args.createClusterNodeCount, "node-count", int(1), "Node count")
+	cmd.Flags().StringVar(&r.args.createClusterKubernetesDistribution, "distribution", "kind", "Kubernetes distribution of the cluster to provision")
+	cmd.Flags().StringVar(&r.args.createClusterKubernetesVersion, "version", "v1.25.3", "Kubernetes version to provision (format is distribution dependent)")
+	cmd.Flags().IntVar(&r.args.createClusterNodeCount, "node", int(1), "Node count")
 	cmd.Flags().Int64Var(&r.args.createClusterVCpus, "vcpus", int64(4), "vCPUs to request per node")
-	cmd.Flags().Int64Var(&r.args.createClusterMemoryMiB, "memory-mib", int64(4096), "Memory (MiB) to request per node")
+	cmd.Flags().Int64Var(&r.args.createClusterMemoryMiB, "memory", int64(4096), "Memory (MiB) to request per node")
 	cmd.Flags().StringVar(&r.args.createClusterTTL, "ttl", "1h", "Cluster TTL (duration)")
 	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
 

--- a/cli/cmd/cluster_kubeconfig.go
+++ b/cli/cmd/cluster_kubeconfig.go
@@ -27,11 +27,9 @@ func (r *runners) InitClusterKubeconfig(parent *cobra.Command) *cobra.Command {
 		Long:         `Download credentials for a test cluster`,
 		RunE:         r.kubeconfigCluster,
 		SilenceUsage: true,
+		Args:         cobra.MinimumNArgs(1),
 	}
 	parent.AddCommand(cmd)
-
-	cmd.Flags().StringVar(&r.args.kubeconfigClusterID, "id", "", "cluster id")
-	cmd.MarkFlagRequired("id")
 
 	return cmd
 }
@@ -39,7 +37,7 @@ func (r *runners) InitClusterKubeconfig(parent *cobra.Command) *cobra.Command {
 func (r *runners) kubeconfigCluster(_ *cobra.Command, args []string) error {
 	kotsRestClient := kotsclient.VendorV3Client{HTTPClient: *r.platformAPI}
 
-	kubeconfig, err := kotsRestClient.GetClusterKubeconfig(r.args.kubeconfigClusterID)
+	kubeconfig, err := kotsRestClient.GetClusterKubeconfig(args[0])
 	if err != nil {
 		return errors.Wrap(err, "get cluster kubeconfig")
 	}

--- a/cli/cmd/login.go
+++ b/cli/cmd/login.go
@@ -17,7 +17,9 @@ func (r *runners) InitLoginCommand(parent *cobra.Command) *cobra.Command {
 		RunE:         r.login,
 	}
 	parent.AddCommand(cmd)
+
 	cmd.Flags().StringVar(&r.args.loginEndpoint, "endpoint", "https://vendor.replicated.com", "The endpoint to use for the login process. Defaults to https://vendor.replicated.com")
+	cmd.Flags().MarkHidden("endpoint")
 
 	return cmd
 }

--- a/cli/cmd/runner.go
+++ b/cli/cmd/runner.go
@@ -175,8 +175,6 @@ type runnerArgs struct {
 	createClusterMemoryMiB              int64
 	createClusterTTL                    string
 
-	kubeconfigClusterID string
-
 	removeClusterForce bool
 
 	lsClusterHideTerminated bool


### PR DESCRIPTION
Changes a couple flags (--kubernetes-version and --kubernetes-distribution to remove the "kubernetes")
Changes kubeconfig command to just take the id as an arg, not a flag
Hides the endpoint command for login