### PR TITLE
Pretty-print JSON errors from API

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -265,8 +266,14 @@ func Execute(rootCmd *cobra.Command, stdin io.Reader, stdout io.Writer, stderr i
 		return nil
 	}
 
-	prerunCommand := func(cmd *cobra.Command, args []string) error {
-		if err := preRunSetupAPIs(cmd, args); err != nil {
+	prerunCommand := func(cmd *cobra.Command, args []string) (err error) {
+		if cmd.SilenceErrors { // when SilenceErrors is set, command wants to use custom error printer
+			defer func() {
+				printIfError(err)
+			}()
+		}
+
+		if err = preRunSetupAPIs(cmd, args); err != nil {
 			return errors.Wrap(err, "set up APIs")
 		}
 
@@ -276,7 +283,7 @@ func Execute(rootCmd *cobra.Command, stdin io.Reader, stdout io.Writer, stderr i
 
 		app, appType, err := runCmds.api.GetAppType(appSlugOrID)
 		if err != nil {
-			return err
+			return errors.Wrap(err, "get app type")
 		}
 
 		runCmds.appType = appType
@@ -301,4 +308,20 @@ func Execute(rootCmd *cobra.Command, stdin io.Reader, stdout io.Writer, stderr i
 	runCmds.rootCmd.AddCommand(Version())
 
 	return runCmds.rootCmd.Execute()
+}
+
+func printIfError(err error) {
+	if err == nil {
+		return
+	}
+
+	switch err := errors.Cause(err).(type) {
+	case platformclient.APIError:
+		fmt.Fprintln(os.Stderr, fmt.Sprintf("ERROR: %d", err.StatusCode))
+		fmt.Fprintln(os.Stderr, fmt.Sprintf("METHOD: %s", err.Method))
+		fmt.Fprintln(os.Stderr, fmt.Sprintf("ENDPOINT: %s", err.Endpoint))
+		fmt.Fprintln(os.Stderr, err.Message) // note that this can have multiple lines
+	default:
+		fmt.Fprintf(os.Stderr, "ERROR: %s\n", err.Error())
+	}
 }


### PR DESCRIPTION
Before:

```
$ replicated release promote 167 Unstable
Error: POST https://<redacted>/release/167/promote 400: {"message":"You are attempting to promote a helm-cli-only release to a channel with kots-enabled customers. This could break those customer installations, so this operation is being blocked. You can fix this by either\n1. Disabling KOTS installations on all customers on the Unstable channel\n2. Moving all kots-enabled customers assigned to Unstable to a different channel\n3. Adding the required KOTS custom resources to this release before promoting (it will still be installable with the Helm CLI as long as it contains a helm chart)"}
```

After:

```
$ replicated release promote 167 Unstable
ERROR: 400
METHOD: POST
ENDPOINT: https://<redacted>/release/167/promote
You are attempting to promote a helm-cli-only release to a channel with kots-enabled customers. This could break those customer installations, so this operation is being blocked. You can fix this by either
1. Disabling KOTS installations on all customers on the Unstable channel
2. Moving all kots-enabled customers assigned to Unstable to a different channel
3. Adding the required KOTS custom resources to this release before promoting (it will still be installable with the Helm CLI as long as it contains a helm chart)
```

Before

```
$ replicated release create --chart yaml-kots/postgresql-11.9.2.tgz  --promote Unstable
You are creating a release that will only be installable with the helm CLI.
For more information, see 
https://docs.replicated.com/vendor/helm-install#about-helm-installations-with-replicated

  • Reading chart from yaml-kots/postgresql-11.9.2.tgz ✓  
  • Creating Release ✓  
    • SEQUENCE: 170
  • Promoting ✗  
```

After
```
$ replicated release create --chart yaml-kots/postgresql-11.9.2.tgz  --promote Unstable
You are creating a release that will only be installable with the helm CLI.
For more information, see 
https://docs.replicated.com/vendor/helm-install#about-helm-installations-with-replicated

  • Reading chart from yaml-kots/postgresql-11.9.2.tgz ✓  
  • Creating Release ✓  
    • SEQUENCE: 170
  • Promoting ✗  
ERROR: 400
METHOD: POST
ENDPOINT: https://<redacted>/release/170/promote
You are attempting to promote a helm-cli-only release to a channel with kots-enabled customers. This could break those customer installations, so this operation is being blocked. You can fix this by either
1. Disabling KOTS installations on all customers on the Unstable channel
2. Moving all kots-enabled customers assigned to Unstable to a different channel
3. Adding the required KOTS custom resources to this release before promoting (it will still be installable with the Helm CLI as long as it contains a helm chart)
```