### PR TITLE
Don't show kots install commands for Helm channels

### DIFF
--- a/cli/print/channel_attributes.go
+++ b/cli/print/channel_attributes.go
@@ -13,20 +13,25 @@ import (
 var channelAttrsTmplSrc = `ID:	{{ .Chan.ID }}
 NAME:	{{ .Chan.Name }}
 DESCRIPTION:	{{ .Chan.Description }}
-RELEASE:	{{ if ge .Chan.ReleaseSequence 1 }}{{ .Chan.ReleaseSequence }}{{else}}	{{end}}
-VERSION:	{{ .Chan.ReleaseLabel }}{{ with .Existing }}
+RELEASE:	{{ if ge .Chan.ReleaseSequence 1 }}{{ .Chan.ReleaseSequence }}{{ else }}	{{ end }}
+VERSION:	{{ .Chan.ReleaseLabel }}
+{{ if not .Chan.IsHelmOnly -}}
+{{ with .Existing -}}
 EXISTING:
 
 {{ . }}
-{{end}}{{with .Embedded}}
+{{ end }}
+{{ with .Embedded -}}
 EMBEDDED:
 
 {{ . }}
-{{end}}{{with .Airgap}}
+{{ end }}
+{{ with .Airgap -}}
 AIRGAP:
 
 {{ . }}
-{{end}}
+{{ end -}}
+{{ end -}}
 `
 
 var channelAttrsTmpl = template.Must(template.New("ChannelAttributes").Parse(channelAttrsTmplSrc))

--- a/cli/print/channel_attributes_test.go
+++ b/cli/print/channel_attributes_test.go
@@ -1,0 +1,70 @@
+package print
+
+import (
+	"bytes"
+	"regexp"
+	"testing"
+	"text/tabwriter"
+
+	"github.com/replicatedhq/replicated/pkg/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ChannelAttrs(t *testing.T) {
+	tests := []struct {
+		name       string
+		appType    string
+		appSlug    string
+		appChan    *types.Channel
+		matchRegex *regexp.Regexp
+		wantMatch  bool
+	}{
+		{
+			name:    "kots channel with install commands",
+			appType: "kots",
+			appSlug: "myapp",
+			appChan: &types.Channel{
+				ID:              "123",
+				Name:            "mychannel",
+				Description:     "mychannel description",
+				ReleaseSequence: 1,
+				ReleaseLabel:    "v1.0.0",
+				IsHelmOnly:      false,
+			},
+			matchRegex: regexp.MustCompile(`(?s).*EXISTING:.*EMBEDDED:.*AIRGAP:.*`), // (?s) mean match line breaks
+			wantMatch:  true,
+		},
+		{
+			name:    "kots channel without install commands",
+			appType: "kots",
+			appSlug: "myapp",
+			appChan: &types.Channel{
+				ID:              "123",
+				Name:            "mychannel",
+				Description:     "mychannel description",
+				ReleaseSequence: 1,
+				ReleaseLabel:    "v1.0.0",
+				IsHelmOnly:      true,
+			},
+			matchRegex: regexp.MustCompile(`(?s).*EXISTING:.*EMBEDDED:.*AIRGAP:.*`), // (?s) mean match line breaks
+			wantMatch:  false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out bytes.Buffer
+			w := tabwriter.NewWriter(&out, 0, 8, 4, ' ', tabwriter.TabIndent)
+
+			err := ChannelAttrs("text", w, tt.appType, tt.appSlug, tt.appChan)
+			assert.NoError(t, err)
+
+			w.Flush()
+
+			if tt.wantMatch {
+				assert.Regexp(t, tt.matchRegex, out.String())
+			} else {
+				assert.NotRegexp(t, tt.matchRegex, out.String())
+			}
+		})
+	}
+}

--- a/cli/print/channels.go
+++ b/cli/print/channels.go
@@ -15,7 +15,7 @@ var channelsTmplSrc = `ID	NAME	RELEASE	VERSION
 
 var channelsTmpl = template.Must(template.New("channels").Parse(channelsTmplSrc))
 
-func Channels(w *tabwriter.Writer, channels []types.Channel) error {
+func Channels(w *tabwriter.Writer, channels []*types.Channel) error {
 	if err := channelsTmpl.Execute(w, channels); err != nil {
 		return err
 	}

--- a/client/channel.go
+++ b/client/channel.go
@@ -9,7 +9,7 @@ import (
 	"github.com/replicatedhq/replicated/pkg/types"
 )
 
-func (c *Client) ListChannels(appID string, appType string, channelName string) ([]types.Channel, error) {
+func (c *Client) ListChannels(appID string, appType string, channelName string) ([]*types.Channel, error) {
 
 	if appType == "platform" {
 		platformChannels, err := c.PlatformClient.ListChannels(appID)
@@ -17,9 +17,9 @@ func (c *Client) ListChannels(appID string, appType string, channelName string) 
 			return nil, err
 		}
 
-		channels := make([]types.Channel, 0, 0)
+		channels := make([]*types.Channel, 0, 0)
 		for _, platformChannel := range platformChannels {
-			channel := types.Channel{
+			channel := &types.Channel{
 				ID:              platformChannel.Id,
 				Name:            platformChannel.Name,
 				Description:     platformChannel.Description,
@@ -68,7 +68,7 @@ func (c *Client) ArchiveChannel(appID string, appType string, channelID string) 
 
 }
 
-func (c *Client) CreateChannel(appID string, appType string, name string, description string) ([]types.Channel, error) {
+func (c *Client) CreateChannel(appID string, appType string, name string, description string) ([]*types.Channel, error) {
 
 	if appType == "platform" {
 		if err := c.PlatformClient.CreateChannel(appID, name, description); err != nil {
@@ -133,19 +133,19 @@ func (c *Client) GetChannelByName(appID string, appType string, name string) (*t
 	return c.GetOrCreateChannelByName(opts)
 }
 
-func (c *Client) findChannel(channels []types.Channel, name string) (*types.Channel, int, error) {
+func (c *Client) findChannel(channels []*types.Channel, nameOrID string) (*types.Channel, int, error) {
 	matchingChannels := make([]*types.Channel, 0)
 	for _, channel := range channels {
-		if channel.ID == name || channel.Name == name {
-			matchingChannels = append(matchingChannels, channel.Copy())
+		if channel.ID == nameOrID || channel.Name == nameOrID {
+			matchingChannels = append(matchingChannels, channel)
 		}
 	}
 	if len(matchingChannels) == 0 {
-		return nil, 0, errors.Errorf("No channel %q ", name)
+		return nil, 0, errors.Errorf("No channel %q ", nameOrID)
 	}
 
 	if len(matchingChannels) > 1 {
-		return nil, len(matchingChannels), fmt.Errorf("channel %q is ambiguous, please use channel ID", name)
+		return nil, len(matchingChannels), fmt.Errorf("channel %q is ambiguous, please use channel ID", nameOrID)
 	}
 	return matchingChannels[0], 1, nil
 }

--- a/pkg/kotsclient/channel.go
+++ b/pkg/kotsclient/channel.go
@@ -32,25 +32,15 @@ func (c *VendorV3Client) ListKotsChannels(appID string, channelName string, excl
 	return response.Channels, nil
 }
 
-func (c *VendorV3Client) ListChannels(appID string, channelName string) ([]types.Channel, error) {
+func (c *VendorV3Client) ListChannels(appID string, channelName string) ([]*types.Channel, error) {
 	kotsChannels, err := c.ListKotsChannels(appID, channelName, true)
 	if err != nil {
 		return nil, err
 	}
 
-	channels := make([]types.Channel, 0)
+	channels := make([]*types.Channel, 0)
 	for _, kotsChannel := range kotsChannels {
-		channel := types.Channel{
-			ID:              kotsChannel.Id,
-			Name:            kotsChannel.Name,
-			Description:     kotsChannel.Description,
-			Slug:            kotsChannel.ChannelSlug,
-			ReleaseSequence: int64(kotsChannel.ReleaseSequence),
-			ReleaseLabel:    kotsChannel.CurrentVersion,
-			IsArchived:      kotsChannel.IsArchived,
-		}
-
-		channels = append(channels, channel)
+		channels = append(channels, kotsChannel.ToChannel())
 	}
 
 	return channels, nil
@@ -73,15 +63,7 @@ func (c *VendorV3Client) CreateChannel(appID, name, description string) (*types.
 		return nil, errors.Wrap(err, "create channel")
 	}
 
-	return &types.Channel{
-		ID:              response.Channel.Id,
-		Name:            response.Channel.Name,
-		Description:     response.Channel.Description,
-		Slug:            response.Channel.ChannelSlug,
-		ReleaseSequence: int64(response.Channel.ReleaseSequence),
-		ReleaseLabel:    response.Channel.CurrentVersion,
-		IsArchived:      response.Channel.IsArchived,
-	}, nil
+	return response.Channel.ToChannel(), nil
 }
 
 func (c *VendorV3Client) GetChannel(appID string, channelID string) (*types.Channel, error) {
@@ -96,15 +78,7 @@ func (c *VendorV3Client) GetChannel(appID string, channelID string) (*types.Chan
 		return nil, errors.Wrap(err, "get app channel")
 	}
 
-	return &types.Channel{
-		ID:              response.Channel.Id,
-		Name:            response.Channel.Name,
-		Description:     response.Channel.Description,
-		Slug:            response.Channel.ChannelSlug,
-		ReleaseSequence: int64(response.Channel.ReleaseSequence),
-		ReleaseLabel:    response.Channel.CurrentVersion,
-		IsArchived:      response.Channel.IsArchived,
-	}, nil
+	return response.Channel.ToChannel(), nil
 }
 
 func (c *VendorV3Client) ArchiveChannel(appID, channelID string) error {

--- a/pkg/types/channel.go
+++ b/pkg/types/channel.go
@@ -21,6 +21,7 @@ type KotsChannel struct {
 	IsDefault                  bool                          `json:"isDefault,omitempty"`
 	Name                       string                        `json:"name,omitempty"`
 	NumReleases                int32                         `json:"numReleases,omitempty"`
+	IsHelmOnly                 bool                          `json:"isHelmOnly,omitempty"`
 	ReleaseNotes               string                        `json:"releaseNotes,omitempty"`
 	// TODO: set these (see kotsChannelToSchema function)
 	ReleaseSequence          int32                   `json:"releaseSequence,omitempty"`
@@ -29,6 +30,19 @@ type KotsChannel struct {
 	ReplicatedRegistryDomain string                  `json:"replicatedRegistryDomain"`
 	CustomHostNameOverrides  CustomHostNameOverrides `json:"customHostNameOverrides"`
 	ChartReleases            []ChartRelease          `json:"chartReleases"`
+}
+
+func (c *KotsChannel) ToChannel() *Channel {
+	return &Channel{
+		ID:              c.Id,
+		Name:            c.Name,
+		Description:     c.Description,
+		Slug:            c.ChannelSlug,
+		ReleaseSequence: int64(c.ReleaseSequence),
+		ReleaseLabel:    c.CurrentVersion,
+		IsArchived:      c.IsArchived,
+		IsHelmOnly:      c.IsHelmOnly,
+	}
 }
 
 type ChartRelease struct {
@@ -88,6 +102,7 @@ type Channel struct {
 	ReleaseLabel    string `json:"releaseLabel"`
 
 	IsArchived bool `json:"isArchived"`
+	IsHelmOnly bool `json:"isHelmOnly"`
 }
 
 type CustomHostNameOverrides struct {
@@ -106,15 +121,4 @@ type CustomHostNameOverrides struct {
 	ReplicatedApp struct {
 		Hostname string `json:"hostname"`
 	} `json:"replicatedApp"`
-}
-
-func (c *Channel) Copy() *Channel {
-	return &Channel{
-		ID:              c.ID,
-		Name:            c.Name,
-		Description:     c.Description,
-		Slug:            c.Slug,
-		ReleaseSequence: c.ReleaseSequence,
-		ReleaseLabel:    c.ReleaseLabel,
-	}
 }


### PR DESCRIPTION
Helm only release output:
```
$ replicated channel inspect Unstable
ID:             28ysVVeOzXzZVYRq8J7bBRAABWd
NAME:           Unstable
DESCRIPTION:    
RELEASE:        166
VERSION:        0.1.142
```

KOTS release output:
```
$ replicated channel inspect Beta
ID:             28ysVWYdIQZF1wPl548WIPM1ykJ
NAME:           Beta
DESCRIPTION:    Beta
RELEASE:        118
VERSION:        0.1.105
EXISTING:

    curl -fsSL https://kots.io/install | bash
    kubectl kots install test-kots/beta

EMBEDDED:

    curl -fsSL https://k8s.kurl.sh/test-kots-beta | sudo bash

AIRGAP:

    curl -fSL -o test-kots-beta.tar.gz https://k8s.kurl.sh/bundle/test-kots-beta.tar.gz
    # ... scp or sneakernet test-kots-beta.tar.gz to airgapped machine, then
    tar xvf test-kots-beta.tar.gz
    sudo bash ./install.sh airgap
```