### PR TITLE
Adding node and nodegroup count to output

### DIFF
--- a/cli/cmd/cluster_create.go
+++ b/cli/cmd/cluster_create.go
@@ -45,7 +45,7 @@ https://docs.replicated.com/vendor/testing-how-to#limitations`,
 
 	cmd.Flags().BoolVar(&r.args.createClusterDryRun, "dry-run", false, "Dry run")
 
-	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
+	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table|wide (default: table)")
 
 	_ = cmd.MarkFlagRequired("distribution")
 

--- a/cli/cmd/cluster_ls.go
+++ b/cli/cmd/cluster_ls.go
@@ -24,7 +24,7 @@ func (r *runners) InitClusterList(parent *cobra.Command) *cobra.Command {
 	cmd.Flags().BoolVar(&r.args.lsClusterShowTerminated, "show-terminated", false, "when set, only show terminated clusters")
 	cmd.Flags().StringVar(&r.args.lsClusterStartTime, "start-time", "", "start time for the query (Format: 2006-01-02T15:04:05Z)")
 	cmd.Flags().StringVar(&r.args.lsClusterEndTime, "end-time", "", "end time for the query (Format: 2006-01-02T15:04:05Z)")
-	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
+	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table|wide (default: table)")
 	cmd.Flags().BoolVarP(&r.args.lsClusterWatch, "watch", "w", false, "watch clusters")
 
 	return cmd
@@ -59,7 +59,7 @@ func (r *runners) listClusters(_ *cobra.Command, args []string) error {
 	if r.args.lsClusterWatch {
 
 		// Checks to see if the outputFormat is table
-		if r.outputFormat != "table" {
+		if r.outputFormat != "table" && r.outputFormat != "wide" {
 			return errors.New("watch is only supported for table output")
 		}
 

--- a/cli/cmd/cluster_update_ttl.go
+++ b/cli/cmd/cluster_update_ttl.go
@@ -21,7 +21,7 @@ func (r *runners) InitClusterUpdateTTL(parent *cobra.Command) *cobra.Command {
 
 	cmd.Flags().StringVar(&r.args.updateClusterTTL, "ttl", "", "Update TTL which starts from the moment the cluster is running (duration, max 48h).")
 
-	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
+	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table|wide (default: table)")
 
 	_ = cmd.MarkFlagRequired("ttl")
 

--- a/cli/cmd/cluster_upgrade.go
+++ b/cli/cmd/cluster_upgrade.go
@@ -27,7 +27,7 @@ func (r *runners) InitClusterUpgrade(parent *cobra.Command) *cobra.Command {
 	cmd.Flags().BoolVar(&r.args.upgradeClusterDryRun, "dry-run", false, "Dry run")
 	cmd.Flags().DurationVar(&r.args.upgradeClusterWaitDuration, "wait", 0, "Wait duration for cluster to be ready (leave empty to not wait)")
 
-	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
+	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table|wide (default: table)")
 
 	_ = cmd.MarkFlagRequired("version")
 

--- a/cli/print/clusters.go
+++ b/cli/print/clusters.go
@@ -19,7 +19,7 @@ var clustersTmplTable = template.Must(template.New("clusters").Funcs(funcs).Pars
 var clustersTmplTableNoHeader = template.Must(template.New("clusters").Funcs(funcs).Parse(clustersTmplTableRowSrc))
 
 // Wide table formatting
-var clustersTmplWideHeaderSrc = `ID	NAME	DISTRIBUTION	VERSION	STATUS	CREATED	EXPIRES	NODES	NODEGROUPS	TAGS`
+var clustersTmplWideHeaderSrc = `ID	NAME	DISTRIBUTION	VERSION	STATUS	CREATED	EXPIRES	TOTAL NODES	NODEGROUPS	TAGS`
 var clustersTmplWideRowSrc = `{{ range . -}}
 {{ .ID }}	{{ padding .Name 27	}}	{{ padding .KubernetesDistribution 12 }}	{{ padding .KubernetesVersion 10 }}	{{ padding (printf "%s" .Status) 12 }}	{{ .CreatedAt}}	{{if .ExpiresAt.IsZero}}-{{else}}{{ .ExpiresAt }}{{end}}	{{$nodecount:=0}}{{ range $index, $ng := .NodeGroups}}{{$nodecount = add $nodecount $ng.NodeCount}}{{ end }}{{ $nodecount}}	{{ len .NodeGroups}}	{{ range $index, $tag := .Tags }}{{if $index}}, {{end}}{{ $tag.Key }}={{ $tag.Value }}{{ end }}
 {{ end }}`

--- a/cli/print/util.go
+++ b/cli/print/util.go
@@ -16,4 +16,7 @@ var funcs = template.FuncMap{
 		}
 		return s
 	},
+	"add": func(a, b int) int {
+		return a + b
+	},
 }

--- a/pkg/types/cluster.go
+++ b/pkg/types/cluster.go
@@ -18,18 +18,36 @@ const (
 )
 
 type Cluster struct {
-	ID                     string `json:"id"`
-	Name                   string `json:"name"`
-	KubernetesDistribution string `json:"kubernetes_distribution"`
-	KubernetesVersion      string `json:"kubernetes_version"`
-	NodeCount              int    `json:"node_count"`
-	DiskGiB                int64  `json:"disk_gib"`
+	ID                     string       `json:"id"`
+	Name                   string       `json:"name"`
+	KubernetesDistribution string       `json:"kubernetes_distribution"`
+	KubernetesVersion      string       `json:"kubernetes_version"`
+	NodeGroups             []*NodeGroup `json:"node_groups"`
 
 	Status    ClusterStatus `json:"status"`
 	CreatedAt time.Time     `json:"created_at"`
 	ExpiresAt time.Time     `json:"expires_at"`
 
 	Tags []Tag `json:"tags"`
+}
+
+type NodeGroup struct {
+	ID           string `json:"id"`
+	ClusterID    string `json:"cluster_id"`
+	IsDefault    bool   `json:"is_default"`
+	InstanceType string `json:"instance_type"`
+
+	Name      string `json:"name"`
+	NodeCount int    `json:"node_count"`
+	DiskGiB   int64  `json:"disk_gib"`
+
+	CreatedAt      time.Time  `json:"created_at"`
+	ProvisioningAt *time.Time `json:"-"`
+	RunningAt      *time.Time `json:"running_at"`
+	CreditsPerHour int64      `json:"credits_per_hour"`
+
+	TotalCredits  int64 `json:"total_credits,omitempty"` // this is only present after the cluster is stopped
+	MinutesBilled int64 `json:"minutes_billed"`
 }
 
 type ClusterDistributionStatus struct {


### PR DESCRIPTION
Example:
```
> replicated cluster ls  --output wide
ID          NAME                           DISTRIBUTION    VERSION       STATUS          CREATED                          EXPIRES                          NODES    NODEGROUPS    TAGS
5742e99e    elastic_pare                   eks             1.29          provisioning    2024-02-14 17:46:30 +0000 UTC    -                                4        2
29e73446    affectionate_jepsen            k3s             1.29.0        running         2024-02-14 17:12:44 +0000 UTC    2024-02-14 18:15:01 +0000 UTC    1        1
```