### PR TITLE
Add --chart flag to release create and update

### DIFF
--- a/cli/cmd/release_promote.go
+++ b/cli/cmd/release_promote.go
@@ -53,6 +53,10 @@ func (r *runners) releasePromote(cmd *cobra.Command, args []string) error {
 		required = r.args.releaseRequired
 	}
 
+	if r.isFoundationApp && r.args.releaseVersion != "" {
+		return errors.New("--version cannot be set for foundation apps")
+	}
+
 	if err := r.api.PromoteRelease(r.appID, r.appType, seq, r.args.releaseVersion, r.args.releaseNotes, required, newID); err != nil {
 		return err
 	}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -280,6 +280,7 @@ func Execute(rootCmd *cobra.Command, stdin io.Reader, stdout io.Writer, stderr i
 
 		runCmds.appID = app.ID
 		runCmds.appSlug = app.Slug
+		runCmds.isFoundationApp = app.IsFoundation
 
 		return nil
 	}

--- a/cli/cmd/runner.go
+++ b/cli/cmd/runner.go
@@ -21,6 +21,7 @@ type runners struct {
 	appID            string
 	appSlug          string
 	appType          string
+	isFoundationApp  bool
 	api              client.Client
 	enterpriseClient *enterpriseclient.HTTPClient
 	platformAPI      *platformclient.HTTPClient
@@ -49,6 +50,7 @@ type runnerArgs struct {
 	createReleaseYaml                 string
 	createReleaseYamlFile             string
 	createReleaseYamlDir              string
+	createReleaseChart                string
 	createReleaseConfigYaml           string
 	createReleaseDeploymentYaml       string
 	createReleaseServiceYaml          string
@@ -71,6 +73,7 @@ type runnerArgs struct {
 	updateReleaseYaml     string
 	updateReleaseYamlDir  string
 	updateReleaseYamlFile string
+	updateReleaseChart    string
 
 	entitlementsAPIServer                string
 	entitlementsVerbose                  bool

--- a/pkg/kotsclient/app.go
+++ b/pkg/kotsclient/app.go
@@ -23,10 +23,11 @@ func (c *VendorV3Client) ListApps() ([]types.AppAndChannels, error) {
 	for _, kotsApp := range response.Apps {
 		app := types.AppAndChannels{
 			App: &types.App{
-				ID:        kotsApp.Id,
-				Name:      kotsApp.Name,
-				Slug:      kotsApp.Slug,
-				Scheduler: "kots",
+				ID:           kotsApp.Id,
+				Name:         kotsApp.Name,
+				Slug:         kotsApp.Slug,
+				IsFoundation: kotsApp.IsFoundation,
+				Scheduler:    "kots",
 			},
 			Channels: kotsApp.Channels,
 		}
@@ -45,10 +46,11 @@ func (c *VendorV3Client) GetApp(appID string) (*types.App, error) {
 	for _, app := range apps {
 		if app.App.ID == appID || app.App.Slug == appID {
 			return &types.App{
-				ID:        app.App.ID,
-				Name:      app.App.Name,
-				Slug:      app.App.Slug,
-				Scheduler: "kots",
+				ID:           app.App.ID,
+				Name:         app.App.Name,
+				Slug:         app.App.Slug,
+				IsFoundation: app.App.IsFoundation,
+				Scheduler:    "kots",
 			}, nil
 		}
 	}

--- a/pkg/types/app.go
+++ b/pkg/types/app.go
@@ -3,10 +3,11 @@ package types
 import "time"
 
 type App struct {
-	ID        string
-	Name      string
-	Scheduler string
-	Slug      string
+	ID           string
+	Name         string
+	Scheduler    string
+	Slug         string
+	IsFoundation bool
 }
 
 type AppAndChannels struct {
@@ -15,16 +16,17 @@ type AppAndChannels struct {
 }
 
 type KotsAppWithChannels struct {
-	Channels    []Channel `json:"channels,omitempty"`
-	Created     time.Time `json:"created,omitempty"`
-	Description string    `json:"description,omitempty"`
-	Id          string    `json:"id,omitempty"`
-	IsArchived  bool      `json:"isArchived,omitempty"`
-	IsKotsApp   bool      `json:"isKotsApp,omitempty"`
-	Name        string    `json:"name,omitempty"`
-	RenamedAt   time.Time `json:"renamedAt,omitempty"`
-	Slug        string    `json:"slug,omitempty"`
-	TeamId      string    `json:"teamId,omitempty"`
+	Channels     []Channel `json:"channels,omitempty"`
+	Created      time.Time `json:"created,omitempty"`
+	Description  string    `json:"description,omitempty"`
+	Id           string    `json:"id,omitempty"`
+	IsArchived   bool      `json:"isArchived,omitempty"`
+	IsKotsApp    bool      `json:"isKotsApp,omitempty"`
+	IsFoundation bool      `json:"isFoundation,omitempty"`
+	Name         string    `json:"name,omitempty"`
+	RenamedAt    time.Time `json:"renamedAt,omitempty"`
+	Slug         string    `json:"slug,omitempty"`
+	TeamId       string    `json:"teamId,omitempty"`
 }
 
 type KotsAppChannel struct {


### PR DESCRIPTION
Adds support for Builders apps. All new validation rules are also enforced on the API side.

1. A release must contain exactly one Helm chart and no other files.
2. Promoted release must have empty string as version label.
3. Builders release cannot be linted.