### PR TITLE
Adds functionality to display customers and their instances for a specific app version

### DIFF
--- a/cli/cmd/customer_ls.go
+++ b/cli/cmd/customer_ls.go
@@ -13,7 +13,10 @@ func (r *runners) InitCustomersLSCommand(parent *cobra.Command) *cobra.Command {
 		Long:  `list customers`,
 		RunE:  r.listCustomers,
 	}
+	// Example to list customers by app version and app
+	// replicated customer ls --app <appID> --appVersion <appVersion>
 	parent.AddCommand(customersCmd)
+	customersCmd.Flags().StringVar(&r.args.lsAppVersion, "appversion", "", "List customers and their instances by app version")
 	customersCmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
 
 	return customersCmd
@@ -21,10 +24,22 @@ func (r *runners) InitCustomersLSCommand(parent *cobra.Command) *cobra.Command {
 
 func (r *runners) listCustomers(_ *cobra.Command, _ []string) error {
 
-	customers, err := r.api.ListCustomers(r.appID, r.appType)
-	if err != nil {
-		return errors.Wrap(err, "list customers")
+	// get appVersion from flags
+	lsappVersion := r.args.lsAppVersion
+	if lsappVersion == "" {
+		customers, err := r.api.ListCustomers(r.appID, r.appType)
+		if err != nil {
+			return errors.Wrap(err, "list customers")
+		}
+		return print.Customers(r.outputFormat, r.w, customers)
+	} else {
+		// call ListCustomersByAppAndVersion
+		customers, err := r.api.ListCustomersByAppAndVersion(r.appID, lsappVersion, r.appType)
+		if err != nil {
+			return errors.Wrap(err, "list customers by app and app version")
+		}
+		return print.CustomersWithInstances(r.outputFormat, r.w, customers)
 	}
+	return errors.New("Failed to list customers")
 
-	return print.Customers(r.outputFormat, r.w, customers)
 }

--- a/cli/cmd/customer_ls.go
+++ b/cli/cmd/customer_ls.go
@@ -27,6 +27,7 @@ func (r *runners) listCustomers(_ *cobra.Command, _ []string) error {
 
 	// get appVersion from flags
 	lsappVersion := r.args.lsAppVersion
+	// if appVersion is blank, call ListCustomers
 	if lsappVersion == "" {
 		customers, err := r.api.ListCustomers(r.appID, r.appType, r.args.customerLsIncludeTest)
 		if err != nil {
@@ -44,10 +45,10 @@ func (r *runners) listCustomers(_ *cobra.Command, _ []string) error {
 			return errors.Wrap(err, "list customers by app and app version")
 		}
 		return print.CustomersWithInstances(r.outputFormat, r.w, customers)
-	customers, err := r.api.ListCustomers(r.appID, r.appType, r.args.customerLsIncludeTest)
-	if err != nil {
-		return errors.Wrap(err, "list customers")
-	}
-	return errors.New("Failed to list customers")
+		if err != nil {
+			return errors.Wrap(err, "list customers")
+		}
+		return errors.New("Failed to list customers")
 
+	}
 }

--- a/cli/cmd/customer_ls.go
+++ b/cli/cmd/customer_ls.go
@@ -35,7 +35,11 @@ func (r *runners) listCustomers(_ *cobra.Command, _ []string) error {
 	} else {
 		// call ListCustomersByAppAndVersion
 		customers, err := r.api.ListCustomersByAppAndVersion(r.appID, lsappVersion, r.appType)
-		if err != nil {
+		// if err and outputFormat is json, customers should be a blank struct and print will return []
+		if err != nil && r.outputFormat == "json" {
+			return print.CustomersWithInstances(r.outputFormat, r.w, customers)
+			// error and outputFormat is table, print error
+		} else if err != nil {
 			return errors.Wrap(err, "list customers by app and app version")
 		}
 		return print.CustomersWithInstances(r.outputFormat, r.w, customers)

--- a/cli/cmd/runner.go
+++ b/cli/cmd/runner.go
@@ -184,6 +184,7 @@ type runnerArgs struct {
 
 	removeClusterForce bool
 
+	lsAppVersion            string
 	lsClusterShowTerminated bool
 	lsClusterStartTime      string
 	lsClusterEndTime        string

--- a/cli/print/customers.go
+++ b/cli/print/customers.go
@@ -30,6 +30,28 @@ func Customers(outputFormat string, w *tabwriter.Writer, customers []types.Custo
 	return w.Flush()
 }
 
+func CustomersWithInstances(outputFormat string, w *tabwriter.Writer, customers []types.Customer) error {
+	// Define a new template for use in this function
+	var customersTmplSrc = `CUSTOMER NAME	INSTANCE ID	LAST ACTIVE	VERSION	
+{{ range . -}}
+{{ .Name }}	{{range .Instances}}{{.InstanceId}}	{{.LastActive}}	{{range .VersionHistory}}{{.VersionLabel}}{{end}}{{end}}
+{{ end }}`
+
+	var customersTmpl = template.Must(template.New("customers").Parse(customersTmplSrc))
+
+	if outputFormat == "table" {
+		if err := customersTmpl.Execute(w, customers); err != nil {
+			return err
+		}
+	} else if outputFormat == "json" {
+		cAsByte, _ := json.MarshalIndent(customers, "", "  ")
+		if _, err := w.Write(cAsByte); err != nil {
+			return err
+		}
+	}
+	return w.Flush()
+}
+
 func Customer(outputFormat string, w *tabwriter.Writer, customer *types.Customer) error {
 	if outputFormat == "table" {
 		if err := customersTmpl.Execute(w, []types.Customer{*customer}); err != nil {

--- a/client/customer.go
+++ b/client/customer.go
@@ -21,7 +21,7 @@ func (c *Client) ListCustomers(appID string, appType string) ([]types.Customer, 
 func (c *Client) ListCustomersByAppAndVersion(appID string, appVersion string, appType string) ([]types.Customer, error) {
 
 	if appType == "platform" {
-		return nil, errors.New("listing customers is not supported for platform applications")
+		return nil, errors.New("listing customers by app version is not supported for native scheduler applications")
 	} else if appType == "kots" {
 		return c.KotsClient.ListCustomersByAppAndVersion(appID, appVersion, appType)
 	}

--- a/client/customer.go
+++ b/client/customer.go
@@ -17,6 +17,18 @@ func (c *Client) ListCustomers(appID string, appType string) ([]types.Customer, 
 	return nil, errors.Errorf("unknown app type %q", appType)
 }
 
+// list customers by app and app version
+func (c *Client) ListCustomersByAppAndVersion(appID string, appVersion string, appType string) ([]types.Customer, error) {
+
+	if appType == "platform" {
+		return nil, errors.New("listing customers is not supported for platform applications")
+	} else if appType == "kots" {
+		return c.KotsClient.ListCustomersByAppAndVersion(appID, appVersion, appType)
+	}
+
+	return nil, errors.Errorf("unknown app type %q", appType)
+}
+
 func (c *Client) CreateCustomer(appType string, opts kotsclient.CreateCustomerOpts) (*types.Customer, error) {
 	if appType == "platform" {
 		return nil, errors.New("creating customers is not supported for platform applications")

--- a/pkg/kotsclient/customer_list_by_app_version.go
+++ b/pkg/kotsclient/customer_list_by_app_version.go
@@ -1,0 +1,56 @@
+package kotsclient
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/replicated/pkg/types"
+)
+
+type CustomerListWithInstancesResponse struct {
+	// Response from /v3/app/{appID}/customers
+	Customers      []types.Customer `json:"customers"`
+	TotalCustomers int              `json:"totalCustomers"`
+}
+
+func (c *VendorV3Client) ListCustomersByAppAndVersion(appID string, appVersion string, appType string) ([]types.Customer, error) {
+
+	matchingCustomers := []types.Customer{}
+	page := 0
+	for {
+		resp := CustomerListWithInstancesResponse{}
+		path := fmt.Sprintf("/v3/app/%s/customers?currentPage=%d", appID, page)
+		err := c.DoJSON("GET", path, http.StatusOK, nil, &resp)
+		if err != nil {
+			return nil, errors.Wrapf(err, "List Customers By App Version page %d", page)
+		}
+
+		for _, customer := range resp.Customers {
+			for _, instance := range customer.Instances {
+				for versionIndex, versionHistory := range instance.VersionHistory {
+					if versionHistory.VersionLabel == appVersion && versionIndex == 0 {
+						// only add the customer if the version matches
+						// index[0] is the latest version
+						// There has to be a better way to do this without creating a tempCustomer
+						tempCustomer := customer
+						tempCustomer.Instances = []types.Instance{instance}
+						tempCustomer.Instances[0].VersionHistory = []types.VersionHistory{versionHistory}
+						matchingCustomers = append(matchingCustomers, tempCustomer)
+
+					}
+				}
+			}
+		}
+		if len(matchingCustomers) == resp.TotalCustomers || len(resp.Customers) == 0 {
+			// We've reached the end of the customer pages
+			break
+		}
+		page = page + 1
+	}
+
+	if len(matchingCustomers) == 0 {
+		return matchingCustomers, fmt.Errorf("no matching customers found for app %q and version %q ", appID, appVersion)
+	}
+	return matchingCustomers, nil
+}

--- a/pkg/types/customer.go
+++ b/pkg/types/customer.go
@@ -6,11 +6,12 @@ import (
 )
 
 type Customer struct {
-	ID       string     `json:"id"`
-	Name     string     `json:"name"`
-	Channels []Channel  `json:"channels"`
-	Type     string     `json:"type"`
-	Expires  *util.Time `json:"expiresAt"`
+	ID        string     `json:"id"`
+	Name      string     `json:"name"`
+	Channels  []Channel  `json:"channels"`
+	Type      string     `json:"type"`
+	Expires   *util.Time `json:"expiresAt"`
+	Instances []Instance `json:"instances"`
 }
 
 func (c Customer) WithExpiryTime(expiryTime string) (Customer, error) {

--- a/pkg/types/instance.go
+++ b/pkg/types/instance.go
@@ -1,0 +1,26 @@
+package types
+
+import "time"
+
+type Instance struct {
+	LicenseId      string           `json:"licenseId,omitempty"`
+	InstanceId     string           `json:"instanceId,omitempty"`
+	ClusterId      string           `json:"clusterId,omitempty"`
+	CreatedAt      time.Time        `json:"createdAt,omitempty"`
+	LastActive     time.Time        `json:"lastActive,omitempty"`
+	AppStatus      string           `json:"appStatus,omitempty"`
+	Active         bool             `json:"active,omitempty"`
+	VersionHistory []VersionHistory `json:"versionHistory,omitempty"`
+}
+
+type VersionHistory struct {
+	InstanceId                string    `json:"instanceId,omitempty"`
+	ClusterId                 string    `json:"clusterId,omitempty"`
+	VersionLabel              string    `json:"versionLabel,omitempty"`
+	DownStreamChannelId       string    `json:"downstreamChannelId,omitempty"`
+	DownStreamReleaseSequence int32     `json:"downstreamReleaseSequence,omitempty"`
+	IntervalStart             time.Time `json:"intervalStart,omitempty"`
+	IntervalLast              time.Time `json:"intervallast,omitempty"`
+	RepHelmCount              int32     `json:"repHelmCount,omitempty"`
+	NativeHelmCount           int32     `json:"nativeHelmCount,omitempty"`
+}


### PR DESCRIPTION
The API already provides instance data including the application version. However, its cumbersome to find which instances or customers that are running a specific software release. This subcommand allows you to use the CLI to report on customers (and their instances), which are running a specific version.

**Use Case**
A vendor wants to know which of their customers and instances are running a specific version of their software.

**Implementation**
- Use the existing Vendor API /v3/app/%s/customers? route to retrieve all customers
- Iterate the response json, looking at which customers are running the appID specified in the 
- Search the Instance versionHistory.VersionLabel for matching instances of the specified version
- Print the results to screen either table or json format (depending on if --output was provided. defaults to table if not provided)

**Usage**
Added a new `--appversion` flag for the `customer ls` command to specify a version string

Example, 
`replicated customer ls  --app <APPID> --appversion <VERSION>`

**Summary of Changes**
modified:   cli/cmd/customer_ls.go
add --appversion flag
if appversion provided, then call ListCustomersByAppAndVersion()

modified:   cli/cmd/runner.go
add lsAppVersion variable

modified:   cli/print/customers.go
add CustomersWithInstances() which prints customer name and instances with the specific app version

modified:   client/customer.go
add ListCustomersByAppAndVersion()

new file:   pkg/kotsclient/customer_list_by_app_version.go

modified:   pkg/types/customer.go
add customer type to now include instance struct

new file:   pkg/types/instance.go
add new instance type