### PR TITLE
Support creating Helm CLI only customers

### DIFF
--- a/cli/cmd/customer_create.go
+++ b/cli/cmd/customer_create.go
@@ -26,6 +26,7 @@ func (r *runners) InitCustomersCreateCommand(parent *cobra.Command) *cobra.Comma
 	cmd.Flags().BoolVar(&r.args.customerCreateIsAirgapEnabled, "airgap", false, "If set, the license will allow airgap installs.")
 	cmd.Flags().BoolVar(&r.args.customerCreateIsGitopsSupported, "gitops", false, "If set, the license will allow the GitOps usage.")
 	cmd.Flags().BoolVar(&r.args.customerCreateIsSnapshotSupported, "snapshot", false, "If set, the license will allow Snapshots.")
+	cmd.Flags().BoolVar(&r.args.customerCreateIsKotInstallEnabled, "kots-install", true, "If set, the license will allow KOTS install. Otherwise license will allow Helm CLI installs only.")
 	cmd.Flags().StringVar(&r.args.customerCreateEmail, "email", "", "Email address of the customer that is to be created.")
 	cmd.Flags().StringVar(&r.args.customerCreateType, "type", "dev", "The license type to create. One of: dev|trial|paid|community|test (default: dev)")
 	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
@@ -68,6 +69,7 @@ func (r *runners) createCustomer(_ *cobra.Command, _ []string) error {
 		IsAirgapEnabled:     r.args.customerCreateIsAirgapEnabled,
 		IsGitopsSupported:   r.args.customerCreateIsGitopsSupported,
 		IsSnapshotSupported: r.args.customerCreateIsSnapshotSupported,
+		IsKotInstallEnabled: r.args.customerCreateIsKotInstallEnabled,
 		LicenseType:         r.args.customerCreateType,
 		Email:               r.args.customerCreateEmail,
 	}

--- a/cli/cmd/runner.go
+++ b/cli/cmd/runner.go
@@ -85,6 +85,7 @@ type runnerArgs struct {
 	customerCreateIsAirgapEnabled     bool
 	customerCreateIsGitopsSupported   bool
 	customerCreateIsSnapshotSupported bool
+	customerCreateIsKotInstallEnabled bool
 	customerCreateEmail               string
 	customerCreateType                string
 

--- a/pkg/kotsclient/customer_create.go
+++ b/pkg/kotsclient/customer_create.go
@@ -17,6 +17,7 @@ type CreateCustomerRequest struct {
 	IsAirgapEnabled     bool   `json:"is_airgap_enabled"`
 	IsGitopsSupported   bool   `json:"is_gitops_supported"`
 	IsSnapshotSupported bool   `json:"is_snapshot_supported"`
+	IsKotInstallEnabled bool   `json:"is_kots_install_enabled"`
 	Email               string `json:"email,omitempty"`
 }
 
@@ -32,6 +33,7 @@ type CreateCustomerOpts struct {
 	IsAirgapEnabled     bool
 	IsGitopsSupported   bool
 	IsSnapshotSupported bool
+	IsKotInstallEnabled bool
 	LicenseType         string
 	Email               string
 }
@@ -45,6 +47,7 @@ func (c *VendorV3Client) CreateCustomer(opts CreateCustomerOpts) (*types.Custome
 		IsAirgapEnabled:     opts.IsAirgapEnabled,
 		IsGitopsSupported:   opts.IsGitopsSupported,
 		IsSnapshotSupported: opts.IsSnapshotSupported,
+		IsKotInstallEnabled: opts.IsKotInstallEnabled,
 		Email:               opts.Email,
 	}
 


### PR DESCRIPTION
```
$ ./bin/replicated customer create --channel Unstable --name "test from cli" --kots-install=false
Error: create customer: create customer: POST https://<redacted>/v3/customer 400: email is required for customers without kots install enabled
```