### PR TITLE
fix: remove appID required for cluster cmds

### DIFF
--- a/cli/cmd/cluster_prepare.go
+++ b/cli/cmd/cluster_prepare.go
@@ -45,6 +45,10 @@ replicated cluster prepare --distribution eks --version 1.27 --instance-type c6.
 		SilenceUsage: true,
 
 		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if appSlugOrID == "" {
+				appSlugOrID = os.Getenv("REPLICATED_APP")
+			}
+
 			app, appType, err := r.api.GetAppType(appSlugOrID)
 			if err != nil {
 				return err

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -293,9 +293,9 @@ func Execute(rootCmd *cobra.Command, stdin io.Reader, stdout io.Writer, stderr i
 	collectorsCmd.PersistentPreRunE = prerunCommand
 	customersCmd.PersistentPreRunE = prerunCommand
 	installerCmd.PersistentPreRunE = prerunCommand
-	clusterCmd.PersistentPreRunE = prerunCommand
 	appCmd.PersistentPreRunE = preRunSetupAPIs
 	registryCmd.PersistentPreRunE = preRunSetupAPIs
+	clusterCmd.PersistentPreRunE = preRunSetupAPIs
 	apiCmd.PersistentPreRunE = preRunSetupAPIs
 
 	runCmds.rootCmd.AddCommand(Version())


### PR DESCRIPTION
fix: 
- remove appID required for cluster cmds
- set appID from env `REPlCATED_APP` for `replicated cluster prepare` cmd