### PR TITLE
feat (c11y): cluster upgrades

### DIFF
--- a/cli/cmd/cluster_create.go
+++ b/cli/cmd/cluster_create.go
@@ -29,15 +29,15 @@ func (r *runners) InitClusterCreate(parent *cobra.Command) *cobra.Command {
 	cmd.Flags().IntVar(&r.args.createClusterNodeCount, "nodes", int(1), "Node count")
 	cmd.Flags().Int64Var(&r.args.createClusterDiskGiB, "disk", int64(50), "Disk Size (GiB) to request per node")
 	cmd.Flags().StringVar(&r.args.createClusterTTL, "ttl", "", "Cluster TTL (duration, max 48h)")
-	cmd.Flags().BoolVar(&r.args.createClusterDryRun, "dry-run", false, "Dry run")
 	cmd.Flags().DurationVar(&r.args.createClusterWaitDuration, "wait", time.Second*0, "Wait duration for cluster to be ready (leave empty to not wait)")
-	cmd.Flags().StringVar(&r.args.createClusterInstanceType, "instance-type", "", "The type of instance to use (e.g. x5.xlarge)")
-	cmd.Flags()
+
+	cmd.Flags().StringVar(&r.args.createClusterInstanceType, "instance-type", "", "the type of instance to use (e.g. x5.xlarge)")
+	cmd.Flags().BoolVar(&r.args.createClusterDryRun, "dry-run", false, "Dry run")
 
 	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
 
-	cmd.MarkFlagRequired("distribution")
-	cmd.MarkFlagRequired("version")
+	_ = cmd.MarkFlagRequired("distribution")
+	_ = cmd.MarkFlagRequired("version")
 
 	return cmd
 }
@@ -54,8 +54,8 @@ func (r *runners) createCluster(_ *cobra.Command, args []string) error {
 		NodeCount:              r.args.createClusterNodeCount,
 		DiskGiB:                r.args.createClusterDiskGiB,
 		TTL:                    r.args.createClusterTTL,
-		DryRun:                 r.args.createClusterDryRun,
 		InstanceType:           r.args.createClusterInstanceType,
+		DryRun:                 r.args.createClusterDryRun,
 	}
 	cl, err := r.createAndWaitForCluster(opts)
 	if err != nil {
@@ -80,7 +80,7 @@ func (r *runners) createAndWaitForCluster(opts kotsclient.CreateClusterOpts) (*t
 
 	if ve != nil && len(ve.Errors) > 0 {
 		if len(ve.SupportedDistributions) > 0 {
-			print.ClusterVersions("table", r.w, ve.SupportedDistributions)
+			_ = print.ClusterVersions("table", r.w, ve.SupportedDistributions)
 		}
 		return nil, fmt.Errorf("%s", errors.New(strings.Join(ve.Errors, ",")))
 	}
@@ -111,7 +111,7 @@ func waitForCluster(kotsRestClient *kotsclient.VendorV3Client, id string, durati
 
 		if cluster.Status == types.ClusterStatusRunning {
 			return cluster, nil
-		} else if cluster.Status == types.ClusterStatusError {
+		} else if cluster.Status == types.ClusterStatusError || cluster.Status == types.ClusterStatusUpgradeError {
 			return nil, errors.New("cluster failed to provision")
 		} else {
 			if time.Now().After(start.Add(duration)) {

--- a/cli/cmd/cluster_upgrade.go
+++ b/cli/cmd/cluster_upgrade.go
@@ -14,7 +14,7 @@ import (
 
 func (r *runners) InitClusterUpgrade(parent *cobra.Command) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:          "Upgrade [cluster id]",
+		Use:          "upgrade [cluster id]",
 		Short:        "Upgrade a test clusters",
 		Long:         `Upgrade a test clusters`,
 		Args:         cobra.ExactArgs(1),

--- a/cli/cmd/cluster_upgrade.go
+++ b/cli/cmd/cluster_upgrade.go
@@ -1,0 +1,86 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/replicated/cli/print"
+	"github.com/replicatedhq/replicated/pkg/kotsclient"
+	"github.com/replicatedhq/replicated/pkg/platformclient"
+	"github.com/replicatedhq/replicated/pkg/types"
+	"github.com/spf13/cobra"
+)
+
+func (r *runners) InitClusterUpgrade(parent *cobra.Command) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "Upgrade [cluster id]",
+		Short:        "Upgrade a test clusters",
+		Long:         `Upgrade a test clusters`,
+		Args:         cobra.ExactArgs(1),
+		RunE:         r.upgradeCluster,
+		SilenceUsage: true,
+		Hidden:       true, // TODO: remove this once released
+	}
+	parent.AddCommand(cmd)
+
+	cmd.Flags().StringVar(&r.args.upgradeClusterKubernetesVersion, "version", "", "Kubernetes version to upgrade to (format is distribution dependent)")
+	cmd.Flags().BoolVar(&r.args.upgradeClusterDryRun, "dry-run", false, "Dry run")
+	cmd.Flags().DurationVar(&r.args.upgradeClusterWaitDuration, "wait", 0, "Wait duration for cluster to be ready (leave empty to not wait)")
+
+	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
+
+	_ = cmd.MarkFlagRequired("version")
+
+	return cmd
+}
+
+func (r *runners) upgradeCluster(cmd *cobra.Command, args []string) error {
+	if len(args) < 1 {
+		return errors.New("cluster id is required")
+	}
+	clusterID := args[0]
+
+	opts := kotsclient.UpgradeClusterOpts{
+		KubernetesVersion: r.args.upgradeClusterKubernetesVersion,
+		DryRun:            r.args.upgradeClusterDryRun,
+	}
+	cl, err := r.upgradeAndWaitForCluster(clusterID, opts)
+	if err != nil {
+		return err
+	}
+
+	if opts.DryRun {
+		_, err := fmt.Fprintln(r.w, "Dry run succeeded.")
+		return err
+	}
+
+	return print.Cluster(r.outputFormat, r.w, cl)
+}
+
+func (r *runners) upgradeAndWaitForCluster(clusterID string, opts kotsclient.UpgradeClusterOpts) (*types.Cluster, error) {
+	cl, ve, err := r.kotsAPI.UpgradeCluster(clusterID, opts)
+	if errors.Cause(err) == platformclient.ErrForbidden {
+		return nil, ErrCompatibilityMatrixTermsNotAccepted
+	} else if err != nil {
+		return nil, errors.Wrap(err, "upgrade cluster")
+	}
+
+	if ve != nil && len(ve.Errors) > 0 {
+		if len(ve.SupportedDistributions) > 0 {
+			_ = print.ClusterVersions("table", r.w, ve.SupportedDistributions)
+		}
+		return nil, fmt.Errorf("%s", errors.New(strings.Join(ve.Errors, ",")))
+	}
+
+	if opts.DryRun {
+		return nil, nil
+	}
+
+	// if the wait flag was provided, we poll the api until the cluster is ready, or a timeout
+	if r.args.upgradeClusterWaitDuration > 0 {
+		return waitForCluster(r.kotsAPI, cl.ID, r.args.upgradeClusterWaitDuration)
+	}
+
+	return cl, nil
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -218,6 +218,7 @@ func Execute(rootCmd *cobra.Command, stdin io.Reader, stdout io.Writer, stderr i
 
 	clusterCmd := runCmds.InitClusterCommand(runCmds.rootCmd)
 	runCmds.InitClusterCreate(clusterCmd)
+	runCmds.InitClusterUpgrade(clusterCmd)
 	runCmds.InitClusterList(clusterCmd)
 	runCmds.InitClusterKubeconfig(clusterCmd)
 	runCmds.InitClusterRemove(clusterCmd)

--- a/cli/cmd/runner.go
+++ b/cli/cmd/runner.go
@@ -171,6 +171,10 @@ type runnerArgs struct {
 	createClusterWaitDuration           time.Duration
 	createClusterInstanceType           string
 
+	upgradeClusterKubernetesVersion string
+	upgradeClusterDryRun            bool
+	upgradeClusterWaitDuration      time.Duration
+
 	prepareClusterID                     string
 	prepareClusterName                   string
 	prepareClusterKubernetesDistribution string

--- a/pkg/kotsclient/cluster_create.go
+++ b/pkg/kotsclient/cluster_create.go
@@ -60,7 +60,7 @@ func (c *VendorV3Client) CreateCluster(opts CreateClusterOpts) (*types.Cluster, 
 func (c *VendorV3Client) doCreateClusterRequest(req CreateClusterRequest) (*types.Cluster, *ClusterValidationError, error) {
 	resp := CreateClusterResponse{}
 	endpoint := "/v3/cluster"
-	err := c.DoJSON("POST", endpoint, http.StatusOK, req, &resp)
+	err := c.DoJSON("POST", endpoint, http.StatusCreated, req, &resp)
 	if err != nil {
 		if strings.Contains(err.Error(), " 400: ") {
 			// to avoid a lot of brittle string parsing, we make the request again with

--- a/pkg/kotsclient/cluster_create.go
+++ b/pkg/kotsclient/cluster_create.go
@@ -30,17 +30,17 @@ type CreateClusterOpts struct {
 	NodeCount              int
 	DiskGiB                int64
 	TTL                    string
-	DryRun                 bool
 	InstanceType           string
+	DryRun                 bool
 }
 
-type ValidationError struct {
+type ClusterValidationError struct {
 	Errors                 []string                `json:"errors"`
 	SupportedDistributions []*types.ClusterVersion `json:"supported_distributions"`
 }
 
-func (c *VendorV3Client) CreateCluster(opts CreateClusterOpts) (*types.Cluster, *ValidationError, error) {
-	reqBody := &CreateClusterRequest{
+func (c *VendorV3Client) CreateCluster(opts CreateClusterOpts) (*types.Cluster, *ClusterValidationError, error) {
+	req := CreateClusterRequest{
 		Name:                   opts.Name,
 		KubernetesDistribution: opts.KubernetesDistribution,
 		KubernetesVersion:      opts.KubernetesVersion,
@@ -50,33 +50,38 @@ func (c *VendorV3Client) CreateCluster(opts CreateClusterOpts) (*types.Cluster, 
 		InstanceType:           opts.InstanceType,
 	}
 
-	cluster := CreateClusterResponse{}
-	endpoint := "/v3/cluster"
 	if opts.DryRun {
-		endpoint = "/v3/cluster?dry-run=true"
-		ve := ValidationError{}
-		err := c.DoJSON("POST", endpoint, http.StatusOK, reqBody, &ve)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		return nil, &ve, nil
+		ve, err := c.doCreateClusterDryRunRequest(req)
+		return nil, ve, err
 	}
-	err := c.DoJSON("POST", endpoint, http.StatusCreated, reqBody, &cluster)
+	return c.doCreateClusterRequest(req)
+}
+
+func (c *VendorV3Client) doCreateClusterRequest(req CreateClusterRequest) (*types.Cluster, *ClusterValidationError, error) {
+	resp := CreateClusterResponse{}
+	endpoint := "/v3/cluster"
+	err := c.DoJSON("POST", endpoint, http.StatusOK, req, &resp)
 	if err != nil {
 		if strings.Contains(err.Error(), " 400: ") {
 			// to avoid a lot of brittle string parsing, we make the request again with
 			// a dry-run flag and expect to get the same result back
-			ve := ValidationError{}
-			err := c.DoJSON("POST", "/v3/cluster?dry-run=true", http.StatusOK, reqBody, &ve)
-			if err != nil {
-				return nil, nil, err
+			ve, _ := c.doCreateClusterDryRunRequest(req)
+			if ve != nil && len(ve.Errors) > 0 {
+				return nil, ve, nil
 			}
-
-			return nil, &ve, nil
 		}
 		return nil, nil, err
 	}
 
-	return cluster.Cluster, nil, nil
+	return resp.Cluster, nil, nil
+}
+
+func (c *VendorV3Client) doCreateClusterDryRunRequest(req CreateClusterRequest) (*ClusterValidationError, error) {
+	resp := ClusterValidationError{}
+	endpoint := "/v3/cluster?dry-run=true"
+	err := c.DoJSON("POST", endpoint, http.StatusOK, req, &resp)
+	if err != nil {
+		return nil, err
+	}
+	return &resp, nil
 }

--- a/pkg/kotsclient/cluster_upgrade.go
+++ b/pkg/kotsclient/cluster_upgrade.go
@@ -1,0 +1,65 @@
+package kotsclient
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/replicatedhq/replicated/pkg/types"
+)
+
+type UpgradeClusterRequest struct {
+	KubernetesVersion string `json:"kubernetes_version"`
+}
+
+type UpgradeClusterResponse struct {
+	Cluster                *types.Cluster    `json:"cluster"`
+	Errors                 []string          `json:"errors"`
+	SupportedDistributions map[string]string `json:"supported_distributions"`
+}
+
+type UpgradeClusterOpts struct {
+	KubernetesVersion string
+	DryRun            bool
+}
+
+func (c *VendorV3Client) UpgradeCluster(clusterID string, opts UpgradeClusterOpts) (*types.Cluster, *ClusterValidationError, error) {
+	req := UpgradeClusterRequest{
+		KubernetesVersion: opts.KubernetesVersion,
+	}
+
+	if opts.DryRun {
+		ve, err := c.doUpgradeClusterDryRunRequest(clusterID, req)
+		return nil, ve, err
+	}
+	return c.doUpgradeClusterRequest(clusterID, req)
+}
+
+func (c *VendorV3Client) doUpgradeClusterRequest(clusterID string, req UpgradeClusterRequest) (*types.Cluster, *ClusterValidationError, error) {
+	resp := UpgradeClusterResponse{}
+	endpoint := fmt.Sprintf("/v3/cluster/%s/upgrade", clusterID)
+	err := c.DoJSON("POST", endpoint, http.StatusOK, req, &resp)
+	if err != nil {
+		if strings.Contains(err.Error(), " 400: ") {
+			// to avoid a lot of brittle string parsing, we make the request again with
+			// a dry-run flag and expect to get the same result back
+			ve, _ := c.doUpgradeClusterDryRunRequest(clusterID, req)
+			if ve != nil && len(ve.Errors) > 0 {
+				return nil, ve, nil
+			}
+		}
+		return nil, nil, err
+	}
+
+	return resp.Cluster, nil, nil
+}
+
+func (c *VendorV3Client) doUpgradeClusterDryRunRequest(clusterID string, req UpgradeClusterRequest) (*ClusterValidationError, error) {
+	resp := ClusterValidationError{}
+	endpoint := fmt.Sprintf("/v3/cluster/%s/upgrade?dry-run=true", clusterID)
+	err := c.DoJSON("POST", endpoint, http.StatusOK, req, &resp)
+	if err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}

--- a/pkg/kotsclient/release_compatibility.go
+++ b/pkg/kotsclient/release_compatibility.go
@@ -15,11 +15,11 @@ type ReportReleaseCompatibilityErrorResponseBody struct {
 	Error ReportReleaseCompatibilityErrorResponse `json:"Error"`
 }
 type ReportReleaseCompatibilityErrorResponse struct {
-	Message         string           `json:"message"`
-	ValidationError *ValidationError `json:"validationError,omitempty"`
+	Message         string                  `json:"message"`
+	ValidationError *ClusterValidationError `json:"validationError,omitempty"`
 }
 
-func (c *VendorV3Client) ReportReleaseCompatibility(appID string, sequence int64, distribution string, version string, success bool, notes string) (*ValidationError, error) {
+func (c *VendorV3Client) ReportReleaseCompatibility(appID string, sequence int64, distribution string, version string, success bool, notes string) (*ClusterValidationError, error) {
 	request := types.CompatibilityResult{
 		Distribution: distribution,
 		Version:      version,

--- a/pkg/types/cluster.go
+++ b/pkg/types/cluster.go
@@ -5,13 +5,15 @@ import "time"
 type ClusterStatus string
 
 const (
-	ClusterStatusQueued       ClusterStatus = "queued"       // Not assigned to a runner yet
-	ClusterStatusAssigned     ClusterStatus = "assigned"     // Assigned to a runner, but have not heard back from the runner
-	ClusterStatusPreparing    ClusterStatus = "preparing"    // The runner sets this when is receives the request
-	ClusterStatusProvisioning ClusterStatus = "provisioning" // The runner sets this when it starts provisioning
-	ClusterStatusRunning      ClusterStatus = "running"      // The runner sets this when it is done provisioning and available
-	ClusterStatusTerminated   ClusterStatus = "terminated"   // This is set when the cluster expires or is deleted
-	ClusterStatusError        ClusterStatus = "error"        // Something unexpected
+	ClusterStatusQueued       ClusterStatus = "queued"        // Not assigned to a runner yet
+	ClusterStatusAssigned     ClusterStatus = "assigned"      // Assigned to a runner, but have not heard back from the runner
+	ClusterStatusPreparing    ClusterStatus = "preparing"     // The runner sets this when is receives the request
+	ClusterStatusProvisioning ClusterStatus = "provisioning"  // The runner sets this when it starts provisioning
+	ClusterStatusRunning      ClusterStatus = "running"       // The runner sets this when it is done provisioning or upgrading and available
+	ClusterStatusTerminated   ClusterStatus = "terminated"    // This is set when the cluster expires or is deleted
+	ClusterStatusError        ClusterStatus = "error"         // Something unexpected
+	ClusterStatusUpgrading    ClusterStatus = "upgrading"     // The runner sets this when it starts upgrading
+	ClusterStatusUpgradeError ClusterStatus = "upgrade_error" // Something unexpected during an upgrade
 	ClusterStatusDeleted      ClusterStatus = "deleted"
 )
 


### PR DESCRIPTION
```
$ replicated cluster upgrade --help
Upgrade a test clusters


Usage:
  replicated cluster upgrade [cluster id] [flags]

Flags:
      --dry-run          Dry run
  -h, --help             help for upgrade
      --output string    The output format to use. One of: json|table (default: table) (default "table")
      --version string   Kubernetes version to upgrade to (format is distribution dependent)
      --wait duration    Wait duration for cluster to be ready (leave empty to not wait)

Global Flags:
      --app string     The app slug or app id to use in all calls
      --token string   The API token to use to access your app in the Vendor API
```