### PR TITLE
Add newline to ouput

### DIFF
--- a/cli/cmd/customer_download_license.go
+++ b/cli/cmd/customer_download_license.go
@@ -1,9 +1,11 @@
 package cmd
 
 import (
+	"fmt"
+	"io/ioutil"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"io/ioutil"
 )
 
 func (r *runners) InitCustomersDownloadLicenseCommand(parent *cobra.Command) *cobra.Command {
@@ -41,7 +43,7 @@ func (r *runners) downloadCustomerLicense(_ *cobra.Command, _ []string) error {
 
 	defer r.w.Flush()
 	if r.args.customerLicenseInspectOutput == "-" {
-		_, err = r.w.Write(license)
+		_, err = fmt.Fprintln(r.w, string(license))
 		return err
 	}
 

--- a/cli/print/channel_attributes.go
+++ b/cli/print/channel_attributes.go
@@ -56,7 +56,7 @@ func ChannelAttrs(outputFormat string,
 		}
 	} else if outputFormat == "json" {
 		cAsByte, _ := json.MarshalIndent(appChan, "", "  ")
-		if _, err := w.Write(append(cAsByte, "\n"...)); err != nil {
+		if _, err := fmt.Fprintln(w, string(cAsByte)); err != nil {
 			return err
 		}
 	}

--- a/cli/print/channel_attributes.go
+++ b/cli/print/channel_attributes.go
@@ -56,7 +56,7 @@ func ChannelAttrs(outputFormat string,
 		}
 	} else if outputFormat == "json" {
 		cAsByte, _ := json.MarshalIndent(appChan, "", "  ")
-		if _, err := w.Write(cAsByte); err != nil {
+		if _, err := w.Write(append(cAsByte, "\n"...)); err != nil {
 			return err
 		}
 	}

--- a/cli/print/clusters.go
+++ b/cli/print/clusters.go
@@ -2,6 +2,7 @@ package print
 
 import (
 	"encoding/json"
+	"fmt"
 	"text/tabwriter"
 	"text/template"
 
@@ -23,7 +24,7 @@ func Clusters(outputFormat string, w *tabwriter.Writer, clusters []*types.Cluste
 		}
 	} else if outputFormat == "json" {
 		cAsByte, _ := json.MarshalIndent(clusters, "", "  ")
-		if _, err := w.Write(append(cAsByte, "\n"...)); err != nil {
+		if _, err := fmt.Fprintln(w, string(cAsByte)); err != nil {
 			return err
 		}
 	}
@@ -32,12 +33,12 @@ func Clusters(outputFormat string, w *tabwriter.Writer, clusters []*types.Cluste
 
 func NoClusters(outputFormat string, w *tabwriter.Writer) error {
 	if outputFormat == "table" {
-		_, err := w.Write([]byte("No clusters found. Use the `replicated cluster create` command to create a new cluster.\n"))
+		_, err := fmt.Fprintln(w, "No clusters found. Use the `replicated cluster create` command to create a new cluster.")
 		if err != nil {
 			return err
 		}
 	} else if outputFormat == "json" {
-		if _, err := w.Write([]byte("[]\n")); err != nil {
+		if _, err := fmt.Fprintln(w, "[]"); err != nil {
 			return err
 		}
 	}
@@ -51,7 +52,7 @@ func Cluster(outputFormat string, w *tabwriter.Writer, cluster *types.Cluster) e
 		}
 	} else if outputFormat == "json" {
 		cAsByte, _ := json.MarshalIndent(cluster, "", "  ")
-		if _, err := w.Write(append(cAsByte, "\n"...)); err != nil {
+		if _, err := fmt.Fprintln(w, string(cAsByte)); err != nil {
 			return err
 		}
 	}

--- a/cli/print/clusters.go
+++ b/cli/print/clusters.go
@@ -23,7 +23,7 @@ func Clusters(outputFormat string, w *tabwriter.Writer, clusters []*types.Cluste
 		}
 	} else if outputFormat == "json" {
 		cAsByte, _ := json.MarshalIndent(clusters, "", "  ")
-		if _, err := w.Write(cAsByte); err != nil {
+		if _, err := w.Write(append(cAsByte, "\n"...)); err != nil {
 			return err
 		}
 	}
@@ -32,12 +32,12 @@ func Clusters(outputFormat string, w *tabwriter.Writer, clusters []*types.Cluste
 
 func NoClusters(outputFormat string, w *tabwriter.Writer) error {
 	if outputFormat == "table" {
-		_, err := w.Write([]byte(`No clusters found. Use the "replicated cluster create" command to create a new cluster.`))
+		_, err := w.Write([]byte("No clusters found. Use the `replicated cluster create` command to create a new cluster.\n"))
 		if err != nil {
 			return err
 		}
 	} else if outputFormat == "json" {
-		if _, err := w.Write([]byte("[]")); err != nil {
+		if _, err := w.Write([]byte("[]\n")); err != nil {
 			return err
 		}
 	}
@@ -51,7 +51,7 @@ func Cluster(outputFormat string, w *tabwriter.Writer, cluster *types.Cluster) e
 		}
 	} else if outputFormat == "json" {
 		cAsByte, _ := json.MarshalIndent(cluster, "", "  ")
-		if _, err := w.Write(cAsByte); err != nil {
+		if _, err := w.Write(append(cAsByte, "\n"...)); err != nil {
 			return err
 		}
 	}

--- a/cli/print/customers.go
+++ b/cli/print/customers.go
@@ -22,7 +22,7 @@ func Customers(outputFormat string, w *tabwriter.Writer, customers []types.Custo
 		}
 	} else if outputFormat == "json" {
 		cAsByte, _ := json.MarshalIndent(customers, "", "  ")
-		if _, err := w.Write(cAsByte); err != nil {
+		if _, err := w.Write(append(cAsByte, "\n"...)); err != nil {
 			return err
 		}
 	}
@@ -36,7 +36,7 @@ func Customer(outputFormat string, w *tabwriter.Writer, customer *types.Customer
 		}
 	} else if outputFormat == "json" {
 		cAsByte, _ := json.MarshalIndent(customer, "", "  ")
-		if _, err := w.Write(cAsByte); err != nil {
+		if _, err := w.Write(append(cAsByte, "\n"...)); err != nil {
 			return err
 		}
 	}

--- a/cli/print/customers.go
+++ b/cli/print/customers.go
@@ -2,6 +2,7 @@ package print
 
 import (
 	"encoding/json"
+	"fmt"
 	"text/tabwriter"
 	"text/template"
 
@@ -22,7 +23,7 @@ func Customers(outputFormat string, w *tabwriter.Writer, customers []types.Custo
 		}
 	} else if outputFormat == "json" {
 		cAsByte, _ := json.MarshalIndent(customers, "", "  ")
-		if _, err := w.Write(append(cAsByte, "\n"...)); err != nil {
+		if _, err := fmt.Fprintln(w, string(cAsByte)); err != nil {
 			return err
 		}
 	}
@@ -36,7 +37,7 @@ func Customer(outputFormat string, w *tabwriter.Writer, customer *types.Customer
 		}
 	} else if outputFormat == "json" {
 		cAsByte, _ := json.MarshalIndent(customer, "", "  ")
-		if _, err := w.Write(append(cAsByte, "\n"...)); err != nil {
+		if _, err := fmt.Fprintln(w, string(cAsByte)); err != nil {
 			return err
 		}
 	}

--- a/pkg/credentials/fetch.go
+++ b/pkg/credentials/fetch.go
@@ -73,7 +73,7 @@ func startLocalWebServer(ctx context.Context, port int) (string, error) {
 
 		tokenChan <- token
 
-		w.Write([]byte("Authentication successful. You may close this window."))
+		fmt.Fprintln(w, "Authentication successful. You may close this window.")
 	})
 
 	go func() {


### PR DESCRIPTION
[SC 77671](https://app.shortcut.com/replicated/story/77671/don-t-show-sign-at-the-end-of-the-replicated-cluster-ls-command-when-no-clusters-are-available)