### PR TITLE
feat: validate release status during cluster prepare cmd

### DIFF
--- a/cli/cmd/cluster_prepare_test.go
+++ b/cli/cmd/cluster_prepare_test.go
@@ -13,8 +13,8 @@ func Test_areReleaseChartsReady(t *testing.T) {
 		want    bool
 		wantErr bool
 	}{
-		{"nil charts", nil, false, false},
-		{"no charts", []types.Chart{}, false, false},
+		{"nil charts", nil, false, true},
+		{"no charts", []types.Chart{}, false, true},
 		{"one chart, no status", []types.Chart{{}}, false, true},
 		{"one chart, status unkown", []types.Chart{{Status: types.ChartStatusUnknown}}, false, false},
 		{"one chart, status pushing", []types.Chart{{Status: types.ChartStatusPushing}}, false, false},
@@ -35,7 +35,7 @@ func Test_areReleaseChartsReady(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := areReleaseChartsReady(tt.charts)
+			got, err := areReleaseChartsPushed(tt.charts)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("areReleaseChartsReady() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/cli/cmd/cluster_prepare_test.go
+++ b/cli/cmd/cluster_prepare_test.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/replicatedhq/replicated/pkg/types"
+)
+
+func Test_areReleaseChartsReady(t *testing.T) {
+	tests := []struct {
+		name    string
+		charts  []types.Chart
+		want    bool
+		wantErr bool
+	}{
+		{"nil charts", nil, false, false},
+		{"no charts", []types.Chart{}, false, false},
+		{"one chart, no status", []types.Chart{{}}, false, true},
+		{"one chart, status unkown", []types.Chart{{Status: types.ChartStatusUnknown}}, false, false},
+		{"one chart, status pushing", []types.Chart{{Status: types.ChartStatusPushing}}, false, false},
+		{"one chart, status pushed", []types.Chart{{Status: types.ChartStatusPushed}}, true, false},
+		{"one chart, status error", []types.Chart{{Status: types.ChartStatusError}}, false, true},
+		{"two charts, status pushed", []types.Chart{{Status: types.ChartStatusPushed}, {Status: types.ChartStatusPushed}}, true, false},
+		{"two charts, status pushed and pushing", []types.Chart{{Status: types.ChartStatusPushed}, {Status: types.ChartStatusPushing}}, false, false},
+		{"two charts, status pushed and error", []types.Chart{{Status: types.ChartStatusPushed}, {Status: types.ChartStatusError}}, false, true},
+		{"two charts, status pushed and unknown", []types.Chart{{Status: types.ChartStatusPushed}, {Status: types.ChartStatusUnknown}}, false, false},
+		{"two charts, status pushing and error", []types.Chart{{Status: types.ChartStatusPushing}, {Status: types.ChartStatusError}}, false, true},
+		{"two charts, status pushing and unknown", []types.Chart{{Status: types.ChartStatusPushing}, {Status: types.ChartStatusUnknown}}, false, false},
+		{"two charts, status error and unknown", []types.Chart{{Status: types.ChartStatusError}, {Status: types.ChartStatusUnknown}}, false, true},
+		{"two charts, status error and error", []types.Chart{{Status: types.ChartStatusError}, {Status: types.ChartStatusError}}, false, true},
+		{"three charts, status pushed, pushing, and error", []types.Chart{{Status: types.ChartStatusPushed}, {Status: types.ChartStatusPushing}, {Status: types.ChartStatusError}}, false, true},
+		{"three charts, status pushed, pushing, and unknown", []types.Chart{{Status: types.ChartStatusPushed}, {Status: types.ChartStatusPushing}, {Status: types.ChartStatusUnknown}}, false, false},
+		{"three charts, status pushed, error, and unknown", []types.Chart{{Status: types.ChartStatusPushed}, {Status: types.ChartStatusError}, {Status: types.ChartStatusUnknown}}, false, true},
+		{"four charts, status pushed, pushing, error, and unknown", []types.Chart{{Status: types.ChartStatusPushed}, {Status: types.ChartStatusPushing}, {Status: types.ChartStatusError}, {Status: types.ChartStatusUnknown}}, false, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := areReleaseChartsReady(tt.charts)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("areReleaseChartsReady() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("areReleaseChartsReady() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cli/print/release.go
+++ b/cli/print/release.go
@@ -4,7 +4,7 @@ import (
 	"text/tabwriter"
 	"text/template"
 
-	releases "github.com/replicatedhq/replicated/gen/go/v1"
+	"github.com/replicatedhq/replicated/pkg/types"
 )
 
 var releaseTmplSrc = `SEQUENCE:	{{ .Sequence }}
@@ -16,7 +16,7 @@ CONFIG:
 
 var releaseTmpl = template.Must(template.New("Release").Funcs(funcs).Parse(releaseTmplSrc))
 
-func Release(w *tabwriter.Writer, release *releases.AppRelease) error {
+func Release(w *tabwriter.Writer, release *types.AppRelease) error {
 	if err := releaseTmpl.Execute(w, release); err != nil {
 		return err
 	}

--- a/client/release.go
+++ b/client/release.go
@@ -3,7 +3,6 @@ package client
 import (
 	"errors"
 
-	releases "github.com/replicatedhq/replicated/gen/go/v1"
 	"github.com/replicatedhq/replicated/pkg/types"
 )
 
@@ -100,10 +99,20 @@ func (c *Client) TestRelease(appID string, appType string, sequence int64) (stri
 	return "", errors.New("unsupported app type")
 }
 
-func (c *Client) GetRelease(appID string, appType string, sequence int64) (*releases.AppRelease, error) {
+func (c *Client) GetRelease(appID string, appType string, sequence int64) (*types.AppRelease, error) {
 
 	if appType == "platform" {
-		return c.PlatformClient.GetRelease(appID, sequence)
+		release, err := c.PlatformClient.GetRelease(appID, sequence)
+		if err != nil {
+			return nil, err
+		}
+		return &types.AppRelease{
+			Config:    release.Config,
+			CreatedAt: release.CreatedAt,
+			Editable:  release.Editable,
+			EditedAt:  release.EditedAt,
+			Sequence:  release.Sequence,
+		}, nil
 	} else if appType == "kots" {
 		return c.KotsClient.GetRelease(appID, sequence)
 	}

--- a/pkg/kots/release/save.go
+++ b/pkg/kots/release/save.go
@@ -8,13 +8,13 @@ import (
 	"path/filepath"
 
 	"github.com/pkg/errors"
-	releases "github.com/replicatedhq/replicated/gen/go/v1"
-	"github.com/replicatedhq/replicated/pkg/kots/release/types"
+	releaseTypes "github.com/replicatedhq/replicated/pkg/kots/release/types"
 	"github.com/replicatedhq/replicated/pkg/logger"
+	"github.com/replicatedhq/replicated/pkg/types"
 )
 
-func Save(dstDir string, release *releases.AppRelease, log *logger.Logger) error {
-	var releaseYamls []types.KotsSingleSpec
+func Save(dstDir string, release *types.AppRelease, log *logger.Logger) error {
+	var releaseYamls []releaseTypes.KotsSingleSpec
 	if err := json.Unmarshal([]byte(release.Config), &releaseYamls); err != nil {
 		return errors.Wrap(err, "unmarshal release yamls")
 	}
@@ -31,7 +31,7 @@ func Save(dstDir string, release *releases.AppRelease, log *logger.Logger) error
 
 }
 
-func writeReleaseFiles(dstDir string, specs []types.KotsSingleSpec, log *logger.Logger) error {
+func writeReleaseFiles(dstDir string, specs []releaseTypes.KotsSingleSpec, log *logger.Logger) error {
 	for _, spec := range specs {
 		if len(spec.Children) > 0 {
 			err := writeReleaseDirectory(dstDir, spec, log)
@@ -49,7 +49,7 @@ func writeReleaseFiles(dstDir string, specs []types.KotsSingleSpec, log *logger.
 	return nil
 }
 
-func writeReleaseDirectory(dstDir string, spec types.KotsSingleSpec, log *logger.Logger) error {
+func writeReleaseDirectory(dstDir string, spec releaseTypes.KotsSingleSpec, log *logger.Logger) error {
 	log.ChildActionWithoutSpinner(spec.Path)
 
 	if err := os.Mkdir(filepath.Join(dstDir, spec.Path), 0755); err != nil && !os.IsExist(err) {
@@ -64,7 +64,7 @@ func writeReleaseDirectory(dstDir string, spec types.KotsSingleSpec, log *logger
 	return nil
 }
 
-func writeReleaseFile(dstDir string, spec types.KotsSingleSpec, log *logger.Logger) error {
+func writeReleaseFile(dstDir string, spec releaseTypes.KotsSingleSpec, log *logger.Logger) error {
 	log.ChildActionWithoutSpinner(spec.Path)
 
 	var content []byte

--- a/pkg/kots/release/save_test.go
+++ b/pkg/kots/release/save_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
-	releases "github.com/replicatedhq/replicated/gen/go/v1"
 	"github.com/replicatedhq/replicated/pkg/logger"
+	"github.com/replicatedhq/replicated/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -26,7 +26,7 @@ func Test_Save(t *testing.T) {
 
 		defer os.RemoveAll(dstDir)
 
-		release := &releases.AppRelease{
+		release := &types.AppRelease{
 			Config: string(releaseToSave),
 		}
 		err = Save(dstDir, release, logger.NewLogger(os.Stdout))

--- a/pkg/kotsclient/release.go
+++ b/pkg/kotsclient/release.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	releases "github.com/replicatedhq/replicated/gen/go/v1"
 	"github.com/replicatedhq/replicated/pkg/graphql"
 	"github.com/replicatedhq/replicated/pkg/types"
 )
@@ -44,7 +43,7 @@ func (c *VendorV3Client) TestRelease(appID string, sequence int64) (string, erro
 	return "", nil
 }
 
-func (c *VendorV3Client) GetRelease(appID string, sequence int64) (*releases.AppRelease, error) {
+func (c *VendorV3Client) GetRelease(appID string, sequence int64) (*types.AppRelease, error) {
 	resp := types.KotsGetReleaseResponse{}
 
 	path := fmt.Sprintf("/v3/app/%s/release/%v", appID, sequence)
@@ -54,11 +53,12 @@ func (c *VendorV3Client) GetRelease(appID string, sequence int64) (*releases.App
 		return nil, errors.Wrap(err, "failed to get release")
 	}
 
-	appRelease := releases.AppRelease{
+	appRelease := types.AppRelease{
 		Config:    resp.Release.Spec,
 		CreatedAt: resp.Release.CreatedAt,
 		Editable:  !resp.Release.IsReleaseNotEditable,
 		Sequence:  resp.Release.Sequence,
+		Charts:    resp.Release.Charts,
 	}
 
 	return &appRelease, nil

--- a/pkg/types/release.go
+++ b/pkg/types/release.go
@@ -94,3 +94,12 @@ type EntitlementValue struct {
 	Name  string `json:"name,omitempty"`
 	Value string `json:"value,omitempty"`
 }
+
+type AppRelease struct {
+	Config    string    `json:"config,omitempty"`
+	CreatedAt time.Time `json:"createdAt,omitempty"`
+	Editable  bool      `json:"editable,omitempty"`
+	EditedAt  time.Time `json:"editedAt,omitempty"`
+	Sequence  int64     `json:"sequence,omitempty"`
+	Charts    []Chart   `json:"charts,omitempty"`
+}


### PR DESCRIPTION
validate release status during cluster prepare cmd
- using chart status from release, validate if charts are pushed successfully before installing the helm charts
https://github.com/replicatedhq/vandoor/blob/11764ef0728ee481aa19a8e95709b655252a0925/vendor-api/kots/release/release.go#L34-L41

- if a release chart is in `pushing` or `unkown` state, sleep for 2 seconds and retry the status check.
- exit and return error if  release chart are not in status `pushed` within `(10 * no of charts) seconds`