### PR TITLE
chore: [sc-63726] Fix text alignment for autocomplete help command

### DIFF
--- a/cli/cmd/completion.go
+++ b/cli/cmd/completion.go
@@ -28,8 +28,8 @@ func NewCmdCompletion(out io.Writer, parentName string) *cobra.Command {
 
 	Bash:
 
-		This script depends on the 'bash-completion' package.
-		If it is not installed already, you can install it via your OS's package manager.
+	  This script depends on the 'bash-completion' package.
+	  If it is not installed already, you can install it via your OS's package manager.
 
 	  $ source <(%[1]s completion bash)
 


### PR DESCRIPTION
Story details: https://app.shortcut.com/replicated/story/63726

Minor fix on help text alignment for `replicated completion --help`.  This fix was tested locally.

**Before**: 
```
	Bash:

		This script depends on the 'bash-completion' package.
		If it is not installed already, you can install it via your OS's package manager.

	  $ source <(replicated completion bash)

```

**After**:
```
	Bash:

	  This script depends on the 'bash-completion' package.
	  If it is not installed already, you can install it via your OS's package manager.

	  $ source <(replicated completion bash)
```