### PR TITLE
fix: chart prepare cmd

### DIFF
--- a/cli/cmd/cluster_prepare.go
+++ b/cli/cmd/cluster_prepare.go
@@ -185,7 +185,7 @@ func (r *runners) prepareCluster(_ *cobra.Command, args []string) error {
 	// to be pushed to the oci registry. this is a terrible hack working
 	// around that part. a pr is in progress to deliver this status
 
-	if len(release.ChartNames) == 0 {
+	if len(release.Charts) == 0 {
 		return errors.New("no charts found in release")
 	}
 
@@ -194,8 +194,8 @@ func (r *runners) prepareCluster(_ *cobra.Command, args []string) error {
 	// run preflights
 
 	// install the chart or application
-	for _, chartName := range release.ChartNames {
-		output, err := installChartRelease(a.Slug, release.Sequence, chartName, email, customer.InstallationID, kubeconfig, r.args.prepareClusterValuesPath, r.args.prepareClusterValueItems)
+	for _, chart := range release.Charts {
+		output, err := installChartRelease(a.Slug, release.Sequence, chart.Name, email, customer.InstallationID, kubeconfig, r.args.prepareClusterValuesPath, r.args.prepareClusterValueItems)
 		if err != nil {
 			return errors.Wrap(err, "install release")
 		}

--- a/pkg/kotsclient/release.go
+++ b/pkg/kotsclient/release.go
@@ -90,9 +90,9 @@ func (c *VendorV3Client) CreateRelease(appID string, multiyaml string) (*types.R
 	}
 
 	releaseInfo := types.ReleaseInfo{
-		AppID:      response.Release.AppID,
-		Sequence:   response.Release.Sequence,
-		ChartNames: response.Release.ChartNames,
+		AppID:    response.Release.AppID,
+		Sequence: response.Release.Sequence,
+		Charts:   response.Release.Charts,
 	}
 
 	return &releaseInfo, nil

--- a/pkg/types/release.go
+++ b/pkg/types/release.go
@@ -2,6 +2,15 @@ package types
 
 import "time"
 
+type ChartStatus string
+
+var (
+	ChartStatusUnknown ChartStatus = "unknown"
+	ChartStatusPushing ChartStatus = "pushing"
+	ChartStatusPushed  ChartStatus = "pushed"
+	ChartStatusError   ChartStatus = "error"
+)
+
 type ReleaseInfo struct {
 	ActiveChannels []Channel
 	AppID          string
@@ -10,7 +19,7 @@ type ReleaseInfo struct {
 	Editable       bool
 	Sequence       int64
 	Version        string
-	ChartNames     []string
+	Charts         []Chart
 }
 
 type LintMessage struct {
@@ -70,7 +79,15 @@ type KotsAppRelease struct {
 	ReleaseNotes         string     `json:"releaseNotes"`
 	IsReleaseNotEditable bool       `json:"isReleaseNotEditable"`
 	Channels             []*Channel `json:"channels"`
-	ChartNames           []string   `json:"chartNames"`
+	Charts               []Chart    `json:"charts"`
+}
+
+type Chart struct {
+	Name      string      `json:"name"`
+	Version   string      `json:"version"`
+	Status    ChartStatus `json:"status"`
+	Error     string      `json:"error,omitempty"`
+	UpdatedAt *time.Time  `json:"updatedAt,omitempty"`
 }
 
 type EntitlementValue struct {


### PR DESCRIPTION
- use charts struct from vendor-api
https://github.com/replicatedhq/vandoor/pull/3891

`ChartNames` was changed to `Charts` which breaks the `cluster prepare` cmd
https://github.com/replicatedhq/vandoor/pull/3891/files#diff-352bc1b2581837f7b0ebd288c4249b22d7a67891f98956d5cc971f1ea9cc6a63R82-R84

