### PR TITLE
Allow customers assigned to test customers to not have a channel

### DIFF
--- a/cli/cmd/customer_create.go
+++ b/cli/cmd/customer_create.go
@@ -42,22 +42,27 @@ func (r *runners) createCustomer(_ *cobra.Command, _ []string) error {
 		return errors.New("test licenses cannot be created with an expiration date greater than 48 hours")
 	}
 
-	getOrCreateChannelOptions := client.GetOrCreateChannelOptions{
-		AppID:          r.appID,
-		AppType:        r.appType,
-		NameOrID:       r.args.customerCreateChannel,
-		Description:    "",
-		CreateIfAbsent: r.args.customerCreateEnsureChannel,
-	}
+	channelID := ""
+	if r.args.customerCreateChannel != "" {
+		getOrCreateChannelOptions := client.GetOrCreateChannelOptions{
+			AppID:          r.appID,
+			AppType:        r.appType,
+			NameOrID:       r.args.customerCreateChannel,
+			Description:    "",
+			CreateIfAbsent: r.args.customerCreateEnsureChannel,
+		}
 
-	channel, err := r.api.GetOrCreateChannelByName(getOrCreateChannelOptions)
-	if err != nil {
-		return errors.Wrap(err, "get channel")
+		channel, err := r.api.GetOrCreateChannelByName(getOrCreateChannelOptions)
+		if err != nil {
+			return errors.Wrap(err, "get channel")
+		}
+
+		channelID = channel.ID
 	}
 
 	opts := kotsclient.CreateCustomerOpts{
 		Name:                r.args.customerCreateName,
-		ChannelID:           channel.ID,
+		ChannelID:           channelID,
 		AppID:               r.appID,
 		ExpiresAt:           r.args.customerCreateExpiryDuration,
 		IsAirgapEnabled:     r.args.customerCreateIsAirgapEnabled,

--- a/pkg/kotsclient/customer_create.go
+++ b/pkg/kotsclient/customer_create.go
@@ -36,8 +36,7 @@ type CreateCustomerOpts struct {
 	Email               string
 }
 
-func (c *VendorV3Client) CreateCustomer(
-	opts CreateCustomerOpts) (*types.Customer, error) {
+func (c *VendorV3Client) CreateCustomer(opts CreateCustomerOpts) (*types.Customer, error) {
 	request := &CreateCustomerRequest{
 		Name:                opts.Name,
 		ChannelID:           opts.ChannelID,


### PR DESCRIPTION
Don't require a channelid (name) when creating a customer if the customer is a "test" type. (this is also enforced in the api) 