### PR TITLE
Fixing preflights for helm charts

### DIFF
--- a/pkg/kotsclient/cluster_get.go
+++ b/pkg/kotsclient/cluster_get.go
@@ -7,13 +7,13 @@ import (
 	"github.com/replicatedhq/replicated/pkg/types"
 )
 
-type ListClusterResponse struct {
+type GetClusterResponse struct {
 	Cluster *types.Cluster `json:"cluster"`
 	Error   string         `json:"error"`
 }
 
 func (c *VendorV3Client) GetCluster(id string) (*types.Cluster, error) {
-	cluster := ListClusterResponse{}
+	cluster := GetClusterResponse{}
 
 	err := c.DoJSON("GET", fmt.Sprintf("/v3/cluster/%s", id), http.StatusOK, nil, &cluster)
 	if err != nil {


### PR DESCRIPTION
Fixes: `runPreflights`: Previously when preflights were run, all the analyzers were ignored. This fixes this and returns an error in case strict preflights are failing.