### PR TITLE
fix (cmx): make cluster upgrade arg consistent

### DIFF
--- a/cli/cmd/cluster_upgrade.go
+++ b/cli/cmd/cluster_upgrade.go
@@ -14,7 +14,7 @@ import (
 
 func (r *runners) InitClusterUpgrade(parent *cobra.Command) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:          "upgrade [cluster id]",
+		Use:          "upgrade ID",
 		Short:        "Upgrade a test clusters",
 		Long:         `Upgrade a test clusters`,
 		Args:         cobra.ExactArgs(1),


### PR DESCRIPTION
make consistent with `replicated cluster kubeconfig ID` command