### PR TITLE
remove vcpus and memory flags

### DIFF
--- a/cli/cmd/cluster_create.go
+++ b/cli/cmd/cluster_create.go
@@ -29,13 +29,11 @@ func (r *runners) InitClusterCreate(parent *cobra.Command) *cobra.Command {
 	cmd.Flags().StringVar(&r.args.createClusterKubernetesDistribution, "distribution", "kind", "Kubernetes distribution of the cluster to provision")
 	cmd.Flags().StringVar(&r.args.createClusterKubernetesVersion, "version", "v1.25.3", "Kubernetes version to provision (format is distribution dependent)")
 	cmd.Flags().IntVar(&r.args.createClusterNodeCount, "node-count", int(1), "Node count")
-	cmd.Flags().Int64Var(&r.args.createClusterVCpus, "vcpu", int64(4), "Number of vCPUs to request per node")
-	cmd.Flags().Int64Var(&r.args.createClusterMemoryGiB, "memory", int64(16), "Memory (GiB) to request per node")
 	cmd.Flags().Int64Var(&r.args.createClusterDiskGiB, "disk", int64(50), "Disk Size (GiB) to request per node")
 	cmd.Flags().StringVar(&r.args.createClusterTTL, "ttl", "", "Cluster TTL (duration, max 48h)")
 	cmd.Flags().BoolVar(&r.args.createClusterDryRun, "dry-run", false, "Dry run")
 	cmd.Flags().DurationVar(&r.args.createClusterWaitDuration, "wait", time.Second*0, "Wait duration for cluster to be ready (leave empty to not wait)")
-	cmd.Flags().StringVar(&r.args.createClusterInstanceType, "instance-type", "", "the type of instance to use for cloud-based clusters (e.g. x5.xlarge)")
+	cmd.Flags().StringVar(&r.args.createClusterInstanceType, "instance-type", "", "the type of instance to use (e.g. x5.xlarge)")
 
 	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
 
@@ -57,8 +55,6 @@ func (r *runners) createCluster(_ *cobra.Command, args []string) error {
 		KubernetesDistribution: r.args.createClusterKubernetesDistribution,
 		KubernetesVersion:      r.args.createClusterKubernetesVersion,
 		NodeCount:              r.args.createClusterNodeCount,
-		VCpus:                  r.args.createClusterVCpus,
-		MemoryGiB:              r.args.createClusterMemoryGiB,
 		DiskGiB:                r.args.createClusterDiskGiB,
 		TTL:                    r.args.createClusterTTL,
 		DryRun:                 r.args.createClusterDryRun,

--- a/cli/cmd/cluster_prepare.go
+++ b/cli/cmd/cluster_prepare.go
@@ -65,11 +65,9 @@ replicated cluster prepare --distribution eks --version 1.27 --instance-type c6.
 	cmd.Flags().StringVar(&r.args.prepareClusterKubernetesDistribution, "distribution", "kind", "Kubernetes distribution of the cluster to provision")
 	cmd.Flags().StringVar(&r.args.prepareClusterKubernetesVersion, "version", "v1.25.3", "Kubernetes version to provision (format is distribution dependent)")
 	cmd.Flags().IntVar(&r.args.prepareClusterNodeCount, "node-count", int(1), "Node count")
-	cmd.Flags().Int64Var(&r.args.prepareClusterVCpus, "vcpu", int64(4), "Number of vCPUs to request per node")
-	cmd.Flags().Int64Var(&r.args.prepareClusterMemoryGiB, "memory", int64(4), "Memory (GiB) to request per node")
 	cmd.Flags().Int64Var(&r.args.prepareClusterDiskGiB, "disk", int64(50), "Disk Size (GiB) to request per node (Default: 50)")
 	cmd.Flags().StringVar(&r.args.prepareClusterTTL, "ttl", "2h", "Cluster TTL (duration, max 48h)")
-	cmd.Flags().StringVar(&r.args.prepareClusterInstanceType, "instance-type", "", "the type of instance to use for cloud-based clusters (e.g. x5.xlarge)")
+	cmd.Flags().StringVar(&r.args.prepareClusterInstanceType, "instance-type", "", "the type of instance to use clusters (e.g. x5.xlarge)")
 
 	// todo maybe remove
 	cmd.Flags().StringVar(&r.args.prepareClusterID, "cluster-id", "", "cluster id")
@@ -122,8 +120,6 @@ func (r *runners) prepareCluster(_ *cobra.Command, args []string) error {
 			KubernetesDistribution: r.args.prepareClusterKubernetesDistribution,
 			KubernetesVersion:      r.args.prepareClusterKubernetesVersion,
 			NodeCount:              r.args.prepareClusterNodeCount,
-			VCpus:                  r.args.prepareClusterVCpus,
-			MemoryGiB:              r.args.prepareClusterMemoryGiB,
 			DiskGiB:                r.args.prepareClusterDiskGiB,
 			TTL:                    r.args.prepareClusterTTL,
 			InstanceType:           r.args.prepareClusterInstanceType,

--- a/cli/cmd/runner.go
+++ b/cli/cmd/runner.go
@@ -165,8 +165,6 @@ type runnerArgs struct {
 	createClusterKubernetesDistribution string
 	createClusterKubernetesVersion      string
 	createClusterNodeCount              int
-	createClusterVCpus                  int64
-	createClusterMemoryGiB              int64
 	createClusterDiskGiB                int64
 	createClusterDryRun                 bool
 	createClusterTTL                    string
@@ -178,8 +176,6 @@ type runnerArgs struct {
 	prepareClusterKubernetesDistribution string
 	prepareClusterKubernetesVersion      string
 	prepareClusterNodeCount              int
-	prepareClusterVCpus                  int64
-	prepareClusterMemoryGiB              int64
 	prepareClusterDiskGiB                int64
 	prepareClusterTTL                    string
 	prepareClusterInstanceType           string

--- a/cli/print/clusters.go
+++ b/cli/print/clusters.go
@@ -9,7 +9,7 @@ import (
 	"github.com/replicatedhq/replicated/pkg/types"
 )
 
-// TODO: implement a -o wide, and expose nodecount, vcpus and memory also?
+// TODO: implement a -o wide, and expose nodecount also?
 var clustersTmplSrc = `ID	NAME	DISTRIBUTION	VERSION	STATUS	CREATED	EXPIRES
 {{ range . -}}
 {{ .ID }}	{{ .Name }}	{{ .KubernetesDistribution}}	{{ .KubernetesVersion	}}	{{ .Status }}	{{ .CreatedAt}}	{{if .ExpiresAt.IsZero}}-{{else}}{{ .ExpiresAt }}{{end}}

--- a/pkg/kotsclient/cluster_create.go
+++ b/pkg/kotsclient/cluster_create.go
@@ -12,8 +12,6 @@ type CreateClusterRequest struct {
 	KubernetesDistribution string `json:"kubernetes_distribution"`
 	KubernetesVersion      string `json:"kubernetes_version"`
 	NodeCount              int    `json:"node_count"`
-	VCpus                  int64  `json:"vcpus"`
-	MemoryGiB              int64  `json:"memory_gib"`
 	DiskGiB                int64  `json:"disk_gib"`
 	TTL                    string `json:"ttl"`
 	InstanceType           string `json:"instance_type"`
@@ -30,8 +28,6 @@ type CreateClusterOpts struct {
 	KubernetesDistribution string
 	KubernetesVersion      string
 	NodeCount              int
-	VCpus                  int64
-	MemoryGiB              int64
 	DiskGiB                int64
 	TTL                    string
 	DryRun                 bool
@@ -48,8 +44,6 @@ var defaultCreateClusterOpts = CreateClusterOpts{
 	KubernetesDistribution: "kind",
 	KubernetesVersion:      "v1.25.3",
 	NodeCount:              int(1),
-	VCpus:                  int64(4),
-	MemoryGiB:              int64(4),
 	DiskGiB:                int64(50),
 	TTL:                    "2h",
 	InstanceType:           "",
@@ -66,12 +60,6 @@ func (c *VendorV3Client) CreateCluster(opts CreateClusterOpts) (*types.Cluster, 
 	if opts.NodeCount == int(0) {
 		opts.NodeCount = defaultCreateClusterOpts.NodeCount
 	}
-	if opts.VCpus == int64(0) {
-		opts.VCpus = defaultCreateClusterOpts.VCpus
-	}
-	if opts.MemoryGiB == int64(0) {
-		opts.MemoryGiB = defaultCreateClusterOpts.MemoryGiB
-	}
 	if opts.DiskGiB == int64(0) {
 		opts.DiskGiB = defaultCreateClusterOpts.DiskGiB
 	}
@@ -84,8 +72,6 @@ func (c *VendorV3Client) CreateCluster(opts CreateClusterOpts) (*types.Cluster, 
 		KubernetesDistribution: opts.KubernetesDistribution,
 		KubernetesVersion:      opts.KubernetesVersion,
 		NodeCount:              opts.NodeCount,
-		VCpus:                  opts.VCpus,
-		MemoryGiB:              opts.MemoryGiB,
 		DiskGiB:                opts.DiskGiB,
 		TTL:                    opts.TTL,
 		InstanceType:           opts.InstanceType,

--- a/pkg/types/cluster.go
+++ b/pkg/types/cluster.go
@@ -8,8 +8,6 @@ type Cluster struct {
 	KubernetesDistribution string `json:"kubernetes_distribution"`
 	KubernetesVersion      string `json:"kubernetes_version"`
 	NodeCount              int    `json:"node_count"`
-	VCpus                  int64  `json:"vcpus"`
-	MemoryGiB              int64  `json:"memory_gib"`
 	DiskGiB                int64  `json:"disk_gib"`
 
 	Status    string    `json:"status"`


### PR DESCRIPTION
This starts to use the new r1.<size> instance types instead.

Before this PR (and other supporting PRs), VM based instances required a vcpus and memory flag while cloud instances required an instance-type flag. This was a bad experience and worse since we only supported powers of 2 for vcpus and balanced (1 by 4) instance specs. Now we have standard instance types and a consistent API and CLI to request VM instances.