### PR TITLE
chore: show cluster subcommand in help

### DIFF
--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -14,7 +14,6 @@ func (r *runners) InitClusterCommand(parent *cobra.Command) *cobra.Command {
 		Use:    "cluster",
 		Short:  "Manage test clusters",
 		Long:   ``,
-		Hidden: true,
 	}
 	parent.AddCommand(cmd)
 


### PR DESCRIPTION
The `cluster` subcommand is missing in the help output. Is that intentional? This PR adds it since c11y is public now.

```sh
[evans] $ replicated -h
The replicated CLI allows vendors to manage their apps, channels, releases and collectors.


Usage:
  replicated [command]

Available Commands:
  api         Make ad-hoc API calls to the Replicated API
  app         Manage apps
  channel     List channels
  completion  Generate the autocompletion script for the specified shell
  customer    Manage customers
  enterprise  Manage enterprise channels, policies and installers
  installer   Manage Kubernetes installers
  login       Log in to Replicated
  registry    Manage registries
  release     Manage app releases
  version     Print the current version and exit

Flags:
      --app string     The app slug or app id to use in all calls
  -h, --help           help for replicated
      --token string   The API token to use to access your app in the Vendor API

Use "replicated [command] --help" for more information about a command.
```

After this change

```sh
[evans] $ ./bin/replicated -h
The replicated CLI allows vendors to manage their apps, channels, releases and collectors.


Usage:
  replicated [command]

Available Commands:
  api         Make ad-hoc API calls to the Replicated API
  app         Manage apps
  channel     List channels
  cluster     Manage test clusters
  completion  Generate completion script
  customer    Manage customers
  enterprise  Manage enterprise channels, policies and installers
  installer   Manage Kubernetes installers
  login       Log in to Replicated
  registry    Manage registries
  release     Manage app releases
  version     Print the current version and exit

Flags:
      --app string     The app slug or app id to use in all calls
  -h, --help           help for replicated
      --token string   The API token to use to access your app in the Vendor API

Use "replicated [command] --help" for more information about a command.
```
