### PR TITLE
Add --output flag to various commands

### DIFF
--- a/cli/cmd/app_create.go
+++ b/cli/cmd/app_create.go
@@ -17,6 +17,7 @@ func (r *runners) InitAppCreate(parent *cobra.Command) *cobra.Command {
 		SilenceUsage: true,
 	}
 	parent.AddCommand(cmd)
+	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
 
 	return cmd
 }
@@ -45,5 +46,5 @@ func (r *runners) createApp(_ *cobra.Command, args []string) error {
 		},
 	}
 
-	return print.Apps(r.w, apps)
+	return print.Apps(r.outputFormat, r.w, apps)
 }

--- a/cli/cmd/app_delete.go
+++ b/cli/cmd/app_delete.go
@@ -19,6 +19,7 @@ func (r *runners) InitAppDelete(parent *cobra.Command) *cobra.Command {
 	}
 	parent.AddCommand(cmd)
 	cmd.Flags().BoolVarP(&r.args.deleteAppForceYes, "force", "f", false, "Skip confirmation prompt. There is no undo for this action.")
+	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
 
 	return cmd
 }
@@ -40,7 +41,7 @@ func (r *runners) deleteApp(_ *cobra.Command, args []string) error {
 
 	apps := []types.AppAndChannels{{App: app}}
 
-	err = print.Apps(r.w, apps)
+	err = print.Apps(r.outputFormat, r.w, apps)
 	if err != nil {
 		return errors.Wrap(err, "print app")
 	}

--- a/cli/cmd/app_ls.go
+++ b/cli/cmd/app_ls.go
@@ -18,6 +18,7 @@ func (r *runners) InitAppList(parent *cobra.Command) *cobra.Command {
 		SilenceUsage: true,
 	}
 	parent.AddCommand(cmd)
+	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
 
 	return cmd
 }
@@ -29,7 +30,7 @@ func (r *runners) listApps(_ *cobra.Command, args []string) error {
 	}
 
 	if len(args) == 0 {
-		return print.Apps(r.w, kotsApps)
+		return print.Apps(r.outputFormat, r.w, kotsApps)
 	}
 
 	appSearch := args[0]
@@ -39,5 +40,5 @@ func (r *runners) listApps(_ *cobra.Command, args []string) error {
 			resultApps = append(resultApps, app)
 		}
 	}
-	return print.Apps(r.w, resultApps)
+	return print.Apps(r.outputFormat, r.w, resultApps)
 }

--- a/cli/cmd/channel_create.go
+++ b/cli/cmd/channel_create.go
@@ -19,6 +19,7 @@ func (r *runners) InitChannelCreate(parent *cobra.Command) {
 
 	cmd.Flags().StringVar(&r.args.channelCreateName, "name", "", "The name of this channel")
 	cmd.Flags().StringVar(&r.args.channelCreateDescription, "description", "", "A longer description of this channel")
+	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
 
 	cmd.RunE = r.channelCreate
 }
@@ -29,5 +30,5 @@ func (r *runners) channelCreate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return print.Channels(r.w, allChannels)
+	return print.Channels(r.outputFormat, r.w, allChannels)
 }

--- a/cli/cmd/channel_inspect.go
+++ b/cli/cmd/channel_inspect.go
@@ -15,7 +15,7 @@ func (r *runners) InitChannelInspect(parent *cobra.Command) {
 		Long:  "Show full details for a channel",
 	}
 	parent.AddCommand(cmd)
-	cmd.Flags().StringVar(&r.args.channelInspectOutputFormat, "output", "text", "The output format to use. One of: json|text (default: text)")
+	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
 
 	cmd.RunE = r.channelInspect
 }
@@ -31,7 +31,7 @@ func (r *runners) channelInspect(_ *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err = print.ChannelAttrs(r.args.channelInspectOutputFormat, r.w, r.appType, r.appSlug, appChan); err != nil {
+	if err = print.ChannelAttrs(r.outputFormat, r.w, r.appType, r.appSlug, appChan); err != nil {
 		return err
 	}
 

--- a/cli/cmd/channel_ls.go
+++ b/cli/cmd/channel_ls.go
@@ -13,6 +13,8 @@ func (r *runners) InitChannelList(parent *cobra.Command) {
 	}
 
 	parent.AddCommand(cmd)
+	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
+
 	cmd.RunE = r.channelList
 }
 
@@ -22,5 +24,5 @@ func (r *runners) channelList(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return print.Channels(r.w, channels)
+	return print.Channels(r.outputFormat, r.w, channels)
 }

--- a/cli/cmd/customer_create.go
+++ b/cli/cmd/customer_create.go
@@ -16,7 +16,7 @@ func (r *runners) InitCustomersCreateCommand(parent *cobra.Command) *cobra.Comma
 		Short:         "create a customer",
 		Long:          `create a customer`,
 		RunE:          r.createCustomer,
-		SilenceUsage:  true,
+		SilenceUsage:  false,
 		SilenceErrors: true, // this command uses custom error printing
 	}
 	parent.AddCommand(cmd)
@@ -34,9 +34,9 @@ func (r *runners) InitCustomersCreateCommand(parent *cobra.Command) *cobra.Comma
 	return cmd
 }
 
-func (r *runners) createCustomer(_ *cobra.Command, _ []string) (err error) {
+func (r *runners) createCustomer(cmd *cobra.Command, _ []string) (err error) {
 	defer func() {
-		printIfError(err)
+		printIfError(cmd, err)
 	}()
 
 	// all of the following validation occurs in the API also, but

--- a/cli/cmd/customer_inspect.go
+++ b/cli/cmd/customer_inspect.go
@@ -21,7 +21,7 @@ func (r *runners) InitCustomersInspectCommand(parent *cobra.Command) *cobra.Comm
 	}
 	parent.AddCommand(cmd)
 	cmd.Flags().StringVar(&r.args.customerInspectCustomer, "customer", "", "The Customer Name or ID")
-	cmd.Flags().StringVar(&r.args.customerInspectOutputFormat, "output", "text", "The output format to use. One of: json|text (default: text)")
+	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
 
 	return cmd
 }
@@ -46,7 +46,7 @@ func (r *runners) inspectCustomer(_ *cobra.Command, _ []string) error {
 		return errors.Wrapf(err, "get registry hostname for customer %q", r.args.customerInspectCustomer)
 	}
 
-	if err = print.CustomerAttrs(r.args.customerInspectOutputFormat, r.w, r.appType, r.appSlug, ch, regHost, customer); err != nil {
+	if err = print.CustomerAttrs(r.outputFormat, r.w, r.appType, r.appSlug, ch, regHost, customer); err != nil {
 		return err
 	}
 

--- a/cli/cmd/customer_ls.go
+++ b/cli/cmd/customer_ls.go
@@ -45,10 +45,5 @@ func (r *runners) listCustomers(_ *cobra.Command, _ []string) error {
 			return errors.Wrap(err, "list customers by app and app version")
 		}
 		return print.CustomersWithInstances(r.outputFormat, r.w, customers)
-		if err != nil {
-			return errors.Wrap(err, "list customers")
-		}
-		return errors.New("Failed to list customers")
-
 	}
 }

--- a/cli/cmd/enterprise_channel_create.go
+++ b/cli/cmd/enterprise_channel_create.go
@@ -19,6 +19,7 @@ func (r *runners) InitEnterpriseChannelCreate(parent *cobra.Command) {
 
 	cmd.Flags().StringVar(&r.args.enterpriseChannelCreateName, "name", "", "The name of this channel")
 	cmd.Flags().StringVar(&r.args.enterpriseChannelCreateDescription, "description", "", "A longer description of this channel")
+	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
 
 	cmd.RunE = r.enterpriseChannelCreate
 }
@@ -29,6 +30,6 @@ func (r *runners) enterpriseChannelCreate(cmd *cobra.Command, args []string) err
 		return err
 	}
 
-	print.EnterpriseChannel(r.w, channel)
+	print.EnterpriseChannel(r.outputFormat, r.w, channel)
 	return nil
 }

--- a/cli/cmd/enterprise_channel_ls.go
+++ b/cli/cmd/enterprise_channel_ls.go
@@ -14,6 +14,7 @@ func (r *runners) InitEnterpriseChannelLS(parent *cobra.Command) *cobra.Command 
 		SilenceUsage: true,
 	}
 	parent.AddCommand(cmd)
+	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
 
 	return cmd
 }
@@ -24,6 +25,6 @@ func (r *runners) enterpriseChannelList(cmd *cobra.Command, args []string) error
 		return err
 	}
 
-	print.EnterpriseChannels(r.w, channels)
+	print.EnterpriseChannels(r.outputFormat, r.w, channels)
 	return nil
 }

--- a/cli/cmd/enterprise_channel_update.go
+++ b/cli/cmd/enterprise_channel_update.go
@@ -20,6 +20,7 @@ func (r *runners) InitEnterpriseChannelUpdate(parent *cobra.Command) {
 	cmd.Flags().StringVar(&r.args.enterpriseChannelUpdateID, "id", "", "The id of the channel to be updated")
 	cmd.Flags().StringVar(&r.args.enterpriseChannelUpdateName, "name", "", "The new name for this channel")
 	cmd.Flags().StringVar(&r.args.enterpriseChannelUpdateDescription, "description", "", "The new description of this channel")
+	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
 
 	cmd.RunE = r.enterpriseChannelUpdate
 }
@@ -30,6 +31,6 @@ func (r *runners) enterpriseChannelUpdate(cmd *cobra.Command, args []string) err
 		return err
 	}
 
-	print.EnterpriseChannel(r.w, channel)
+	print.EnterpriseChannel(r.outputFormat, r.w, channel)
 	return nil
 }

--- a/cli/cmd/enterprise_installer_create.go
+++ b/cli/cmd/enterprise_installer_create.go
@@ -21,6 +21,7 @@ func (r *runners) InitEnterpriseInstallerCreate(parent *cobra.Command) {
 	parent.AddCommand(cmd)
 
 	cmd.Flags().StringVar(&r.args.enterpriseInstallerCreateFile, "yaml-file", "", "The filename containing the installer yaml")
+	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
 
 	cmd.RunE = r.enterpriseInstallerCreate
 }
@@ -36,6 +37,6 @@ func (r *runners) enterpriseInstallerCreate(cmd *cobra.Command, args []string) e
 		return err
 	}
 
-	print.EnterpriseInstaller(r.w, installer)
+	print.EnterpriseInstaller(r.outputFormat, r.w, installer)
 	return nil
 }

--- a/cli/cmd/enterprise_installer_ls.go
+++ b/cli/cmd/enterprise_installer_ls.go
@@ -14,6 +14,7 @@ func (r *runners) InitEnterpriseInstallerLS(parent *cobra.Command) *cobra.Comman
 		SilenceUsage: true,
 	}
 	parent.AddCommand(cmd)
+	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
 
 	return cmd
 }
@@ -24,6 +25,6 @@ func (r *runners) enterpriseInstallerList(cmd *cobra.Command, args []string) err
 		return err
 	}
 
-	print.EnterpriseInstallers(r.w, installers)
+	print.EnterpriseInstallers(r.outputFormat, r.w, installers)
 	return nil
 }

--- a/cli/cmd/enterprise_installer_update.go
+++ b/cli/cmd/enterprise_installer_update.go
@@ -22,6 +22,7 @@ func (r *runners) InitEnterpriseInstallerUpdate(parent *cobra.Command) {
 
 	cmd.Flags().StringVar(&r.args.enterpriseInstallerUpdateID, "id", "", "The id of the installer to be updated")
 	cmd.Flags().StringVar(&r.args.enterpriseInstallerUpdateFile, "yaml-file", "", "The filename containing the installer yaml")
+	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
 
 	cmd.RunE = r.enterpriseInstallerUpdate
 }
@@ -37,6 +38,6 @@ func (r *runners) enterpriseInstallerUpdate(cmd *cobra.Command, args []string) e
 		return err
 	}
 
-	print.EnterpriseInstaller(r.w, installer)
+	print.EnterpriseInstaller(r.outputFormat, r.w, installer)
 	return nil
 }

--- a/cli/cmd/enterprise_policy_create.go
+++ b/cli/cmd/enterprise_policy_create.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/replicated/cli/print"
@@ -23,12 +23,13 @@ func (r *runners) InitEnterprisePolicyCreate(parent *cobra.Command) {
 	cmd.Flags().StringVar(&r.args.enterprisePolicyCreateName, "name", "", "The name of this policy")
 	cmd.Flags().StringVar(&r.args.enterprisePolicyCreateDescription, "description", "", "A longer description of this policy")
 	cmd.Flags().StringVar(&r.args.enterprisePolicyCreateFile, "policy-file", "", "The filename containing an OPA policy")
+	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
 
 	cmd.RunE = r.enterprisePolicyCreate
 }
 
 func (r *runners) enterprisePolicyCreate(cmd *cobra.Command, args []string) error {
-	b, err := ioutil.ReadFile(r.args.enterprisePolicyCreateFile)
+	b, err := os.ReadFile(r.args.enterprisePolicyCreateFile)
 	if err != nil {
 		return errors.Wrap(err, "failed to read file")
 	}
@@ -38,6 +39,6 @@ func (r *runners) enterprisePolicyCreate(cmd *cobra.Command, args []string) erro
 		return err
 	}
 
-	print.EnterprisePolicy(r.w, policy)
+	print.EnterprisePolicy(r.outputFormat, r.w, policy)
 	return nil
 }

--- a/cli/cmd/enterprise_policy_ls.go
+++ b/cli/cmd/enterprise_policy_ls.go
@@ -16,6 +16,7 @@ func (r *runners) InitEnterprisePolicyLS(parent *cobra.Command) *cobra.Command {
 		SilenceUsage: true,
 	}
 	parent.AddCommand(cmd)
+	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
 
 	return cmd
 }
@@ -32,6 +33,6 @@ func (r *runners) enterprisePolicyList(cmd *cobra.Command, args []string) error 
 		return nil
 	}
 
-	print.EnterprisePolicies(r.w, policies)
+	print.EnterprisePolicies(r.outputFormat, r.w, policies)
 	return nil
 }

--- a/cli/cmd/enterprise_policy_update.go
+++ b/cli/cmd/enterprise_policy_update.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/replicated/cli/print"
@@ -24,12 +24,13 @@ func (r *runners) InitEnterprisePolicyUpdate(parent *cobra.Command) {
 	cmd.Flags().StringVar(&r.args.enterprisePolicyUpdateName, "name", "", "The new name for this policy")
 	cmd.Flags().StringVar(&r.args.enterprisePolicyUpdateDescription, "description", "", "The new description of this policy")
 	cmd.Flags().StringVar(&r.args.enterprisePolicyUpdateFile, "policy-file", "", "The filename containing an OPA policy")
+	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
 
 	cmd.RunE = r.enterprisePolicyUpdate
 }
 
 func (r *runners) enterprisePolicyUpdate(cmd *cobra.Command, args []string) error {
-	b, err := ioutil.ReadFile(r.args.enterprisePolicyUpdateFile)
+	b, err := os.ReadFile(r.args.enterprisePolicyUpdateFile)
 	if err != nil {
 		return errors.Wrap(err, "failed to read file")
 	}
@@ -39,6 +40,6 @@ func (r *runners) enterprisePolicyUpdate(cmd *cobra.Command, args []string) erro
 		return err
 	}
 
-	print.EnterprisePolicy(r.w, policy)
+	print.EnterprisePolicy(r.outputFormat, r.w, policy)
 	return nil
 }

--- a/cli/cmd/installer_ls.go
+++ b/cli/cmd/installer_ls.go
@@ -13,6 +13,8 @@ func (r *runners) InitInstallerList(parent *cobra.Command) {
 	}
 
 	parent.AddCommand(cmd)
+	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
+
 	cmd.RunE = r.installerList
 }
 
@@ -22,5 +24,5 @@ func (r *runners) installerList(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	return print.Installers(r.w, installers)
+	return print.Installers(r.outputFormat, r.w, installers)
 }

--- a/cli/cmd/registry_add_dockerhub.go
+++ b/cli/cmd/registry_add_dockerhub.go
@@ -25,6 +25,7 @@ func (r *runners) InitRegistryAddDockerHub(parent *cobra.Command) *cobra.Command
 	cmd.Flags().BoolVar(&r.args.addRegistryPasswordFromStdIn, "password-stdin", false, "Take the password from stdin")
 	cmd.Flags().StringVar(&r.args.addRegistryToken, "token", "", "The token to authenticate to the registry with")
 	cmd.Flags().BoolVar(&r.args.addRegistryTokenFromStdIn, "token-stdin", false, "Take the token from stdin")
+	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
 
 	cmd.RunE = r.registryAddDockerHub
 
@@ -72,7 +73,7 @@ func (r *runners) registryAddDockerHub(cmd *cobra.Command, args []string) error 
 		*registry,
 	}
 
-	return print.Registries(r.w, registries)
+	return print.Registries(r.outputFormat, r.w, registries)
 }
 
 func (r *runners) validateRegistryAddDockerHub() (kotsclient.AddKOTSRegistryRequest, []error) {

--- a/cli/cmd/registry_add_ecr.go
+++ b/cli/cmd/registry_add_ecr.go
@@ -23,6 +23,7 @@ func (r *runners) InitRegistryAddECR(parent *cobra.Command) {
 	cmd.Flags().StringVar(&r.args.addRegistryAccessKeyID, "accesskeyid", "", "The access key id to authenticate to the registry with")
 	cmd.Flags().StringVar(&r.args.addRegistrySecretAccessKey, "secretaccesskey", "", "The secret access key to authenticate to the registry with")
 	cmd.Flags().BoolVar(&r.args.addRegistrySecretAccessKeyFromStdIn, "secretaccesskey-stdin", false, "Take the secret access key from stdin")
+	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
 
 	cmd.RunE = r.registryAddECR
 }
@@ -60,7 +61,7 @@ func (r *runners) registryAddECR(cmd *cobra.Command, args []string) error {
 		*registry,
 	}
 
-	return print.Registries(r.w, registries)
+	return print.Registries(r.outputFormat, r.w, registries)
 }
 
 func (r *runners) validateRegistryAddECR() (kotsclient.AddKOTSRegistryRequest, []error) {

--- a/cli/cmd/registry_add_gcr.go
+++ b/cli/cmd/registry_add_gcr.go
@@ -22,6 +22,7 @@ func (r *runners) InitRegistryAddGCR(parent *cobra.Command) {
 	cmd.Flags().StringVar(&r.args.addRegistryEndpoint, "endpoint", "", "The GCR endpoint")
 	cmd.Flags().StringVar(&r.args.addRegistryServiceAccountKey, "serviceaccountkey", "", "The service account key to authenticate to the registry with")
 	cmd.Flags().BoolVar(&r.args.addRegistryServiceAccountKeyFromStdIn, "serviceaccountkey-stdin", false, "Take the service account key from stdin")
+	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
 
 	cmd.RunE = r.registryAddGCR
 }
@@ -59,7 +60,7 @@ func (r *runners) registryAddGCR(cmd *cobra.Command, args []string) error {
 		*registry,
 	}
 
-	return print.Registries(r.w, registries)
+	return print.Registries(r.outputFormat, r.w, registries)
 
 }
 

--- a/cli/cmd/registry_add_ghcr.go
+++ b/cli/cmd/registry_add_ghcr.go
@@ -21,6 +21,7 @@ func (r *runners) InitRegistryAddGHCR(parent *cobra.Command) {
 
 	cmd.Flags().StringVar(&r.args.addRegistryToken, "token", "", "The token to use to auth to the registry with")
 	cmd.Flags().BoolVar(&r.args.addRegistryTokenFromStdIn, "token-stdin", false, "Take the token from stdin")
+	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
 
 	cmd.RunE = r.registryAddGHCR
 }
@@ -58,7 +59,7 @@ func (r *runners) registryAddGHCR(cmd *cobra.Command, args []string) error {
 		*registry,
 	}
 
-	return print.Registries(r.w, registries)
+	return print.Registries(r.outputFormat, r.w, registries)
 }
 
 func (r *runners) validateRegistryAddGHCR() (kotsclient.AddKOTSRegistryRequest, []error) {

--- a/cli/cmd/registry_add_other.go
+++ b/cli/cmd/registry_add_other.go
@@ -23,6 +23,7 @@ func (r *runners) InitRegistryAddOther(parent *cobra.Command) *cobra.Command {
 	cmd.Flags().StringVar(&r.args.addRegistryUsername, "username", "", "The userame to authenticate to the registry with")
 	cmd.Flags().StringVar(&r.args.addRegistryPassword, "password", "", "The password to authenticate to the registry with")
 	cmd.Flags().BoolVar(&r.args.addRegistryPasswordFromStdIn, "password-stdin", false, "Take the password from stdin")
+	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
 
 	cmd.RunE = r.registryAddOther
 
@@ -62,7 +63,7 @@ func (r *runners) registryAddOther(cmd *cobra.Command, args []string) error {
 		*registry,
 	}
 
-	return print.Registries(r.w, registries)
+	return print.Registries(r.outputFormat, r.w, registries)
 }
 
 func (r *runners) validateRegistryAddOther() (kotsclient.AddKOTSRegistryRequest, []error) {

--- a/cli/cmd/registry_add_quay.go
+++ b/cli/cmd/registry_add_quay.go
@@ -22,6 +22,7 @@ func (r *runners) InitRegistryAddQuay(parent *cobra.Command) *cobra.Command {
 	cmd.Flags().StringVar(&r.args.addRegistryUsername, "username", "", "The userame to authenticate to the registry with")
 	cmd.Flags().StringVar(&r.args.addRegistryPassword, "password", "", "The password to authenticate to the registry with")
 	cmd.Flags().BoolVar(&r.args.addRegistryPasswordFromStdIn, "password-stdin", false, "Take the password from stdin")
+	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
 
 	cmd.RunE = r.registryAddQuay
 
@@ -61,7 +62,7 @@ func (r *runners) registryAddQuay(cmd *cobra.Command, args []string) error {
 		*registry,
 	}
 
-	return print.Registries(r.w, registries)
+	return print.Registries(r.outputFormat, r.w, registries)
 }
 
 func (r *runners) validateRegistryAddQuay() (kotsclient.AddKOTSRegistryRequest, []error) {

--- a/cli/cmd/registry_ls.go
+++ b/cli/cmd/registry_ls.go
@@ -18,6 +18,7 @@ func (r *runners) InitRegistryList(parent *cobra.Command) *cobra.Command {
 		SilenceUsage: true,
 	}
 	parent.AddCommand(cmd)
+	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
 
 	return cmd
 }
@@ -29,7 +30,7 @@ func (r *runners) listRegistries(_ *cobra.Command, args []string) error {
 	}
 
 	if len(args) == 0 {
-		return print.Registries(r.w, kotsRegistries)
+		return print.Registries(r.outputFormat, r.w, kotsRegistries)
 	}
 
 	registrySearch := args[0]
@@ -40,5 +41,5 @@ func (r *runners) listRegistries(_ *cobra.Command, args []string) error {
 		}
 	}
 
-	return print.Registries(r.w, resultRegistries)
+	return print.Registries(r.outputFormat, r.w, resultRegistries)
 }

--- a/cli/cmd/release_create.go
+++ b/cli/cmd/release_create.go
@@ -32,7 +32,7 @@ func (r *runners) InitReleaseCreate(parent *cobra.Command) error {
 		Short: "Create a new release",
 		Long: `Create a new release by providing YAML configuration for the next release in
   your sequence.`,
-		SilenceUsage:  true,
+		SilenceUsage:  false,
 		SilenceErrors: true, // this command uses custom error printing
 	}
 
@@ -155,7 +155,7 @@ func (r *runners) setKOTSDefaultReleaseParams() error {
 
 func (r *runners) releaseCreate(cmd *cobra.Command, args []string) (err error) {
 	defer func() {
-		printIfError(err)
+		printIfError(cmd, err)
 	}()
 
 	log := logger.NewLogger(r.w)

--- a/cli/cmd/release_lint.go
+++ b/cli/cmd/release_lint.go
@@ -35,6 +35,7 @@ func (r *runners) InitReleaseLint(parent *cobra.Command) {
 	cmd.Flags().StringVar(&r.args.lintReleaseYamlDir, "yaml-dir", "", "The directory containing multiple yamls for a Kots release.  Cannot be used with the `yaml` flag.")
 	cmd.Flags().StringVar(&r.args.lintReleaseChart, "chart", "", "Helm chart to lint from. Cannot be used with the --yaml, --yaml-file, or --yaml-dir flags.")
 	cmd.Flags().StringVar(&r.args.lintReleaseFailOn, "fail-on", "error", "The minimum severity to cause the command to exit with a non-zero exit code. Supported values are [info, warn, error, none].")
+	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
 
 	cmd.RunE = r.releaseLint
 }
@@ -79,7 +80,7 @@ func (r *runners) releaseLint(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "failed to lint release")
 	}
 
-	if err := print.LintErrors(r.w, lintResult); err != nil {
+	if err := print.LintErrors(r.outputFormat, r.w, lintResult); err != nil {
 		return errors.Wrap(err, "failed to print lint errors")
 	}
 

--- a/cli/cmd/release_ls.go
+++ b/cli/cmd/release_ls.go
@@ -13,6 +13,8 @@ func (r *runners) IniReleaseList(parent *cobra.Command) {
 	}
 
 	parent.AddCommand(cmd)
+	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
+
 	cmd.RunE = r.releaseList
 }
 
@@ -22,5 +24,5 @@ func (r *runners) releaseList(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return print.Releases(r.w, releases)
+	return print.Releases(r.outputFormat, r.w, releases)
 }

--- a/cli/cmd/release_promote.go
+++ b/cli/cmd/release_promote.go
@@ -31,7 +31,7 @@ func (r *runners) InitReleasePromote(parent *cobra.Command) {
 
 func (r *runners) releasePromote(cmd *cobra.Command, args []string) (err error) {
 	defer func() {
-		printIfError(err)
+		printIfError(cmd, err)
 	}()
 
 	// parse sequence and channel ID positional arguments

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -277,7 +277,7 @@ func Execute(rootCmd *cobra.Command, stdin io.Reader, stdout io.Writer, stderr i
 	prerunCommand := func(cmd *cobra.Command, args []string) (err error) {
 		if cmd.SilenceErrors { // when SilenceErrors is set, command wants to use custom error printer
 			defer func() {
-				printIfError(err)
+				printIfError(cmd, err)
 			}()
 		}
 
@@ -319,10 +319,12 @@ func Execute(rootCmd *cobra.Command, stdin io.Reader, stdout io.Writer, stderr i
 	return runCmds.rootCmd.Execute()
 }
 
-func printIfError(err error) {
+func printIfError(cmd *cobra.Command, err error) {
 	if err == nil {
 		return
 	}
+
+	cmd.SilenceUsage = true
 
 	switch err := errors.Cause(err).(type) {
 	case platformclient.APIError:

--- a/cli/cmd/runner.go
+++ b/cli/cmd/runner.go
@@ -222,10 +222,7 @@ type runnerArgs struct {
 	apiPostBody string
 	apiPutBody  string
 
-	channelInspectOutputFormat string
-
-	customerInspectOutputFormat string
-	customerInspectCustomer     string
+	customerInspectCustomer string
 
 	compatibilityKubernetesDistribution string
 	compatibilityKubernetesVersion      string

--- a/cli/print/apps.go
+++ b/cli/print/apps.go
@@ -1,6 +1,8 @@
 package print
 
 import (
+	"encoding/json"
+	"fmt"
 	"text/tabwriter"
 	"text/template"
 
@@ -14,15 +16,22 @@ var appsTmplSrc = `ID	NAME	SLUG	SCHEDULER
 
 var appsTmpl = template.Must(template.New("apps").Funcs(funcs).Parse(appsTmplSrc))
 
-func Apps(w *tabwriter.Writer, apps []types.AppAndChannels) error {
-	var as []*types.App
+func Apps(outputFormat string, w *tabwriter.Writer, apps []types.AppAndChannels) error {
+	if outputFormat == "table" {
+		var as []*types.App
 
-	for _, a := range apps {
-		as = append(as, a.App)
-	}
+		for _, a := range apps {
+			as = append(as, a.App)
+		}
 
-	if err := appsTmpl.Execute(w, as); err != nil {
-		return err
+		if err := appsTmpl.Execute(w, as); err != nil {
+			return err
+		}
+	} else if outputFormat == "json" {
+		cAsByte, _ := json.MarshalIndent(apps, "", "  ")
+		if _, err := fmt.Fprintln(w, string(cAsByte)); err != nil {
+			return err
+		}
 	}
 
 	return w.Flush()

--- a/cli/print/channel_attributes.go
+++ b/cli/print/channel_attributes.go
@@ -42,7 +42,7 @@ func ChannelAttrs(outputFormat string,
 	appSlug string,
 	appChan *types.Channel,
 ) error {
-	if outputFormat == "text" {
+	if outputFormat == "text" || outputFormat == "table" {
 		attrs := struct {
 			Existing string
 			Embedded string

--- a/cli/print/channel_attributes_test.go
+++ b/cli/print/channel_attributes_test.go
@@ -55,7 +55,7 @@ func Test_ChannelAttrs(t *testing.T) {
 			var out bytes.Buffer
 			w := tabwriter.NewWriter(&out, 0, 8, 4, ' ', tabwriter.TabIndent)
 
-			err := ChannelAttrs("text", w, tt.appType, tt.appSlug, tt.appChan)
+			err := ChannelAttrs("table", w, tt.appType, tt.appSlug, tt.appChan)
 			assert.NoError(t, err)
 
 			w.Flush()

--- a/cli/print/channels.go
+++ b/cli/print/channels.go
@@ -1,6 +1,8 @@
 package print
 
 import (
+	"encoding/json"
+	"fmt"
 	"text/tabwriter"
 	"text/template"
 
@@ -15,9 +17,16 @@ var channelsTmplSrc = `ID	NAME	RELEASE	VERSION
 
 var channelsTmpl = template.Must(template.New("channels").Parse(channelsTmplSrc))
 
-func Channels(w *tabwriter.Writer, channels []*types.Channel) error {
-	if err := channelsTmpl.Execute(w, channels); err != nil {
-		return err
+func Channels(outputFormat string, w *tabwriter.Writer, channels []*types.Channel) error {
+	if outputFormat == "table" {
+		if err := channelsTmpl.Execute(w, channels); err != nil {
+			return err
+		}
+	} else if outputFormat == "json" {
+		cAsByte, _ := json.MarshalIndent(channels, "", "  ")
+		if _, err := fmt.Fprintln(w, string(cAsByte)); err != nil {
+			return err
+		}
 	}
 	return w.Flush()
 }

--- a/cli/print/customer_attributes.go
+++ b/cli/print/customer_attributes.go
@@ -49,7 +49,7 @@ func CustomerAttrs(outputFormat string,
 	registryHostname string,
 	cust *types.Customer,
 ) error {
-	if outputFormat == "text" {
+	if outputFormat == "text" || outputFormat == "table" {
 		attrs := struct {
 			Login     string
 			Preflight string

--- a/cli/print/enterprise_channel.go
+++ b/cli/print/enterprise_channel.go
@@ -1,6 +1,8 @@
 package print
 
 import (
+	"encoding/json"
+	"fmt"
 	"text/tabwriter"
 	"text/template"
 
@@ -13,9 +15,16 @@ var enterpriseChannelTmplSrc = `ID	NAME
 
 var enterpriseChannelTmpl = template.Must(template.New("enterprisechannel").Parse(enterpriseChannelTmplSrc))
 
-func EnterpriseChannel(w *tabwriter.Writer, channel *enterprisetypes.Channel) error {
-	if err := enterpriseChannelTmpl.Execute(w, channel); err != nil {
-		return err
+func EnterpriseChannel(outputFormat string, w *tabwriter.Writer, channel *enterprisetypes.Channel) error {
+	if outputFormat == "table" {
+		if err := enterpriseChannelTmpl.Execute(w, channel); err != nil {
+			return err
+		}
+	} else if outputFormat == "json" {
+		cAsByte, _ := json.MarshalIndent(channel, "", "  ")
+		if _, err := fmt.Fprintln(w, string(cAsByte)); err != nil {
+			return err
+		}
 	}
 	return w.Flush()
 }

--- a/cli/print/enterprise_channels.go
+++ b/cli/print/enterprise_channels.go
@@ -1,6 +1,8 @@
 package print
 
 import (
+	"encoding/json"
+	"fmt"
 	"text/tabwriter"
 	"text/template"
 
@@ -14,9 +16,16 @@ var enterpriseChannelsTmplSrc = `ID	NAME
 
 var enterpriseChannelsTmpl = template.Must(template.New("enterprisechannels").Parse(enterpriseChannelsTmplSrc))
 
-func EnterpriseChannels(w *tabwriter.Writer, channels []*enterprisetypes.Channel) error {
-	if err := enterpriseChannelsTmpl.Execute(w, channels); err != nil {
-		return err
+func EnterpriseChannels(outputFormat string, w *tabwriter.Writer, channels []*enterprisetypes.Channel) error {
+	if outputFormat == "table" {
+		if err := enterpriseChannelsTmpl.Execute(w, channels); err != nil {
+			return err
+		}
+	} else if outputFormat == "json" {
+		cAsByte, _ := json.MarshalIndent(channels, "", "  ")
+		if _, err := fmt.Fprintln(w, string(cAsByte)); err != nil {
+			return err
+		}
 	}
 	return w.Flush()
 }

--- a/cli/print/enterprise_installer.go
+++ b/cli/print/enterprise_installer.go
@@ -1,6 +1,8 @@
 package print
 
 import (
+	"encoding/json"
+	"fmt"
 	"text/tabwriter"
 	"text/template"
 
@@ -13,9 +15,17 @@ var enterpriseInstallerTmplSrc = `ID
 
 var enterpriseInstallerTmpl = template.Must(template.New("enterpriseinstaller").Parse(enterpriseInstallerTmplSrc))
 
-func EnterpriseInstaller(w *tabwriter.Writer, installer *enterprisetypes.Installer) error {
-	if err := enterpriseInstallerTmpl.Execute(w, installer); err != nil {
-		return err
+func EnterpriseInstaller(outputFormat string, w *tabwriter.Writer, installer *enterprisetypes.Installer) error {
+	if outputFormat == "table" {
+		if err := enterpriseInstallerTmpl.Execute(w, installer); err != nil {
+			return err
+		}
+	} else if outputFormat == "json" {
+		cAsByte, _ := json.MarshalIndent(installer, "", "  ")
+		if _, err := fmt.Fprintln(w, string(cAsByte)); err != nil {
+			return err
+		}
 	}
+
 	return w.Flush()
 }

--- a/cli/print/enterprise_installers.go
+++ b/cli/print/enterprise_installers.go
@@ -1,6 +1,8 @@
 package print
 
 import (
+	"encoding/json"
+	"fmt"
 	"text/tabwriter"
 	"text/template"
 
@@ -14,9 +16,17 @@ var enterpriseInstallersTmplSrc = `ID
 
 var enterpriseInstallersTmpl = template.Must(template.New("enterpriseinstallers").Parse(enterpriseInstallersTmplSrc))
 
-func EnterpriseInstallers(w *tabwriter.Writer, installers []*enterprisetypes.Installer) error {
-	if err := enterpriseInstallersTmpl.Execute(w, installers); err != nil {
-		return err
+func EnterpriseInstallers(outputFormat string, w *tabwriter.Writer, installers []*enterprisetypes.Installer) error {
+	if outputFormat == "table" {
+		if err := enterpriseInstallersTmpl.Execute(w, installers); err != nil {
+			return err
+		}
+	} else if outputFormat == "json" {
+		cAsByte, _ := json.MarshalIndent(installers, "", "  ")
+		if _, err := fmt.Fprintln(w, string(cAsByte)); err != nil {
+			return err
+		}
 	}
+
 	return w.Flush()
 }

--- a/cli/print/enterprise_policies.go
+++ b/cli/print/enterprise_policies.go
@@ -1,6 +1,8 @@
 package print
 
 import (
+	"encoding/json"
+	"fmt"
 	"text/tabwriter"
 	"text/template"
 
@@ -14,9 +16,16 @@ var enterprisePoliciesTmplSrc = `ID	NAME
 
 var enterprisePoliciesTmpl = template.Must(template.New("enterprisepolicies").Parse(enterprisePoliciesTmplSrc))
 
-func EnterprisePolicies(w *tabwriter.Writer, policies []*enterprisetypes.Policy) error {
-	if err := enterprisePoliciesTmpl.Execute(w, policies); err != nil {
-		return err
+func EnterprisePolicies(outputFormat string, w *tabwriter.Writer, policies []*enterprisetypes.Policy) error {
+	if outputFormat == "table" {
+		if err := enterprisePoliciesTmpl.Execute(w, policies); err != nil {
+			return err
+		}
+	} else if outputFormat == "json" {
+		cAsByte, _ := json.MarshalIndent(policies, "", "  ")
+		if _, err := fmt.Fprintln(w, string(cAsByte)); err != nil {
+			return err
+		}
 	}
 	return w.Flush()
 }

--- a/cli/print/enterprise_policy.go
+++ b/cli/print/enterprise_policy.go
@@ -1,6 +1,8 @@
 package print
 
 import (
+	"encoding/json"
+	"fmt"
 	"text/tabwriter"
 	"text/template"
 
@@ -13,9 +15,16 @@ var enterprisePolicyTmplSrc = `ID	NAME
 
 var enterprisePolicyTmpl = template.Must(template.New("entrerprisepolicy").Parse(enterprisePolicyTmplSrc))
 
-func EnterprisePolicy(w *tabwriter.Writer, policy *enterprisetypes.Policy) error {
-	if err := enterprisePolicyTmpl.Execute(w, policy); err != nil {
-		return err
+func EnterprisePolicy(outputFormat string, w *tabwriter.Writer, policy *enterprisetypes.Policy) error {
+	if outputFormat == "table" {
+		if err := enterprisePolicyTmpl.Execute(w, policy); err != nil {
+			return err
+		}
+	} else if outputFormat == "json" {
+		cAsByte, _ := json.MarshalIndent(policy, "", "  ")
+		if _, err := fmt.Fprintln(w, string(cAsByte)); err != nil {
+			return err
+		}
 	}
 	return w.Flush()
 }

--- a/cli/print/lint.go
+++ b/cli/print/lint.go
@@ -1,6 +1,8 @@
 package print
 
 import (
+	"encoding/json"
+	"fmt"
 	"text/tabwriter"
 	"text/template"
 
@@ -14,9 +16,16 @@ var lintTmplSrc = `RULE	TYPE	FILENAME	LINE	MESSAGE
 
 var lintTmpl = template.Must(template.New("lint").Parse(lintTmplSrc))
 
-func LintErrors(w *tabwriter.Writer, lintErrors []types.LintMessage) error {
-	if err := lintTmpl.Execute(w, lintErrors); err != nil {
-		return err
+func LintErrors(outputFormat string, w *tabwriter.Writer, lintErrors []types.LintMessage) error {
+	if outputFormat == "table" {
+		if err := lintTmpl.Execute(w, lintErrors); err != nil {
+			return err
+		}
+	} else if outputFormat == "json" {
+		cAsByte, _ := json.MarshalIndent(lintErrors, "", "  ")
+		if _, err := fmt.Fprintln(w, string(cAsByte)); err != nil {
+			return err
+		}
 	}
 	return w.Flush()
 }

--- a/cli/print/registries.go
+++ b/cli/print/registries.go
@@ -1,6 +1,8 @@
 package print
 
 import (
+	"encoding/json"
+	"fmt"
 	"text/tabwriter"
 	"text/template"
 
@@ -14,9 +16,16 @@ var registriesTmplSrc = `PROVIDER	ENDPOINT	AUTHTYPE
 
 var registriesTmpl = template.Must(template.New("registries").Funcs(funcs).Parse(registriesTmplSrc))
 
-func Registries(w *tabwriter.Writer, registries []types.Registry) error {
-	if err := registriesTmpl.Execute(w, registries); err != nil {
-		return err
+func Registries(outputFormat string, w *tabwriter.Writer, registries []types.Registry) error {
+	if outputFormat == "table" {
+		if err := registriesTmpl.Execute(w, registries); err != nil {
+			return err
+		}
+	} else if outputFormat == "json" {
+		cAsByte, _ := json.MarshalIndent(registries, "", "  ")
+		if _, err := fmt.Fprintln(w, string(cAsByte)); err != nil {
+			return err
+		}
 	}
 
 	return w.Flush()

--- a/cli/print/releases.go
+++ b/cli/print/releases.go
@@ -1,6 +1,8 @@
 package print
 
 import (
+	"encoding/json"
+	"fmt"
 	"strings"
 	"text/tabwriter"
 	"text/template"
@@ -16,32 +18,39 @@ var releasesTmplSrc = `SEQUENCE	CREATED	EDITED	ACTIVE_CHANNELS
 
 var releasesTmpl = template.Must(template.New("Releases").Funcs(funcs).Parse(releasesTmplSrc))
 
-func Releases(w *tabwriter.Writer, appReleases []types.ReleaseInfo) error {
-	rs := make([]map[string]interface{}, len(appReleases))
+func Releases(outputFormat string, w *tabwriter.Writer, appReleases []types.ReleaseInfo) error {
+	if outputFormat == "table" {
+		rs := make([]map[string]interface{}, len(appReleases))
 
-	for i, r := range appReleases {
-		// join active channel names like "Stable,Unstable"
-		activeChans := make([]string, len(r.ActiveChannels))
-		for j, activeChan := range r.ActiveChannels {
-			activeChans[j] = activeChan.Name
-		}
-		activeChansField := strings.Join(activeChans, ",")
+		for i, r := range appReleases {
+			// join active channel names like "Stable,Unstable"
+			activeChans := make([]string, len(r.ActiveChannels))
+			for j, activeChan := range r.ActiveChannels {
+				activeChans[j] = activeChan.Name
+			}
+			activeChansField := strings.Join(activeChans, ",")
 
-		// don't print edited if it's the same as created
-		edited := r.EditedAt.Format(time.RFC3339)
-		if r.CreatedAt.Equal(r.EditedAt) {
-			edited = ""
+			// don't print edited if it's the same as created
+			edited := r.EditedAt.Format(time.RFC3339)
+			if r.CreatedAt.Equal(r.EditedAt) {
+				edited = ""
+			}
+			rs[i] = map[string]interface{}{
+				"Sequence":       r.Sequence,
+				"CreatedAt":      r.CreatedAt,
+				"EditedAt":       edited,
+				"ActiveChannels": activeChansField,
+			}
 		}
-		rs[i] = map[string]interface{}{
-			"Sequence":       r.Sequence,
-			"CreatedAt":      r.CreatedAt,
-			"EditedAt":       edited,
-			"ActiveChannels": activeChansField,
-		}
-	}
 
-	if err := releasesTmpl.Execute(w, rs); err != nil {
-		return err
+		if err := releasesTmpl.Execute(w, rs); err != nil {
+			return err
+		}
+	} else if outputFormat == "json" {
+		cAsByte, _ := json.MarshalIndent(appReleases, "", "  ")
+		if _, err := fmt.Fprintln(w, string(cAsByte)); err != nil {
+			return err
+		}
 	}
 
 	return w.Flush()

--- a/pkg/types/app.go
+++ b/pkg/types/app.go
@@ -3,16 +3,16 @@ package types
 import "time"
 
 type App struct {
-	ID           string
-	Name         string
-	Scheduler    string
-	Slug         string
-	IsFoundation bool
+	ID           string `json:"id"`
+	Name         string `json:"name"`
+	Scheduler    string `json:"scheduler"`
+	Slug         string `json:"slug"`
+	IsFoundation bool   `json:"isFoundation"`
 }
 
 type AppAndChannels struct {
-	App      *App
-	Channels []Channel
+	App      *App      `json:"app"`
+	Channels []Channel `json:"channels"`
 }
 
 type KotsAppWithChannels struct {


### PR DESCRIPTION
Added for various commands with some exceptions:
- commands that don't support KOTS
- `customer license download`

There were two existing commands that expected "text" instead of "table". They now support both, but only "table" will be documented"

```
$ ./bin/replicated channel ls --output json
Update available: v0.60.0
To automatically upgrade, run "replicated version upgrade"
[
  {
    "id": "2ULZUQp3A9bH79uS3rwSaGArWig",
    "name": "Stable",
    "description": "",
    "channelSlug": "stable",
    "releaseSequence": 0,
    "releaseLabel": "",
    "isArchived": false,
    "isHelmOnly": false
  },
  {
    "id": "2ULZUSyJypjZLc6xkBZfReDMqPz",
    "name": "Beta",
    "description": "",
    "channelSlug": "beta",
    "releaseSequence": 47,
    "releaseLabel": "1.0.16",
    "isArchived": false,
    "isHelmOnly": true
  },
  {
    "id": "2ULZURFgOKVpjtpWG4xJUBKL8Rc",
    "name": "Unstable",
    "description": "",
    "channelSlug": "unstable",
    "releaseSequence": 50,
    "releaseLabel": "0.0.4",
    "isArchived": false,
    "isHelmOnly": false
  }
]
```

```
$ ./bin/replicated app ls --output json
Update available: v0.60.0
To automatically upgrade, run "replicated version upgrade"
[
  {
    "app": {
      "id": "28ysVLZT3OiZLXuOVW3ZUDXRu9D",
      "name": "okteto-kots",
      "scheduler": "kots",
      "slug": "okteto-kots",
      "isFoundation": false
    },
    "channels": [
      {
        "id": "28ysVXknIJUl9ncG4xVRHgw5tUt",
        "name": "Stable",
        "description": "",
        "channelSlug": "stable",
        "releaseSequence": 170,
        "releaseLabel": "",
        "isArchived": false,
        "isHelmOnly": true
      },
...
```

```
$ ./bin/replicated release lint --yaml-dir ./yaml-kots --output json
Update available: v0.60.0
To automatically upgrade, run "replicated version upgrade"
[
  {
    "rule": "helm-chart-missing",
    "type": "error",
    "path": "",
    "message": "Could not find helm chart manifest for archive 'yaml-kots/postgresql-11.9.2.tgz'",
    "positions": null
  }
]
Error: One or more errors of severity "error" or higher were found
```