### PR TITLE
Adding instance types to cluster versions command

### DIFF
--- a/cli/print/clusters.go
+++ b/cli/print/clusters.go
@@ -16,8 +16,8 @@ var clustersTmplSrc = `ID	NAME	DISTRIBUTION	VERSION	STATUS	CREATED	EXPIRES
 {{ end }}`
 
 var clusterVersionsTmplSrc = `Supported Kubernetes distributions and versions are:
-DISTRIBUTION	VERSION
-{{ range $d := . -}}{{ $d.Name }}	{{ range $i, $v := $d.Versions -}}{{if $i}},{{end}} {{ $v }}{{ end }}
+DISTRIBUTION	VERSION	INSTANCE_TYPES
+{{ range $d := . -}}{{ $d.Name }}	{{ range $i, $v := $d.Versions -}}{{if $i}}, {{end}}{{ $v }}{{ end }}	{{ range $i, $it := $d.InstanceTypes -}}{{if $i}}, {{end}}{{ $it }}{{ end }}
 {{ end }}`
 
 var clustersTmpl = template.Must(template.New("clusters").Funcs(funcs).Parse(clustersTmplSrc))

--- a/pkg/types/cluster.go
+++ b/pkg/types/cluster.go
@@ -29,6 +29,7 @@ type Cluster struct {
 }
 
 type ClusterVersion struct {
-	Name     string   `json:"short_name"`
-	Versions []string `json:"versions"`
+	Name          string   `json:"short_name"`
+	Versions      []string `json:"versions"`
+	InstanceTypes []string `json:"instance_types"`
 }


### PR DESCRIPTION
```
$> replicated cluster versions                                                                         
Supported Kubernetes distributions and versions are:
DISTRIBUTION    VERSION                                                                                                            INSTANCE_TYPES
eks              1.22, 1.23, 1.24, 1.25, 1.26, 1.27                                                                                 m6i.large, m6i.xlarge, m6i.2xlarge, m6i.4xlarge, m6i.8xlarge
helmvm           1.27                                                                                                               r1.small, r1.medium, r1.large, r1.xlarge, r1.2xlarge
k3s              1.24, 1.25, 1.26                                                                                                   r1.small, r1.medium, r1.large, r1.xlarge, r1.2xlarge
kind             1.25.0, 1.25.1, 1.25.2, 1.25.3, 1.25.4, 1.25.5, 1.25.6, 1.25.7, 1.25.8, 1.26.0, 1.26.1, 1.26.2, 1.26.3, 1.27.0     r1.small, r1.medium, r1.large, r1.xlarge, r1.2xlarge
kurl             A valid kurl version.                                                                                              r1.small, r1.medium, r1.large, r1.xlarge, r1.2xlarge
openshift        4.13.0-okd                                                                                                         r1.small, r1.medium, r1.large, r1.xlarge, r1.2xlarge
```