### PR TITLE
When the c11y entitlement is not enabled, redirect to terms of service

### DIFF
--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -1,7 +1,12 @@
 package cmd
 
 import (
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+)
+
+var (
+	ErrCompatibilityMatrixTermsNotAccepted = errors.New("You must read and accept the Compatibility Matrix Terms of Service before using this command. To view, please visit https://vendor.replicated.com/compatibility-matrix")
 )
 
 func (r *runners) InitClusterCommand(parent *cobra.Command) *cobra.Command {

--- a/cli/cmd/cluster_create.go
+++ b/cli/cmd/cluster_create.go
@@ -80,9 +80,8 @@ func (r *runners) createCluster(_ *cobra.Command, args []string) error {
 func createCluster(kotsRestClient kotsclient.VendorV3Client, opts kotsclient.CreateClusterOpts, waitDuration time.Duration) (*types.Cluster, error) {
 	cl, ve, err := kotsRestClient.CreateCluster(opts)
 	if errors.Cause(err) == kotsclient.ErrForbidden {
-		return nil, errors.New("This command is not available for your account or team. Please contact your customer success representative for more information.")
-	}
-	if err != nil {
+		return nil, ErrCompatibilityMatrixTermsNotAccepted
+	} else if err != nil {
 		return nil, errors.Wrap(err, "create cluster")
 	}
 

--- a/cli/cmd/cluster_kubeconfig.go
+++ b/cli/cmd/cluster_kubeconfig.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/replicated/pkg/kotsclient"
+	"github.com/replicatedhq/replicated/pkg/platformclient"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -49,7 +50,9 @@ func (r *runners) kubeconfigCluster(_ *cobra.Command, args []string) error {
 		clusterID = args[0]
 	} else if r.args.kubeconfigClusterName != "" {
 		clusters, err := kotsRestClient.ListClusters(false, nil, nil)
-		if err != nil {
+		if errors.Cause(err) == platformclient.ErrForbidden {
+			return ErrCompatibilityMatrixTermsNotAccepted
+		} else if err != nil {
 			return errors.Wrap(err, "list clusters")
 		}
 		for _, cluster := range clusters {
@@ -65,7 +68,9 @@ func (r *runners) kubeconfigCluster(_ *cobra.Command, args []string) error {
 	}
 
 	kubeconfig, err := kotsRestClient.GetClusterKubeconfig(clusterID)
-	if err != nil {
+	if errors.Cause(err) == platformclient.ErrForbidden {
+		return ErrCompatibilityMatrixTermsNotAccepted
+	} else if err != nil {
 		return errors.Wrap(err, "get cluster kubeconfig")
 	}
 

--- a/cli/cmd/cluster_ls.go
+++ b/cli/cmd/cluster_ls.go
@@ -55,9 +55,8 @@ func (r *runners) listClusters(_ *cobra.Command, args []string) error {
 
 	clusters, err := kotsRestClient.ListClusters(r.args.lsClusterShowTerminated, startTime, endTime)
 	if errors.Cause(err) == platformclient.ErrForbidden {
-		return errors.New("This command is not available for your account or team. Please contact your customer success representative for more information.")
-	}
-	if err != nil {
+		return ErrCompatibilityMatrixTermsNotAccepted
+	} else if err != nil {
 		return errors.Wrap(err, "list clusters")
 	}
 

--- a/cli/cmd/cluster_rm.go
+++ b/cli/cmd/cluster_rm.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/replicated/pkg/kotsclient"
+	"github.com/replicatedhq/replicated/pkg/platformclient"
 	"github.com/spf13/cobra"
 )
 
@@ -27,7 +28,9 @@ func (r *runners) removeCluster(_ *cobra.Command, args []string) error {
 
 	for _, arg := range args {
 		err := kotsRestClient.RemoveCluster(arg, r.args.removeClusterForce)
-		if err != nil {
+		if errors.Cause(err) == platformclient.ErrForbidden {
+			return ErrCompatibilityMatrixTermsNotAccepted
+		} else if err != nil {
 			return errors.Wrap(err, "remove cluster")
 		}
 	}

--- a/cli/cmd/cluster_versions.go
+++ b/cli/cmd/cluster_versions.go
@@ -30,9 +30,8 @@ func (r *runners) listClusterVersions(_ *cobra.Command, args []string) error {
 
 	cv, err := kotsRestClient.ListClusterVersions()
 	if errors.Cause(err) == platformclient.ErrForbidden {
-		return errors.New("This command is not available for your account or team. Please contact your customer success representative for more information.")
-	}
-	if err != nil {
+		return ErrCompatibilityMatrixTermsNotAccepted
+	} else if err != nil {
 		return errors.Wrap(err, "list cluster versions")
 	}
 


### PR DESCRIPTION
403 means that the compatibility_matrix entitlement is not enabled. This entitlement is enabled when the team has agreed to the c11y matrix terms of service. Instead of a generic message to get the feature enabled, show the link to self-service tos agreement.