### PR TITLE
Remove references to app.IsFoundation

### DIFF
--- a/cli/cmd/release_create.go
+++ b/cli/cmd/release_create.go
@@ -99,7 +99,7 @@ func (r *runners) gitSHABranch() (sha string, branch string, dirty bool, err err
 }
 
 func (r *runners) setKOTSDefaultReleaseParams() error {
-	if !r.isFoundationApp && r.args.createReleaseYamlDir == "" {
+	if r.args.createReleaseYamlDir == "" {
 		r.args.createReleaseYamlDir = "./manifests"
 	}
 
@@ -142,14 +142,12 @@ func (r *runners) setKOTSDefaultReleaseParams() error {
 		}
 	}
 
-	if !r.isFoundationApp && r.args.createReleasePromoteVersion == "" {
+	if r.args.createReleasePromoteVersion == "" {
 		r.args.createReleasePromoteVersion = fmt.Sprintf("%s-%s%s", r.args.createReleasePromote, rev, dirtyStatus)
 	}
 
 	r.args.createReleasePromoteEnsureChannel = true
-	if !r.isFoundationApp {
-		r.args.createReleaseLint = true
-	}
+	r.args.createReleaseLint = true
 
 	return nil
 }
@@ -243,11 +241,9 @@ Prepared to create release with defaults:
 	}
 
 	if r.args.createReleaseChart != "" {
-		if !r.isFoundationApp {
-			fmt.Fprint(r.w, "You are creating a release that will only be installable with the helm CLI.\n"+
-				"For more information, see \n"+
-				"https://docs.replicated.com/vendor/helm-install#about-helm-installations-with-replicated\n")
-		}
+		fmt.Fprint(r.w, "You are creating a release that will only be installable with the helm CLI.\n"+
+			"For more information, see \n"+
+			"https://docs.replicated.com/vendor/helm-install#about-helm-installations-with-replicated\n")
 		fmt.Fprintln(r.w)
 		log.ActionWithSpinner("Reading chart from %s", r.args.createReleaseChart)
 		r.args.createReleaseYaml, err = makeReleaseFromChart(r.args.createReleaseChart)

--- a/cli/cmd/release_lint.go
+++ b/cli/cmd/release_lint.go
@@ -51,12 +51,13 @@ func (r *runners) releaseLint(cmd *cobra.Command, args []string) error {
 			return errors.Wrap(err, "failed to read yaml dir")
 		}
 		lintReleaseData = data
-		isBuildersRelease = r.isFoundationApp
+		// TODO: all specfiles are charts => isBuildersRelease
+		isBuildersRelease = false
 		contentType = "application/tar"
 	} else if r.args.lintReleaseChart != "" {
 		data, err := ioutil.ReadFile(r.args.lintReleaseChart)
 		if err != nil {
-			return errors.Wrap(err, "faile to read chart file")
+			return errors.Wrap(err, "failed to read chart file")
 		}
 		lintReleaseData = data
 		isBuildersRelease = true
@@ -71,7 +72,7 @@ func (r *runners) releaseLint(cmd *cobra.Command, args []string) error {
 
 	lintResult, err := r.api.LintRelease(r.appType, lintReleaseData, isBuildersRelease, contentType)
 	if err != nil {
-		return errors.Wrap(err, "faile to lint release")
+		return errors.Wrap(err, "failed to lint release")
 	}
 
 	if err := print.LintErrors(r.w, lintResult); err != nil {

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -290,7 +290,6 @@ func Execute(rootCmd *cobra.Command, stdin io.Reader, stdout io.Writer, stderr i
 
 		runCmds.appID = app.ID
 		runCmds.appSlug = app.Slug
-		runCmds.isFoundationApp = app.IsFoundation
 
 		return nil
 	}


### PR DESCRIPTION
https://app.shortcut.com/replicated/story/80304/remove-is-foundation-app-flag

First in a series for this story: remove references to `app.IsFoundation` from CLI

vendor-api to follow in separate PR