### PR TITLE
hide registry logs

### DIFF
--- a/cli/cmd/registry_logs.go
+++ b/cli/cmd/registry_logs.go
@@ -12,6 +12,7 @@ func (r *runners) InitRegistryLogs(parent *cobra.Command) *cobra.Command {
 		Short:        "show registry logs",
 		Long:         `show registry logs for a single registry`,
 		RunE:         r.logsRegistry,
+		Hidden:       true,
 		SilenceUsage: true,
 	}
 	parent.AddCommand(cmd)


### PR DESCRIPTION
```
$ go run ./cli/ registry help
registry can be used to manage existing registries and add new registries to a team

Usage:
  replicated registry [command]

Available Commands:
  add         add
  ls          list registries
  rm          remove registry
  test        test registry
```