### PR TITLE
Adding c11y results to release inspect

### DIFF
--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -14,7 +14,6 @@ func (r *runners) InitClusterCommand(parent *cobra.Command) *cobra.Command {
 		Use:    "cluster",
 		Short:  "Manage test clusters",
 		Long:   ``,
-		Hidden: true,
 	}
 	parent.AddCommand(cmd)
 

--- a/cli/cmd/cluster_create.go
+++ b/cli/cmd/cluster_create.go
@@ -16,16 +16,16 @@ import (
 
 func (r *runners) InitClusterCreate(parent *cobra.Command) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:          "create",
-		Short:        "create test clusters",
-		Long:         `create test clusters`,
-		RunE:         r.createCluster,
+		Use:   "create",
+		Short: "create test clusters",
+		Long:  `create test clusters`,
+		RunE:  r.createCluster,
 	}
 	parent.AddCommand(cmd)
 
 	cmd.Flags().StringVar(&r.args.createClusterName, "name", "", "cluster name")
 	cmd.Flags().StringVar(&r.args.createClusterKubernetesDistribution, "distribution", "kind", "Kubernetes distribution of the cluster to provision")
-	cmd.Flags().StringVar(&r.args.createClusterKubernetesVersion, "version", "v1.25.3", "Kubernetes version to provision (format is distribution dependent)")
+	cmd.Flags().StringVar(&r.args.createClusterKubernetesVersion, "version", "1.25.3", "Kubernetes version to provision (format is distribution dependent)")
 	cmd.Flags().IntVar(&r.args.createClusterNodeCount, "nodes", int(1), "Node count")
 	cmd.Flags().Int64Var(&r.args.createClusterDiskGiB, "disk", int64(50), "Disk Size (GiB) to request per node")
 	cmd.Flags().StringVar(&r.args.createClusterTTL, "ttl", "", "Cluster TTL (duration, max 48h)")

--- a/cli/cmd/cluster_create.go
+++ b/cli/cmd/cluster_create.go
@@ -16,17 +16,17 @@ import (
 
 func (r *runners) InitClusterCreate(parent *cobra.Command) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:          "create",
-		Short:        "Create test clusters",
-		Long:         `Create test clusters`,
-		RunE:         r.createCluster,
+		Use:   "create",
+		Short: "Create test clusters",
+		Long:  `Create test clusters`,
+		RunE:  r.createCluster,
 	}
 	parent.AddCommand(cmd)
 
 	cmd.Flags().StringVar(&r.args.createClusterName, "name", "", "Cluster name (defaults to random name)")
 	cmd.Flags().StringVar(&r.args.createClusterKubernetesDistribution, "distribution", "", "Kubernetes distribution of the cluster to provision")
 	cmd.Flags().StringVar(&r.args.createClusterKubernetesVersion, "version", "", "Kubernetes version to provision (format is distribution dependent)")
-	cmd.Flags().IntVar(&r.args.createClusterNodeCount, "node-count", int(1), "Node count")
+	cmd.Flags().IntVar(&r.args.createClusterNodeCount, "nodes", int(1), "Node count")
 	cmd.Flags().Int64Var(&r.args.createClusterDiskGiB, "disk", int64(50), "Disk Size (GiB) to request per node")
 	cmd.Flags().StringVar(&r.args.createClusterTTL, "ttl", "", "Cluster TTL (duration, max 48h)")
 	cmd.Flags().BoolVar(&r.args.createClusterDryRun, "dry-run", false, "Dry run")

--- a/cli/cmd/cluster_create.go
+++ b/cli/cmd/cluster_create.go
@@ -20,7 +20,6 @@ func (r *runners) InitClusterCreate(parent *cobra.Command) *cobra.Command {
 		Short:        "create test clusters",
 		Long:         `create test clusters`,
 		RunE:         r.createCluster,
-		SilenceUsage: true,
 	}
 	parent.AddCommand(cmd)
 

--- a/cli/cmd/cluster_create.go
+++ b/cli/cmd/cluster_create.go
@@ -27,7 +27,7 @@ func (r *runners) InitClusterCreate(parent *cobra.Command) *cobra.Command {
 	cmd.Flags().StringVar(&r.args.createClusterName, "name", "", "cluster name")
 	cmd.Flags().StringVar(&r.args.createClusterKubernetesDistribution, "distribution", "kind", "Kubernetes distribution of the cluster to provision")
 	cmd.Flags().StringVar(&r.args.createClusterKubernetesVersion, "version", "v1.25.3", "Kubernetes version to provision (format is distribution dependent)")
-	cmd.Flags().IntVar(&r.args.createClusterNodeCount, "node-count", int(1), "Node count")
+	cmd.Flags().IntVar(&r.args.createClusterNodeCount, "nodes", int(1), "Node count")
 	cmd.Flags().Int64Var(&r.args.createClusterDiskGiB, "disk", int64(50), "Disk Size (GiB) to request per node")
 	cmd.Flags().StringVar(&r.args.createClusterTTL, "ttl", "", "Cluster TTL (duration, max 48h)")
 	cmd.Flags().BoolVar(&r.args.createClusterDryRun, "dry-run", false, "Dry run")

--- a/cli/cmd/cluster_kubeconfig.go
+++ b/cli/cmd/cluster_kubeconfig.go
@@ -26,7 +26,6 @@ func (r *runners) InitClusterKubeconfig(parent *cobra.Command) *cobra.Command {
 		Short:        "Download credentials for a test cluster",
 		Long:         `Download credentials for a test cluster`,
 		RunE:         r.kubeconfigCluster,
-		SilenceUsage: true,
 	}
 	parent.AddCommand(cmd)
 

--- a/cli/cmd/cluster_ls.go
+++ b/cli/cmd/cluster_ls.go
@@ -19,7 +19,6 @@ func (r *runners) InitClusterList(parent *cobra.Command) *cobra.Command {
 		Short:        "list test clusters",
 		Long:         `list test clusters`,
 		RunE:         r.listClusters,
-		SilenceUsage: true,
 	}
 	parent.AddCommand(cmd)
 

--- a/cli/cmd/cluster_prepare.go
+++ b/cli/cmd/cluster_prepare.go
@@ -60,7 +60,6 @@ replicated cluster prepare --distribution eks --version 1.27 --instance-type c6.
 	  --entitlement seat_count=100 --entitlement license_type=enterprise \
 	  --chart ./my-helm-chart --values ./values.yaml --set chart-key=value --set chart-key2=value2`,
 		RunE:         r.prepareCluster,
-		SilenceUsage: true,
 	}
 
 	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {

--- a/cli/cmd/cluster_rm.go
+++ b/cli/cmd/cluster_rm.go
@@ -16,7 +16,6 @@ func (r *runners) InitClusterRemove(parent *cobra.Command) *cobra.Command {
 
 You can specify the --all flag to terminate all clusters.`,
 		RunE:         r.removeCluster,
-		SilenceUsage: true,
 	}
 	parent.AddCommand(cmd)
 

--- a/cli/cmd/cluster_versions.go
+++ b/cli/cmd/cluster_versions.go
@@ -14,7 +14,6 @@ func (r *runners) InitClusterVersions(parent *cobra.Command) *cobra.Command {
 		Short:        "list cluster versions",
 		Long:         `list cluster versions`,
 		RunE:         r.listClusterVersions,
-		SilenceUsage: true,
 	}
 	parent.AddCommand(cmd)
 

--- a/cli/cmd/release_compatibility.go
+++ b/cli/cmd/release_compatibility.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+func (r *runners) InitReleaseCompatibility(parent *cobra.Command) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "compatibility SEQUENCE",
+		Short: "report release compatibility",
+		Long:  "report release compatibility for a kubernetes distribution and version",
+		RunE:  r.reportReleaseCompatibility,
+	}
+	parent.AddCommand(cmd)
+
+	cmd.Flags().StringVar(&r.args.compatibilityKubernetesDistribution, "distribution", "kind", "Kubernetes distribution of the cluster to report on.")
+	cmd.Flags().StringVar(&r.args.compatibilityKubernetesVersion, "version", "v1.25.3", "Kubernetes version of the cluster to report on (format is distribution dependent)")
+	cmd.Flags().BoolVar(&r.args.compatibilitySuccess, "success", false, "If set, the compatibility will be reported as a success.")
+	cmd.Flags().BoolVar(&r.args.compatibilityFailure, "failure", false, "If set, the compatibility will be reported as a failure.")
+	cmd.Flags().StringVar(&r.args.compatibilityNotes, "notes", "", "Additional notes to report.")
+
+	cmd.MarkFlagRequired("distribution")
+	cmd.MarkFlagRequired("version")
+
+	return cmd
+}
+
+func (r *runners) reportReleaseCompatibility(_ *cobra.Command, args []string) error {
+	// parse sequence positional arguments
+	if len(args) != 1 {
+		return errors.New("release sequence is required")
+	}
+	seq, err := strconv.ParseInt(args[0], 10, 64)
+	if err != nil {
+		return fmt.Errorf("Failed to parse sequence argument %s", args[0])
+	}
+
+	//Check if one of success or failure is set
+	if r.args.compatibilitySuccess && r.args.compatibilityFailure {
+		return fmt.Errorf("cannot set both success and failure")
+	}
+	if !r.args.compatibilitySuccess && !r.args.compatibilityFailure {
+		return fmt.Errorf("must set either success or failure")
+	}
+
+	err = r.kotsAPI.ReportReleaseCompatibility(r.appID, seq)
+	if err != nil {
+		return fmt.Errorf("report release compatibility")
+	}
+
+	return nil
+}

--- a/cli/cmd/release_compatibility.go
+++ b/cli/cmd/release_compatibility.go
@@ -3,8 +3,10 @@ package cmd
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/replicatedhq/replicated/cli/print"
 	"github.com/spf13/cobra"
 )
 
@@ -52,7 +54,13 @@ func (r *runners) reportReleaseCompatibility(_ *cobra.Command, args []string) er
 		success = true
 	}
 
-	err = r.kotsAPI.ReportReleaseCompatibility(r.appID, seq, r.args.compatibilityKubernetesDistribution, r.args.compatibilityKubernetesVersion, success, r.args.compatibilityNotes)
+	ve, err := r.kotsAPI.ReportReleaseCompatibility(r.appID, seq, r.args.compatibilityKubernetesDistribution, r.args.compatibilityKubernetesVersion, success, r.args.compatibilityNotes)
+	if ve != nil && len(ve.Errors) > 0 {
+		if len(ve.SupportedDistributions) > 0 {
+			print.ClusterVersions("table", r.w, ve.SupportedDistributions)
+		}
+		return fmt.Errorf("%s", errors.New(strings.Join(ve.Errors, ",")))
+	}
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/release_compatibility.go
+++ b/cli/cmd/release_compatibility.go
@@ -18,7 +18,7 @@ func (r *runners) InitReleaseCompatibility(parent *cobra.Command) *cobra.Command
 	parent.AddCommand(cmd)
 
 	cmd.Flags().StringVar(&r.args.compatibilityKubernetesDistribution, "distribution", "kind", "Kubernetes distribution of the cluster to report on.")
-	cmd.Flags().StringVar(&r.args.compatibilityKubernetesVersion, "version", "v1.25.3", "Kubernetes version of the cluster to report on (format is distribution dependent)")
+	cmd.Flags().StringVar(&r.args.compatibilityKubernetesVersion, "version", "1.25.3", "Kubernetes version of the cluster to report on (format is distribution dependent)")
 	cmd.Flags().BoolVar(&r.args.compatibilitySuccess, "success", false, "If set, the compatibility will be reported as a success.")
 	cmd.Flags().BoolVar(&r.args.compatibilityFailure, "failure", false, "If set, the compatibility will be reported as a failure.")
 	cmd.Flags().StringVar(&r.args.compatibilityNotes, "notes", "", "Additional notes to report.")
@@ -36,7 +36,7 @@ func (r *runners) reportReleaseCompatibility(_ *cobra.Command, args []string) er
 	}
 	seq, err := strconv.ParseInt(args[0], 10, 64)
 	if err != nil {
-		return fmt.Errorf("Failed to parse sequence argument %s", args[0])
+		return fmt.Errorf("failed to parse sequence argument %s", args[0])
 	}
 
 	//Check if one of success or failure is set
@@ -47,9 +47,14 @@ func (r *runners) reportReleaseCompatibility(_ *cobra.Command, args []string) er
 		return fmt.Errorf("must set either success or failure")
 	}
 
-	err = r.kotsAPI.ReportReleaseCompatibility(r.appID, seq)
+	success := false
+	if r.args.compatibilitySuccess {
+		success = true
+	}
+
+	err = r.kotsAPI.ReportReleaseCompatibility(r.appID, seq, r.args.compatibilityKubernetesDistribution, r.args.compatibilityKubernetesVersion, success, r.args.compatibilityNotes)
 	if err != nil {
-		return fmt.Errorf("report release compatibility")
+		return err
 	}
 
 	return nil

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -152,6 +152,7 @@ func Execute(rootCmd *cobra.Command, stdin io.Reader, stdout io.Writer, stderr i
 	runCmds.InitReleasePromote(releaseCmd)
 	runCmds.InitReleaseLint(releaseCmd)
 	runCmds.InitReleaseTest(releaseCmd)
+	runCmds.InitReleaseCompatibility(releaseCmd)
 
 	collectorsCmd := runCmds.InitCollectorsCommand(runCmds.rootCmd)
 	runCmds.InitCollectorList(collectorsCmd)

--- a/cli/cmd/runner.go
+++ b/cli/cmd/runner.go
@@ -215,4 +215,10 @@ type runnerArgs struct {
 
 	customerInspectOutputFormat string
 	customerInspectCustomer     string
+
+	compatibilityKubernetesDistribution string
+	compatibilityKubernetesVersion      string
+	compatibilitySuccess                bool
+	compatibilityFailure                bool
+	compatibilityNotes                  string
 }

--- a/cli/print/release.go
+++ b/cli/print/release.go
@@ -10,6 +10,11 @@ import (
 var releaseTmplSrc = `SEQUENCE:	{{ .Sequence }}
 CREATED:	{{ time .CreatedAt }}
 EDITED:	{{ time .EditedAt }}
+{{if .CompatibilityResults}}COMPATIBILITY RESULTS:
+	DISTRIBUTION	VERSION	SUCCESS_AT	SUCCESS_NOTES	FAILURE_AT	FAILURE_NOTES
+	{{ range .CompatibilityResults -}}
+	{{ .Distribution }}	{{ .Version }}	{{if .SuccessAt}}{{ time .SuccessAt }}{{else}}-{{end}}	{{ .SuccessNotes }}	{{if .FailureAt}}{{ time .FailureAt }}{{else}}-{{end}}	{{ .FailureNotes }}
+	{{ end }}{{end}}
 CONFIG:
 {{ .Config }}
 `

--- a/pkg/kotsclient/release.go
+++ b/pkg/kotsclient/release.go
@@ -54,12 +54,13 @@ func (c *VendorV3Client) GetRelease(appID string, sequence int64) (*types.AppRel
 	}
 
 	appRelease := types.AppRelease{
-		Config:     resp.Release.Spec,
-		CreatedAt:  resp.Release.CreatedAt,
-		Editable:   !resp.Release.IsReleaseNotEditable,
-		Sequence:   resp.Release.Sequence,
-		Charts:     resp.Release.Charts,
-		IsHelmOnly: resp.Release.IsHelmOnly,
+		Config:               resp.Release.Spec,
+		CreatedAt:            resp.Release.CreatedAt,
+		Editable:             !resp.Release.IsReleaseNotEditable,
+		Sequence:             resp.Release.Sequence,
+		Charts:               resp.Release.Charts,
+		CompatibilityResults: resp.Release.CompatibilityResults,
+		IsHelmOnly:           resp.Release.IsHelmOnly,
 	}
 
 	return &appRelease, nil

--- a/pkg/kotsclient/release_compatibility.go
+++ b/pkg/kotsclient/release_compatibility.go
@@ -1,0 +1,6 @@
+package kotsclient
+
+func (c *VendorV3Client) ReportReleaseCompatibility(appID string, sequence int64) error {
+	// TBD
+	return nil
+}

--- a/pkg/kotsclient/release_compatibility.go
+++ b/pkg/kotsclient/release_compatibility.go
@@ -1,14 +1,25 @@
 package kotsclient
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
 
+	"github.com/replicatedhq/replicated/pkg/platformclient"
 	"github.com/replicatedhq/replicated/pkg/types"
 )
 
-func (c *VendorV3Client) ReportReleaseCompatibility(appID string, sequence int64, distribution string, version string, success bool, notes string) error {
+type ReportReleaseCompatibilityErrorResponseBody struct {
+	Error ReportReleaseCompatibilityErrorResponse `json:"Error"`
+}
+type ReportReleaseCompatibilityErrorResponse struct {
+	Message         string           `json:"message"`
+	ValidationError *ValidationError `json:"validationError,omitempty"`
+}
+
+func (c *VendorV3Client) ReportReleaseCompatibility(appID string, sequence int64, distribution string, version string, success bool, notes string) (*ValidationError, error) {
 	request := types.CompatibilityResult{
 		Distribution: distribution,
 		Version:      version,
@@ -26,8 +37,18 @@ func (c *VendorV3Client) ReportReleaseCompatibility(appID string, sequence int64
 	path := fmt.Sprintf("/v3/app/%s/release/%v/compatibility", appID, sequence)
 	err := c.DoJSON("POST", path, http.StatusCreated, request, nil)
 	if err != nil {
-		return err
+		if err, ok := err.(platformclient.APIError); ok && err.StatusCode == http.StatusBadRequest {
+			// parse the error response body
+			respBody := &ReportReleaseCompatibilityErrorResponseBody{}
+			if err := json.NewDecoder(bytes.NewReader(err.Body)).Decode(respBody); err != nil {
+				return nil, fmt.Errorf("Error decoding error response body: %w", err)
+			}
+			if respBody.Error.ValidationError != nil {
+				return respBody.Error.ValidationError, nil
+			}
+		}
+		return nil, err
 	}
 
-	return nil
+	return nil, nil
 }

--- a/pkg/kotsclient/release_compatibility.go
+++ b/pkg/kotsclient/release_compatibility.go
@@ -1,6 +1,33 @@
 package kotsclient
 
-func (c *VendorV3Client) ReportReleaseCompatibility(appID string, sequence int64) error {
-	// TBD
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/replicatedhq/replicated/pkg/types"
+)
+
+func (c *VendorV3Client) ReportReleaseCompatibility(appID string, sequence int64, distribution string, version string, success bool, notes string) error {
+	request := types.CompatibilityResult{
+		Distribution: distribution,
+		Version:      version,
+	}
+
+	now := time.Now()
+	if success {
+		request.SuccessAt = &now
+		request.SuccessNotes = notes
+	} else {
+		request.FailureAt = &now
+		request.FailureNotes = notes
+	}
+
+	path := fmt.Sprintf("/v3/app/%s/release/%v/compatibility", appID, sequence)
+	err := c.DoJSON("POST", path, http.StatusCreated, request, nil)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/pkg/types/release.go
+++ b/pkg/types/release.go
@@ -72,16 +72,17 @@ type KotsPromoteReleaseRequest struct {
 }
 
 type KotsAppRelease struct {
-	AppID                string     `json:"appId"`
-	Sequence             int64      `json:"sequence"`
-	CreatedAt            time.Time  `json:"created"`
-	IsArchived           bool       `json:"isArchived"`
-	Spec                 string     `json:"spec"`
-	ReleaseNotes         string     `json:"releaseNotes"`
-	IsReleaseNotEditable bool       `json:"isReleaseNotEditable"`
-	Channels             []*Channel `json:"channels"`
-	Charts               []Chart    `json:"charts"`
-	IsHelmOnly           bool       `json:"isHelmOnly"`
+	AppID                string                `json:"appId"`
+	Sequence             int64                 `json:"sequence"`
+	CreatedAt            time.Time             `json:"created"`
+	IsArchived           bool                  `json:"isArchived"`
+	Spec                 string                `json:"spec"`
+	ReleaseNotes         string                `json:"releaseNotes"`
+	IsReleaseNotEditable bool                  `json:"isReleaseNotEditable"`
+	Channels             []*Channel            `json:"channels"`
+	Charts               []Chart               `json:"charts"`
+	CompatibilityResults []CompatibilityResult `json:"compatibilityResults"`
+	IsHelmOnly           bool                  `json:"isHelmOnly"`
 }
 
 type Chart struct {
@@ -97,12 +98,22 @@ type EntitlementValue struct {
 	Value string `json:"value,omitempty"`
 }
 
+type CompatibilityResult struct {
+	Distribution string     `json:"distribution"`
+	Version      string     `json:"version"`
+	SuccessAt    *time.Time `json:"successAt,omitempty"`
+	SuccessNotes string     `json:"successNotes,omitempty"`
+	FailureAt    *time.Time `json:"failureAt,omitempty"`
+	FailureNotes string     `json:"failureNotes,omitempty"`
+}
+
 type AppRelease struct {
-	Config     string    `json:"config,omitempty"`
-	CreatedAt  time.Time `json:"createdAt,omitempty"`
-	Editable   bool      `json:"editable,omitempty"`
-	EditedAt   time.Time `json:"editedAt,omitempty"`
-	Sequence   int64     `json:"sequence,omitempty"`
-	Charts     []Chart   `json:"charts,omitempty"`
-	IsHelmOnly bool      `json:"isHelmOnly,omitempty"`
+	Config               string                `json:"config,omitempty"`
+	CreatedAt            time.Time             `json:"createdAt,omitempty"`
+	Editable             bool                  `json:"editable,omitempty"`
+	EditedAt             time.Time             `json:"editedAt,omitempty"`
+	Sequence             int64                 `json:"sequence,omitempty"`
+	Charts               []Chart               `json:"charts,omitempty"`
+	CompatibilityResults []CompatibilityResult `json:"compatibilityResults,omitempty"`
+	IsHelmOnly           bool                  `json:"isHelmOnly,omitempty"`
 }


### PR DESCRIPTION
Current output
```
$> ~/Projects/src/github/replicatedhq/replicated/bin/replicated release inspect 38                                                                                                             
Update available: v0.56.0
To upgrade, run "brew upgrade replicatedhq/replicated/cli"
SEQUENCE:    38
CREATED:     2023-08-17T22:13:42Z
EDITED:      0001-01-01T00:00:00Z
COMPATIBILITY RESULTS:
	DISTRIBUTION    VERSION    SUCCESS_AT              SUCCESS_NOTES    FAILURE_AT              FAILURE_NOTES
	k3s             1.26       -                                        2023-08-22T19:21:49Z    it does not work
	kind            1.25.0     2023-08-22T19:20:49Z    it works also    -

CONFIG:
[{"name":"wordpress-enterprise-0.3.1.tgz","path":"wordpress-enterprise-.........
```