### PR TITLE
Add an 'api get' command

### DIFF
--- a/cli/cmd/api.go
+++ b/cli/cmd/api.go
@@ -1,0 +1,17 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func (r *runners) InitAPICommand(parent *cobra.Command) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "api",
+		Short:  "Make ad-hoc API calls to the Replicated API",
+		Long:   ``,
+		Hidden: false,
+	}
+	parent.AddCommand(cmd)
+
+	return cmd
+}

--- a/cli/cmd/api_get.go
+++ b/cli/cmd/api_get.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/replicatedhq/replicated/pkg/kotsclient"
+	"github.com/spf13/cobra"
+)
+
+func (r *runners) InitAPIGet(parent *cobra.Command) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get",
+		Short: "Make ad-hoc GET API calls to the Replicated API",
+		Long: `This is essentially like curl for the Replicated API, but
+uses your local credentials and prints the response unmodified.
+
+We recommend piping the output to jq for easier reading.
+
+Pass the PATH of the request as the final argument. Do not include the host or version.
+
+Example:
+  replicated api get /v3/apps
+  
+`,
+		RunE:         r.apiGet,
+		SilenceUsage: true,
+		Args:         cobra.ExactArgs(1),
+	}
+	parent.AddCommand(cmd)
+
+	return cmd
+}
+
+func (r *runners) apiGet(cmd *cobra.Command, args []string) error {
+	path := args[0]
+
+	if !strings.HasPrefix(args[0], "/") {
+		path = fmt.Sprintf("/%s", args[0])
+	}
+	pathParts := strings.Split(path, "/")
+	// remove any empty parts
+	for i := len(pathParts) - 1; i >= 0; i-- {
+		if pathParts[i] == "" {
+			pathParts = append(pathParts[:i], pathParts[i+1:]...)
+		}
+	}
+
+	// v1 and v2 paths use platform client, v3 uses kots client
+	// split the path on the first slash to determine which client to use
+	if pathParts[0] == "v1" {
+
+	} else if pathParts[0] == "v3" {
+		kotsRestClient := kotsclient.VendorV3Client{HTTPClient: *r.platformAPI}
+		response, err := kotsRestClient.Get(path)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("%s", response)
+	}
+
+	return nil
+}

--- a/cli/cmd/api_post.go
+++ b/cli/cmd/api_post.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/replicatedhq/replicated/pkg/kotsclient"
+	"github.com/spf13/cobra"
+)
+
+func (r *runners) InitAPIPost(parent *cobra.Command) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "post",
+		Short: "Make ad-hoc POST API calls to the Replicated API",
+		Long: `This is essentially like curl for the Replicated API, but
+uses your local credentials and prints the response unmodified.
+
+We recommend piping the output to jq for easier reading.
+
+Pass the PATH of the request as the final argument. Do not include the host or version.
+
+Example:
+  replicated api post /v3/app/2EuFxKLDxKjPNk2jxMTmF6Vxvxu/channel -b '{"name":"marc-waz-here"}'
+  
+`,
+		RunE:         r.apiPost,
+		SilenceUsage: true,
+		Args:         cobra.ExactArgs(1),
+	}
+	parent.AddCommand(cmd)
+
+	cmd.Flags().StringVarP(&r.args.apiPostBody, "body", "b", "", "JSON body to send with the request")
+
+	return cmd
+}
+
+func (r *runners) apiPost(cmd *cobra.Command, args []string) error {
+	path := args[0]
+
+	if !strings.HasPrefix(args[0], "/") {
+		path = fmt.Sprintf("/%s", args[0])
+	}
+	pathParts := strings.Split(path, "/")
+	// remove any empty parts
+	for i := len(pathParts) - 1; i >= 0; i-- {
+		if pathParts[i] == "" {
+			pathParts = append(pathParts[:i], pathParts[i+1:]...)
+		}
+	}
+
+	// v1 and v2 paths use platform client, v3 uses kots client
+	// split the path on the first slash to determine which client to use
+	if pathParts[0] == "v1" {
+
+	} else if pathParts[0] == "v3" {
+		kotsRestClient := kotsclient.VendorV3Client{HTTPClient: *r.platformAPI}
+		response, err := kotsRestClient.Post(path, r.args.apiPostBody)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("%s", response)
+	}
+
+	return nil
+}

--- a/cli/cmd/api_put.go
+++ b/cli/cmd/api_put.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/replicatedhq/replicated/pkg/kotsclient"
+	"github.com/spf13/cobra"
+)
+
+func (r *runners) InitAPIPut(parent *cobra.Command) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "put",
+		Short: "Make ad-hoc PUT API calls to the Replicated API",
+		Long: `This is essentially like curl for the Replicated API, but
+uses your local credentials and prints the response unmodified.
+
+We recommend piping the output to jq for easier reading.
+
+Pass the PATH of the request as the final argument. Do not include the host or version.
+
+Example:
+  replicated api put /v3/app/2EuFxKLDxKjPNk2jxMTmF6Vxvxu/channel/2QLPm10JPkta7jO3Z3Mk4aXTPyZ -b '{"name":"marc-waz-here2"}'
+  
+`,
+		RunE:         r.apiPut,
+		SilenceUsage: true,
+		Args:         cobra.ExactArgs(1),
+	}
+	parent.AddCommand(cmd)
+
+	cmd.Flags().StringVarP(&r.args.apiPutBody, "body", "b", "", "JSON body to send with the request")
+
+	return cmd
+}
+
+func (r *runners) apiPut(cmd *cobra.Command, args []string) error {
+	path := args[0]
+
+	if !strings.HasPrefix(args[0], "/") {
+		path = fmt.Sprintf("/%s", args[0])
+	}
+	pathParts := strings.Split(path, "/")
+	// remove any empty parts
+	for i := len(pathParts) - 1; i >= 0; i-- {
+		if pathParts[i] == "" {
+			pathParts = append(pathParts[:i], pathParts[i+1:]...)
+		}
+	}
+
+	// v1 and v2 paths use platform client, v3 uses kots client
+	// split the path on the first slash to determine which client to use
+	if pathParts[0] == "v1" {
+
+	} else if pathParts[0] == "v3" {
+		kotsRestClient := kotsclient.VendorV3Client{HTTPClient: *r.platformAPI}
+		response, err := kotsRestClient.Put(path, r.args.apiPutBody)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("%s", response)
+	}
+
+	return nil
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -219,6 +219,11 @@ func Execute(rootCmd *cobra.Command, stdin io.Reader, stdout io.Writer, stderr i
 
 	runCmds.InitLoginCommand(runCmds.rootCmd)
 
+	apiCmd := runCmds.InitAPICommand(runCmds.rootCmd)
+	runCmds.InitAPIGet(apiCmd)
+	runCmds.InitAPIPost(apiCmd)
+	runCmds.InitAPIPut(apiCmd)
+
 	runCmds.rootCmd.SetUsageTemplate(rootCmdUsageTmpl)
 
 	preRunSetupAPIs := func(_ *cobra.Command, _ []string) error {
@@ -287,6 +292,7 @@ func Execute(rootCmd *cobra.Command, stdin io.Reader, stdout io.Writer, stderr i
 	appCmd.PersistentPreRunE = preRunSetupAPIs
 	registryCmd.PersistentPreRunE = preRunSetupAPIs
 	clusterCmd.PersistentPreRunE = preRunSetupAPIs
+	apiCmd.PersistentPreRunE = preRunSetupAPIs
 
 	runCmds.rootCmd.AddCommand(Version())
 

--- a/cli/cmd/runner.go
+++ b/cli/cmd/runner.go
@@ -180,4 +180,7 @@ type runnerArgs struct {
 	lsClusterHideTerminated bool
 
 	loginEndpoint string
+
+	apiPostBody string
+	apiPutBody  string
 }

--- a/pkg/kotsclient/api.go
+++ b/pkg/kotsclient/api.go
@@ -1,0 +1,28 @@
+package kotsclient
+
+func (c *VendorV3Client) Get(path string) ([]byte, error) {
+	resp, err := c.DoJSONWithoutUnmarshal("GET", path, "")
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+func (c *VendorV3Client) Post(path string, body string) ([]byte, error) {
+	resp, err := c.DoJSONWithoutUnmarshal("POST", path, body)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+func (c *VendorV3Client) Put(path string, body string) ([]byte, error) {
+	resp, err := c.DoJSONWithoutUnmarshal("PUT", path, body)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}


### PR DESCRIPTION
This is a quick implementation of a `replicated api <path>` command that works for GET methods today, using the CLI creds.

Exmaple

```
% make build && ./bin/replicated api get v3/apps | jq | more
go build \
                -ldflags " -X github.com/replicatedhq/replicated/pkg/version.version=v0.44.0-22-g65b01545 -X github.com/replicatedhq/replicated/pkg/version.gitSHA=`git rev-parse HEAD` -X github.com/replicatedhq/replicated/pkg/version.buildTime=`date -u +"%Y-%m-%dT%H:%M:%SZ"` " \
                -o bin/replicated \
                cli/main.go
Update available: v0.46.0
To automatically upgrade, run "replicated version upgrade"
{
  "apps": [
    {
      "id": "cut",
      "teamId": "cut",
      "name": "Slackernews",
      "created": "2022-06-02T20:53:54Z",
      "description": "",
      "isArchived": false,
      "slug": "slackernews",
      "renamedAt": null,
      "isKotsApp": true,
      "publicKeyPem": "-----BEGIN PUBLIC
  <cut>
```
