### PR TITLE
added watch command to cluster ls

### DIFF
--- a/cli/cmd/cluster_create.go
+++ b/cli/cmd/cluster_create.go
@@ -83,7 +83,7 @@ func (r *runners) createCluster(_ *cobra.Command, args []string) error {
 		return r.waitForCluster(cl.ID, r.args.createClusterWaitDuration)
 	}
 
-	return print.Cluster(r.outputFormat, r.w, cl, true)
+	return print.Cluster(r.outputFormat, r.w, cl)
 }
 
 func (r *runners) waitForCluster(id string, duration time.Duration) error {
@@ -99,12 +99,12 @@ func (r *runners) waitForCluster(id string, duration time.Duration) error {
 		for _, cluster := range clusters {
 			if cluster.ID == id {
 				if cluster.Status == "running" {
-					return print.Cluster(r.outputFormat, r.w, cluster, true)
+					return print.Cluster(r.outputFormat, r.w, cluster)
 				} else if cluster.Status == "error" {
 					return errors.New("cluster failed to provision")
 				} else {
 					if time.Now().After(start.Add(duration)) {
-						return print.Cluster(r.outputFormat, r.w, cluster, true)
+						return print.Cluster(r.outputFormat, r.w, cluster)
 					}
 				}
 			}

--- a/cli/cmd/cluster_create.go
+++ b/cli/cmd/cluster_create.go
@@ -83,7 +83,7 @@ func (r *runners) createCluster(_ *cobra.Command, args []string) error {
 		return r.waitForCluster(cl.ID, r.args.createClusterWaitDuration)
 	}
 
-	return print.Cluster(r.outputFormat, r.w, cl)
+	return print.Cluster(r.outputFormat, r.w, cl, true)
 }
 
 func (r *runners) waitForCluster(id string, duration time.Duration) error {
@@ -99,12 +99,12 @@ func (r *runners) waitForCluster(id string, duration time.Duration) error {
 		for _, cluster := range clusters {
 			if cluster.ID == id {
 				if cluster.Status == "running" {
-					return print.Cluster(r.outputFormat, r.w, cluster)
+					return print.Cluster(r.outputFormat, r.w, cluster, true)
 				} else if cluster.Status == "error" {
 					return errors.New("cluster failed to provision")
 				} else {
 					if time.Now().After(start.Add(duration)) {
-						return print.Cluster(r.outputFormat, r.w, cluster)
+						return print.Cluster(r.outputFormat, r.w, cluster, true)
 					}
 				}
 			}

--- a/cli/cmd/cluster_ls.go
+++ b/cli/cmd/cluster_ls.go
@@ -123,8 +123,8 @@ func (r *runners) listClusters(_ *cobra.Command, args []string) error {
 
 			clusters = newClusters
 
-			// Waits 2 seconds before running again]
-			time.Sleep(time.Second * 2)
+			// Waits 2 seconds before running again
+			time.Tick(2 * time.Second)
 		}
 	}
 

--- a/cli/cmd/cluster_ls.go
+++ b/cli/cmd/cluster_ls.go
@@ -1,12 +1,15 @@
 package cmd
 
 import (
+	"reflect"
 	"time"
 
+	"github.com/manifoldco/promptui"
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/replicated/cli/print"
 	"github.com/replicatedhq/replicated/pkg/kotsclient"
 	"github.com/replicatedhq/replicated/pkg/platformclient"
+	"github.com/replicatedhq/replicated/pkg/types"
 	"github.com/spf13/cobra"
 )
 
@@ -24,6 +27,7 @@ func (r *runners) InitClusterList(parent *cobra.Command) *cobra.Command {
 	cmd.Flags().StringVar(&r.args.lsClusterStartTime, "start-time", "", "start time for the query (Format: 2006-01-02T15:04:05Z)")
 	cmd.Flags().StringVar(&r.args.lsClusterEndTime, "end-time", "", "end time for the query (Format: 2006-01-02T15:04:05Z)")
 	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
+	cmd.Flags().BoolVarP(&r.args.lsClusterWatch, "watch", "w", false, "watch clusters")
 
 	return cmd
 }
@@ -56,9 +60,77 @@ func (r *runners) listClusters(_ *cobra.Command, args []string) error {
 		return errors.Wrap(err, "list clusters")
 	}
 
+	if r.args.lsClusterWatch {
+
+		var noInitialClusters bool = false
+		// Prints the intial list of clusters
+		if len(clusters) == 0 {
+			print.NoClusters(r.outputFormat, r.w)
+			noInitialClusters = true
+		} else {
+			print.Clusters(r.outputFormat, r.w, clusters, true)
+		}
+
+		// Runs until ctrl C is recognized
+		for {
+
+			newClusters, err := kotsRestClient.ListClusters(!r.args.lsClusterHideTerminated)
+
+			if err != nil {
+				if err == promptui.ErrInterrupt {
+					return errors.New("interrupted")
+				}
+
+				return errors.Wrap(err, "watch clusters")
+			}
+
+			// Create a map from the IDs of the new clusters
+			newClusterMap := make(map[string]*types.Cluster)
+			for _, newCluster := range newClusters {
+				newClusterMap[newCluster.ID] = newCluster
+			}
+
+			// Create a map from the IDs of the old clusters
+			oldClusterMap := make(map[string]*types.Cluster)
+			for _, cluster := range clusters {
+				oldClusterMap[cluster.ID] = cluster
+			}
+
+			// Check for new clusters and print them
+			for id, newCluster := range newClusterMap {
+				if oldCluster, found := oldClusterMap[id]; !found {
+					if noInitialClusters {
+						noInitialClusters = false
+						print.Cluster(r.outputFormat, r.w, newCluster, true)
+					} else {
+						print.Cluster(r.outputFormat, r.w, newCluster, false)
+					}
+				} else {
+					// Check if properties of existing clusters have changed
+					if !reflect.DeepEqual(newCluster, oldCluster) {
+						print.Cluster(r.outputFormat, r.w, newCluster, false)
+					}
+				}
+			}
+
+			// Check for removed clusters and print them, changing their status to be "deleted"
+			for id, cluster := range oldClusterMap {
+				if _, found := newClusterMap[id]; !found {
+					cluster.Status = "deleted"
+					print.Cluster(r.outputFormat, r.w, cluster, false)
+				}
+			}
+
+			clusters = newClusters
+
+			// Waits 2 seconds before running again]
+			time.Sleep(time.Second * 2)
+		}
+	}
+
 	if len(clusters) == 0 {
 		return print.NoClusters(r.outputFormat, r.w)
 	}
 
-	return print.Clusters(r.outputFormat, r.w, clusters)
+	return print.Clusters(r.outputFormat, r.w, clusters, true)
 }

--- a/cli/cmd/cluster_ls.go
+++ b/cli/cmd/cluster_ls.go
@@ -123,7 +123,7 @@ func (r *runners) listClusters(_ *cobra.Command, args []string) error {
 
 			// Prints the clusters
 			if len(clustersToPrint) > 0 {
-				fmt.Print("\033[H\033[2J")
+				fmt.Print("\033[H\033[2J") // Clears the console
 				print.Clusters(r.outputFormat, r.w, clustersToPrint, true)
 			}
 

--- a/cli/cmd/cluster_ls.go
+++ b/cli/cmd/cluster_ls.go
@@ -124,7 +124,7 @@ func (r *runners) listClusters(_ *cobra.Command, args []string) error {
 			// Prints the clusters
 			if len(clustersToPrint) > 0 {
 				fmt.Print("\033[H\033[2J") // Clears the console
-				print.Clusters(r.outputFormat, r.w, clustersToPrint, true)
+				print.Clusters(r.outputFormat, r.w, clustersToPrint)
 			}
 
 			clusters = newClusters
@@ -135,5 +135,5 @@ func (r *runners) listClusters(_ *cobra.Command, args []string) error {
 		return print.NoClusters(r.outputFormat, r.w)
 	}
 
-	return print.Clusters(r.outputFormat, r.w, clusters, true)
+	return print.Clusters(r.outputFormat, r.w, clusters)
 }

--- a/cli/cmd/cluster_ls.go
+++ b/cli/cmd/cluster_ls.go
@@ -62,7 +62,7 @@ func (r *runners) listClusters(_ *cobra.Command, args []string) error {
 
 	if r.args.lsClusterWatch {
 
-		var noInitialClusters bool = false
+		noInitialClusters := false
 		// Prints the intial list of clusters
 		if len(clusters) == 0 {
 			print.NoClusters(r.outputFormat, r.w)

--- a/cli/cmd/cluster_ls.go
+++ b/cli/cmd/cluster_ls.go
@@ -79,7 +79,7 @@ func (r *runners) listClusters(_ *cobra.Command, args []string) error {
 
 		// Runs until ctrl C is recognized
 		for range time.Tick(2 * time.Second) {
-			newClusters, err := kotsRestClient.ListClusters(!r.args.lsClusterHideTerminated)
+			newClusters, err := kotsRestClient.ListClusters(r.args.lsClusterShowTerminated, startTime, endTime)
 
 			if err != nil {
 				if err == promptui.ErrInterrupt {

--- a/cli/cmd/runner.go
+++ b/cli/cmd/runner.go
@@ -187,6 +187,7 @@ type runnerArgs struct {
 	lsClusterShowTerminated bool
 	lsClusterStartTime      string
 	lsClusterEndTime        string
+	lsClusterWatch          bool
 
 	kubeconfigClusterName string
 	kubeconfigClusterID   string

--- a/cli/print/clusters.go
+++ b/cli/print/clusters.go
@@ -21,8 +21,10 @@ var clusterTmpNoHeader = template.Must(template.New("clusters").Funcs(funcs).Par
 var clustersTmpl = template.Must(template.New("clusters").Funcs(funcs).Parse(clustersSourceTmpHeader + clustersTmplSrc))
 
 func Clusters(outputFormat string, w *tabwriter.Writer, clusters []*types.Cluster, includeHeader bool) error {
+	tmpl := clustersTmpl
+
 	if outputFormat == "table" {
-		if err := clustersTmpl.Execute(w, clusters); err != nil {
+		if err := tmpl.Execute(w, clusters); err != nil {
 			return err
 		}
 	} else if outputFormat == "json" {
@@ -49,21 +51,5 @@ func NoClusters(outputFormat string, w *tabwriter.Writer) error {
 }
 
 func Cluster(outputFormat string, w *tabwriter.Writer, cluster *types.Cluster, includerHeader bool) error {
-	if outputFormat == "table" {
-		if includerHeader {
-			if err := clustersTmpl.Execute(w, []types.Cluster{*cluster}); err != nil {
-				return err
-			}
-		} else {
-			if err := clusterTmpNoHeader.Execute(w, []types.Cluster{*cluster}); err != nil {
-				return err
-			}
-		}
-	} else if outputFormat == "json" {
-		cAsByte, _ := json.MarshalIndent(cluster, "", "  ")
-		if _, err := fmt.Fprintln(w, string(cAsByte)); err != nil {
-			return err
-		}
-	}
-	return w.Flush()
+	return Clusters(outputFormat, w, []*types.Cluster{cluster}, false)
 }

--- a/cli/print/clusters.go
+++ b/cli/print/clusters.go
@@ -18,7 +18,7 @@ var clustersTmplSrc = `ID	NAME	K8S DISTRO	K8S VERSION	STATUS	CREATED	EXPIRES
 
 var clustersTmpl = template.Must(template.New("clusters").Funcs(funcs).Parse(clustersTmplSrc))
 
-func Clusters(outputFormat string, w *tabwriter.Writer, clusters []*types.Cluster, includeHeader bool) error {
+func Clusters(outputFormat string, w *tabwriter.Writer, clusters []*types.Cluster) error {
 	if outputFormat == "table" {
 		if err := clustersTmpl.Execute(w, clusters); err != nil {
 			return err
@@ -46,6 +46,6 @@ func NoClusters(outputFormat string, w *tabwriter.Writer) error {
 	return w.Flush()
 }
 
-func Cluster(outputFormat string, w *tabwriter.Writer, cluster *types.Cluster, includerHeader bool) error {
-	return Clusters(outputFormat, w, []*types.Cluster{cluster}, false)
+func Cluster(outputFormat string, w *tabwriter.Writer, cluster *types.Cluster) error {
+	return Clusters(outputFormat, w, []*types.Cluster{cluster})
 }

--- a/cli/print/clusters.go
+++ b/cli/print/clusters.go
@@ -10,21 +10,17 @@ import (
 )
 
 // TODO: implement a -o wide, and expose nodecount, vcpus and memory also?
-var clustersSourceTmpHeader = `ID	NAME	K8S DISTRO	K8S VERSION	STATUS	CREATED	EXPIRES
-`
 
-var clustersTmplSrc = `{{ range . -}}
+var clustersTmplSrc = `ID	NAME	K8S DISTRO	K8S VERSION	STATUS	CREATED	EXPIRES
+{{ range . -}}
 {{ .ID }}	{{ .Name }}	{{ .KubernetesDistribution}}	{{ .KubernetesVersion	}}	{{ .Status }}	{{ .CreatedAt}}	{{ .ExpiresAt }}
 {{ end }}`
 
-var clusterTmpNoHeader = template.Must(template.New("clusters").Funcs(funcs).Parse(clustersTmplSrc))
-var clustersTmpl = template.Must(template.New("clusters").Funcs(funcs).Parse(clustersSourceTmpHeader + clustersTmplSrc))
+var clustersTmpl = template.Must(template.New("clusters").Funcs(funcs).Parse(clustersTmplSrc))
 
 func Clusters(outputFormat string, w *tabwriter.Writer, clusters []*types.Cluster, includeHeader bool) error {
-	tmpl := clustersTmpl
-
 	if outputFormat == "table" {
-		if err := tmpl.Execute(w, clusters); err != nil {
+		if err := clustersTmpl.Execute(w, clusters); err != nil {
 			return err
 		}
 	} else if outputFormat == "json" {


### PR DESCRIPTION
Added a watch flag to cluster ls that compares the cluster list every 2 seconds and prints the changes made to the CLI. Adding new clusters, removing clusters, or a cluster being changed or updated will all trigger a new printing of that cluster.