### PR TITLE
Options to get kubeconfig

### DIFF
--- a/cli/cmd/runner.go
+++ b/cli/cmd/runner.go
@@ -182,6 +182,10 @@ type runnerArgs struct {
 
 	lsClusterHideTerminated bool
 
+	kubeconfigClusterName string
+	kubeconfigClusterID   string
+	kubeconfigPath        string
+
 	loginEndpoint string
 
 	apiPostBody string


### PR DESCRIPTION
Allows use to get kubeconfig by id or name of cluster (id as a position arg remains the default).  also allows writing the kubeconfig to a file instead of merging, if desired.