### PR TITLE
Add custom-id to customer create params

### DIFF
--- a/cli/cmd/customer_create.go
+++ b/cli/cmd/customer_create.go
@@ -21,6 +21,7 @@ func (r *runners) InitCustomersCreateCommand(parent *cobra.Command) *cobra.Comma
 	}
 	parent.AddCommand(cmd)
 	cmd.Flags().StringVar(&r.args.customerCreateName, "name", "", "Name of the customer")
+	cmd.Flags().StringVar(&r.args.customerCreateCustomID, "custom-id", "", "Set a custom customer ID to more easily tie this customer record to your external data systems")
 	cmd.Flags().StringVar(&r.args.customerCreateChannel, "channel", "", "Release channel to which the customer should be assigned")
 	cmd.Flags().DurationVar(&r.args.customerCreateExpiryDuration, "expires-in", 0, "If set, an expiration date will be set on the license. Supports Go durations like '72h' or '3600m'")
 	cmd.Flags().BoolVar(&r.args.customerCreateEnsureChannel, "ensure-channel", false, "If set, channel will be created if it does not exist.")
@@ -71,6 +72,7 @@ func (r *runners) createCustomer(cmd *cobra.Command, _ []string) (err error) {
 
 	opts := kotsclient.CreateCustomerOpts{
 		Name:                r.args.customerCreateName,
+		CustomID:            r.args.customerCreateCustomID,
 		ChannelID:           channelID,
 		AppID:               r.appID,
 		ExpiresAt:           r.args.customerCreateExpiryDuration,

--- a/cli/cmd/runner.go
+++ b/cli/cmd/runner.go
@@ -77,6 +77,7 @@ type runnerArgs struct {
 
 	customerArchiveNameOrId           string
 	customerCreateName                string
+	customerCreateCustomID            string
 	customerCreateChannel             string
 	customerCreateEnsureChannel       bool
 	customerCreateExpiryDuration      time.Duration

--- a/cli/print/customers.go
+++ b/cli/print/customers.go
@@ -10,9 +10,9 @@ import (
 	"github.com/replicatedhq/replicated/pkg/types"
 )
 
-var customersTmplSrc = `ID	NAME	CHANNELS	EXPIRES	TYPE
+var customersTmplSrc = `ID	NAME	CHANNELS	EXPIRES	TYPE	CUSTOM_ID
 {{ range . -}}
-{{ .ID }}	{{ .Name }}	{{range .Channels}} {{.Name}}{{end}}	{{if not .Expires}}Never{{else}}{{.Expires}}{{end}}	{{.Type}}
+{{ .ID }}	{{ .Name }}	{{range .Channels}} {{.Name}}{{end}}	{{if not .Expires}}Never{{else}}{{.Expires}}{{end}}	{{.Type}}	{{if not .CustomID}}Not Set{{else}}{{.CustomID}}{{end}}
 {{ end }}`
 
 var customersTmpl = template.Must(template.New("channels").Parse(customersTmplSrc))

--- a/pkg/kotsclient/customer_create.go
+++ b/pkg/kotsclient/customer_create.go
@@ -16,6 +16,7 @@ type EntitlementValue struct {
 type CreateCustomerRequest struct {
 	Name                string             `json:"name"`
 	ChannelID           string             `json:"channel_id"`
+	CustomID            string             `json:"custom_id"`
 	AppID               string             `json:"app_id"`
 	Type                string             `json:"type"`
 	ExpiresAt           string             `json:"expires_at"`
@@ -33,6 +34,7 @@ type CreateCustomerResponse struct {
 
 type CreateCustomerOpts struct {
 	Name                string
+	CustomID            string
 	ChannelID           string
 	AppID               string
 	ExpiresAt           time.Duration
@@ -48,6 +50,7 @@ type CreateCustomerOpts struct {
 func (c *VendorV3Client) CreateCustomer(opts CreateCustomerOpts) (*types.Customer, error) {
 	request := &CreateCustomerRequest{
 		Name:                opts.Name,
+		CustomID:            opts.CustomID,
 		ChannelID:           opts.ChannelID,
 		AppID:               opts.AppID,
 		Type:                opts.LicenseType,

--- a/pkg/types/customer.go
+++ b/pkg/types/customer.go
@@ -7,6 +7,7 @@ import (
 
 type Customer struct {
 	ID             string     `json:"id"`
+	CustomID       string     `json:"customId"`
 	Name           string     `json:"name"`
 	Email          string     `json:"email"`
 	Channels       []Channel  `json:"channels"`


### PR DESCRIPTION
- Adds ability to create customer with a `custom-id`
- `customer ls` now displays `custom-id`