### PR TITLE
minor: small typo on replicated registry test

### DIFF
--- a/cli/cmd/registry_validate.go
+++ b/cli/cmd/registry_validate.go
@@ -38,7 +38,7 @@ func (r *runners) registryTest(cmd *cobra.Command, args []string) error {
 	}
 
 	if status == http.StatusOK {
-		fmt.Println("Registry conection appears ok")
+		fmt.Println("Registry coninection appears ok")
 	} else if status == http.StatusNotFound {
 		fmt.Println(`Registry connection failed with MANIFEST_UNKNOWN.
 Check that the credentials are ok and that the image exists.

--- a/cli/cmd/registry_validate.go
+++ b/cli/cmd/registry_validate.go
@@ -38,7 +38,7 @@ func (r *runners) registryTest(cmd *cobra.Command, args []string) error {
 	}
 
 	if status == http.StatusOK {
-		fmt.Println("Registry coninection appears ok")
+		fmt.Println("Registry connection appears ok")
 	} else if status == http.StatusNotFound {
 		fmt.Println(`Registry connection failed with MANIFEST_UNKNOWN.
 Check that the credentials are ok and that the image exists.


### PR DESCRIPTION
```
replicated registry test <endpoint> --image <repo>/<image>
Registry conection appears ok
```