### PR TITLE
feat: return human readable err when requesting kubeconfig for cluster not running 

### DIFF
--- a/cli/cmd/cluster_create.go
+++ b/cli/cmd/cluster_create.go
@@ -113,9 +113,9 @@ func waitForCluster(kotsRestClient *kotsclient.VendorV3Client, id string, durati
 			return nil, errors.Wrap(err, "get cluster")
 		}
 
-		if cluster.Status == "running" {
+		if cluster.Status == types.ClusterStatusRunning {
 			return cluster, nil
-		} else if cluster.Status == "error" {
+		} else if cluster.Status == types.ClusterStatusError {
 			return nil, errors.New("cluster failed to provision")
 		} else {
 			if time.Now().After(start.Add(duration)) {

--- a/cli/cmd/cluster_ls.go
+++ b/cli/cmd/cluster_ls.go
@@ -112,7 +112,7 @@ func (r *runners) listClusters(_ *cobra.Command, args []string) error {
 			// Check for removed clusters and print them, changing their status to be "deleted"
 			for id, cluster := range oldClusterMap {
 				if _, found := newClusterMap[id]; !found {
-					cluster.Status = "deleted"
+					cluster.Status = types.ClusterStatusDeleted
 					clustersToPrint = append(clustersToPrint, cluster)
 				}
 			}

--- a/pkg/types/cluster.go
+++ b/pkg/types/cluster.go
@@ -2,6 +2,19 @@ package types
 
 import "time"
 
+type ClusterStatus string
+
+const (
+	ClusterStatusQueued       ClusterStatus = "queued"       // Not assigned to a runner yet
+	ClusterStatusAssigned     ClusterStatus = "assigned"     // Assigned to a runner, but have not heard back from the runner
+	ClusterStatusPreparing    ClusterStatus = "preparing"    // The runner sets this when is receives the request
+	ClusterStatusProvisioning ClusterStatus = "provisioning" // The runner sets this when it starts provisioning
+	ClusterStatusRunning      ClusterStatus = "running"      // The runner sets this when it is done provisioning and available
+	ClusterStatusTerminated   ClusterStatus = "terminated"   // This is set when the cluster expires or is deleted
+	ClusterStatusError        ClusterStatus = "error"        // Something unexpected
+	ClusterStatusDeleted      ClusterStatus = "deleted"
+)
+
 type Cluster struct {
 	ID                     string `json:"id"`
 	Name                   string `json:"name"`
@@ -10,9 +23,9 @@ type Cluster struct {
 	NodeCount              int    `json:"node_count"`
 	DiskGiB                int64  `json:"disk_gib"`
 
-	Status    string    `json:"status"`
-	CreatedAt time.Time `json:"created_at"`
-	ExpiresAt time.Time `json:"expires_at"`
+	Status    ClusterStatus `json:"status"`
+	CreatedAt time.Time     `json:"created_at"`
+	ExpiresAt time.Time     `json:"expires_at"`
 }
 
 type ClusterVersion struct {


### PR DESCRIPTION
return human readable err when requesting kubeconfig for cluster not running

https://app.shortcut.com/replicated/story/82999/requesting-kubeconfig-for-cluster-not-running-should-provide-a-nicer-human-readable-error


<img width="889" alt="image" src="https://github.com/replicatedhq/replicated/assets/8703626/6b919c6c-116b-47ab-93bb-b2781e885318">
