### PR TITLE
Require arg of yaml-dir command line parameter to be a file

### DIFF
--- a/cli/cmd/release_create.go
+++ b/cli/cmd/release_create.go
@@ -410,8 +410,17 @@ func encodeKotsFile(prefix, path string, info os.FileInfo, err error) (*kotstype
 }
 
 func makeReleaseFromDir(fileDir string) (string, error) {
+	fileInfo, err := os.Stat(fileDir)
+	if err != nil {
+		return "", errors.Wrapf(err, "stat %s", fileDir)
+	}
+
+	if !fileInfo.IsDir() {
+		return "", errors.Errorf("chart path %s is not a directory", fileDir)
+	}
+
 	var allKotsReleaseSpecs []kotstypes.KotsSingleSpec
-	err := filepath.Walk(fileDir, func(path string, info os.FileInfo, err error) error {
+	err = filepath.Walk(fileDir, func(path string, info os.FileInfo, err error) error {
 		spec, err := encodeKotsFile(fileDir, path, info, err)
 		if err != nil {
 			return err

--- a/cli/cmd/release_create.go
+++ b/cli/cmd/release_create.go
@@ -416,7 +416,7 @@ func makeReleaseFromDir(fileDir string) (string, error) {
 	}
 
 	if !fileInfo.IsDir() {
-		return "", errors.Errorf("chart path %s is not a directory", fileDir)
+		return "", errors.Errorf("path %s is not a directory", fileDir)
 	}
 
 	var allKotsReleaseSpecs []kotstypes.KotsSingleSpec


### PR DESCRIPTION
https://app.shortcut.com/replicated/story/81185/ensure-yaml-dir-target-is-a-directory-before-uploading-release