### PR TITLE
Adding cluster distribution status

### DIFF
--- a/cli/print/clusters.go
+++ b/cli/print/clusters.go
@@ -21,7 +21,10 @@ var clusterVersionsTmplSrc = `Supported Kubernetes distributions and versions ar
 DISTRIBUTION: {{ $d.Name }}
 • VERSIONS: {{ range $i, $v := $d.Versions -}}{{if $i}}, {{end}}{{ $v }}{{ end }}
 • INSTANCE TYPES: {{ range $i, $it := $d.InstanceTypes -}}{{if $i}}, {{end}}{{ $it }}{{ end }}
-• MAX NODES: {{ $d.NodesMax }}
+• MAX NODES: {{ $d.NodesMax }}{{if $d.Status}}
+• ENABLED: {{ $d.Status.Enabled }}
+• STATUS: {{ $d.Status.Status }}
+• DETAILS: {{ $d.Status.StatusMessage }}{{end}}
 
 {{ end }}`
 

--- a/pkg/types/cluster.go
+++ b/pkg/types/cluster.go
@@ -37,9 +37,16 @@ type Cluster struct {
 	Tags []ClusterTag `json:"tags"`
 }
 
+type ClusterDistributionStatus struct {
+	Enabled       bool   `json:"enabled"`
+	Status        string `json:"status"`
+	StatusMessage string `json:"status_message"`
+}
+
 type ClusterVersion struct {
-	Name          string   `json:"short_name"`
-	Versions      []string `json:"versions"`
-	InstanceTypes []string `json:"instance_types"`
-	NodesMax      int      `json:"nodes_max"`
+	Name          string                     `json:"short_name"`
+	Versions      []string                   `json:"versions"`
+	InstanceTypes []string                   `json:"instance_types"`
+	NodesMax      int                        `json:"nodes_max"`
+	Status        *ClusterDistributionStatus `json:"status,omitempty"`
 }


### PR DESCRIPTION
Example for AKS:
```
DISTRIBUTION: aks
• VERSIONS: 1.27
• INSTANCE TYPES: Standard_B2ms, Standard_B4ms, Standard_B8ms, Standard_B16ms
• MAX NODES: 10
• ENABLED: false
• STATUS: unavailable
• DETAILS: Azure isn't having it today
```