### PR TITLE
Remove all clusters

### DIFF
--- a/cli/cmd/cluster_rm.go
+++ b/cli/cmd/cluster_rm.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/replicated/pkg/platformclient"
 	"github.com/spf13/cobra"
@@ -8,23 +10,48 @@ import (
 
 func (r *runners) InitClusterRemove(parent *cobra.Command) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:          "rm ID [ID …]",
-		Short:        "remove test clusters",
-		Long:         `remove test clusters`,
+		Use:   "rm ID [ID …]",
+		Short: "remove test clusters",
+		Long: `Removes a cluster immediately.
+
+You can specify the --all flag to terminate all clusters.`,
 		RunE:         r.removeCluster,
 		SilenceUsage: true,
-		Args:         cobra.MinimumNArgs(1),
 	}
 	parent.AddCommand(cmd)
 
-	cmd.Flags().BoolVar(&r.args.removeClusterForce, "force", false, "force remove cluster")
+	cmd.Flags().BoolVar(&r.args.removeClusterAll, "all", false, "remove all clusters")
 
 	return cmd
 }
 
 func (r *runners) removeCluster(_ *cobra.Command, args []string) error {
+	if len(args) == 0 && !r.args.removeClusterAll {
+		return errors.New("ID or --all flag required")
+	} else if len(args) > 0 && r.args.removeClusterAll {
+		return errors.New("cannot specify ID and --all flag")
+	}
+
+	if r.args.removeClusterAll {
+		clusters, err := r.kotsAPI.ListClusters(false, nil, nil)
+		if err != nil {
+			return errors.Wrap(err, "list clusters")
+		}
+
+		for _, cluster := range clusters {
+			err := r.kotsAPI.RemoveCluster(cluster.ID)
+			if errors.Cause(err) == platformclient.ErrForbidden {
+				return ErrCompatibilityMatrixTermsNotAccepted
+			} else if err != nil {
+				return errors.Wrap(err, "remove cluster")
+			} else {
+				fmt.Printf("removed cluster %s\n", cluster.ID)
+			}
+		}
+	}
+
 	for _, arg := range args {
-		err := r.kotsAPI.RemoveCluster(arg, r.args.removeClusterForce)
+		err := r.kotsAPI.RemoveCluster(arg)
 		if errors.Cause(err) == platformclient.ErrForbidden {
 			return ErrCompatibilityMatrixTermsNotAccepted
 		} else if err != nil {

--- a/cli/cmd/runner.go
+++ b/cli/cmd/runner.go
@@ -187,7 +187,7 @@ type runnerArgs struct {
 	prepareClusterValuesPath             []string
 	prepareClusterValueItems             []string
 
-	removeClusterForce bool
+	removeClusterAll bool
 
 	lsAppVersion                            string
 	lsVersionsClusterKubernetesDistribution string

--- a/pkg/kotsclient/cluster_rm.go
+++ b/pkg/kotsclient/cluster_rm.go
@@ -13,14 +13,10 @@ type RemoveClusterResponse struct {
 	Error string `json:"error"`
 }
 
-func (c *VendorV3Client) RemoveCluster(id string, force bool) error {
+func (c *VendorV3Client) RemoveCluster(id string) error {
 	resp := RemoveClusterResponse{}
 
 	url := fmt.Sprintf("/v3/cluster/%s", id)
-	if force {
-		url = fmt.Sprintf("%s?force=true", url)
-	}
-
 	err := c.DoJSON("DELETE", url, http.StatusOK, nil, &resp)
 	if err != nil {
 		return err


### PR DESCRIPTION
This adds a new `--all` flag to cluster rm. It also requires a `--force` flag to remove a running cluster.