### PR TITLE
Allow linting Builders apps

### DIFF
--- a/cli/cmd/release_create.go
+++ b/cli/cmd/release_create.go
@@ -196,6 +196,7 @@ Prepared to create release with defaults:
 	if r.args.createReleaseLint {
 		// Request lint release yaml directory to check
 		r.args.lintReleaseYamlDir = r.args.createReleaseYamlDir
+		r.args.lintReleaseChart = r.args.createReleaseChart
 		// Call release_lint.go releaseLint function
 		err := r.releaseLint(cmd, args)
 		if err != nil {
@@ -323,10 +324,6 @@ func (r *runners) validateReleaseCreateParams() error {
 			return errors.New("use the --yaml-file flag when passing a yaml filename")
 		}
 	} else {
-		if r.isFoundationApp && r.args.createReleaseLint {
-			return errors.New("--lint cannot be used with Builders KOTS app")
-		}
-
 		if !r.isFoundationApp && r.args.createReleaseYamlDir == "" {
 			return errors.New("--yaml-dir flag must be provided for KOTS applications")
 		}

--- a/cli/cmd/runner.go
+++ b/cli/cmd/runner.go
@@ -65,6 +65,7 @@ type runnerArgs struct {
 	// Add Create Release Lint
 	createReleaseLint     bool
 	lintReleaseYamlDir    string
+	lintReleaseChart      string
 	lintReleaseFailOn     string
 	releaseOptional       bool
 	releaseRequired       bool

--- a/client/release.go
+++ b/client/release.go
@@ -123,11 +123,11 @@ func (c *Client) PromoteRelease(appID string, appType string, sequence int64, la
 
 // data is a []byte describing a tarred yaml-dir, created by tarYAMLDir()
 // this Client abstraction continue to spring more leaks :)
-func (c *Client) LintRelease(appType string, data []byte) ([]types.LintMessage, error) {
+func (c *Client) LintRelease(appType string, data []byte, isBuildersRelease bool, contentType string) ([]types.LintMessage, error) {
 	if appType == "platform" {
 		return nil, errors.New("Linting is not yet supported in this CLI, please install github.com/replicatedhq/replicated-lint to lint this application")
 	} else if appType == "kots" {
-		return c.KotsClient.LintRelease(data)
+		return c.KotsClient.LintRelease(data, isBuildersRelease, contentType)
 	}
 
 	return nil, errors.New("unknown app type")

--- a/pkg/kotsclient/release_lint.go
+++ b/pkg/kotsclient/release_lint.go
@@ -6,24 +6,37 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
 
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/replicated/pkg/types"
 	"github.com/replicatedhq/replicated/pkg/version"
 )
 
+var linterOrigin = "https://lint.replicated.com"
+
+func init() {
+	if v := os.Getenv("LINTER_API_ORIGIN"); v != "" {
+		linterOrigin = v
+	}
+}
+
 // this is part of the gql client with plans to rename gql client to kotsclient
 // and have endpoints for multiple release services included
-func (c *VendorV3Client) LintRelease(data []byte) ([]types.LintMessage, error) {
-	endpoint := "https://lint.replicated.com/v1/lint"
+func (c *VendorV3Client) LintRelease(data []byte, isBuildersRelease bool, contentType string) ([]types.LintMessage, error) {
+	url := fmt.Sprintf("%s/v1/lint", linterOrigin)
+	if isBuildersRelease {
+		url = fmt.Sprintf("%s/v1/builders-lint", linterOrigin)
+	}
 
 	reader := bytes.NewReader(data)
-	req, err := http.NewRequest("POST", endpoint, reader)
+	req, err := http.NewRequest("POST", url, reader)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create request")
 	}
 
 	req.Header.Set("User-Agent", fmt.Sprintf("Replicated/%s", version.Version()))
+	req.Header.Set("Content-Type", contentType)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to execute request")


### PR DESCRIPTION
Relevant linter PR: https://github.com/replicatedhq/kots-lint/pull/161

```
$ ./bin/replicated release lint --chart testchart-without-labels-16.2.2.tgz 
Update available: v0.48.0
To automatically upgrade, run "replicated version upgrade"
RULE                          TYPE    FILENAME    LINE    MESSAGE
preflight-spec                warn                            Missing preflight spec                       
informers-labels-not-found    warn                            No informer labels found on any resources    
```

```
$ ./bin/replicated release lint --yaml-dir ./builders-files
Update available: v0.48.1
To automatically upgrade, run "replicated version upgrade"
RULE    TYPE    FILENAME    LINE    MESSAGE
preflight-spec                warn                            Missing preflight spec                       
```