### PR TITLE
feat(cmx): add embedded-cluster distribution

### DIFF
--- a/cli/cmd/cluster_create.go
+++ b/cli/cmd/cluster_create.go
@@ -34,6 +34,7 @@ https://docs.replicated.com/vendor/testing-how-to#limitations`,
 	cmd.Flags().StringVar(&r.args.createClusterName, "name", "", "Cluster name (defaults to random name)")
 	cmd.Flags().StringVar(&r.args.createClusterKubernetesDistribution, "distribution", "", "Kubernetes distribution of the cluster to provision")
 	cmd.Flags().StringVar(&r.args.createClusterKubernetesVersion, "version", "", "Kubernetes version to provision (format is distribution dependent)")
+	cmd.Flags().StringVar(&r.args.createClusterLicenseID, "license-id", "", "License ID to use for the installation (required for Embedded Cluster)")
 	cmd.Flags().IntVar(&r.args.createClusterNodeCount, "nodes", int(1), "Node count")
 	cmd.Flags().Int64Var(&r.args.createClusterDiskGiB, "disk", int64(50), "Disk Size (GiB) to request per node")
 	cmd.Flags().StringVar(&r.args.createClusterTTL, "ttl", "", "Cluster TTL (duration, max 48h)")
@@ -71,6 +72,7 @@ func (r *runners) createCluster(_ *cobra.Command, args []string) error {
 		Name:                   r.args.createClusterName,
 		KubernetesDistribution: r.args.createClusterKubernetesDistribution,
 		KubernetesVersion:      r.args.createClusterKubernetesVersion,
+		LicenseID:              r.args.createClusterLicenseID,
 		NodeCount:              r.args.createClusterNodeCount,
 		DiskGiB:                r.args.createClusterDiskGiB,
 		TTL:                    r.args.createClusterTTL,

--- a/cli/cmd/cluster_create.go
+++ b/cli/cmd/cluster_create.go
@@ -34,7 +34,7 @@ https://docs.replicated.com/vendor/testing-how-to#limitations`,
 	cmd.Flags().StringVar(&r.args.createClusterName, "name", "", "Cluster name (defaults to random name)")
 	cmd.Flags().StringVar(&r.args.createClusterKubernetesDistribution, "distribution", "", "Kubernetes distribution of the cluster to provision")
 	cmd.Flags().StringVar(&r.args.createClusterKubernetesVersion, "version", "", "Kubernetes version to provision (format is distribution dependent)")
-	cmd.Flags().StringVar(&r.args.createClusterLicenseID, "license-id", "", "License ID to use for the installation (required for Embedded Cluster)")
+	cmd.Flags().StringVar(&r.args.createClusterLicenseID, "license-id", "", "License ID to use for the installation (required for Embedded Cluster distribution)")
 	cmd.Flags().IntVar(&r.args.createClusterNodeCount, "nodes", int(1), "Node count")
 	cmd.Flags().Int64Var(&r.args.createClusterDiskGiB, "disk", int64(50), "Disk Size (GiB) to request per node")
 	cmd.Flags().StringVar(&r.args.createClusterTTL, "ttl", "", "Cluster TTL (duration, max 48h)")

--- a/cli/cmd/runner.go
+++ b/cli/cmd/runner.go
@@ -172,6 +172,7 @@ type runnerArgs struct {
 	createClusterName                   string
 	createClusterKubernetesDistribution string
 	createClusterKubernetesVersion      string
+	createClusterLicenseID              string
 	createClusterNodeCount              int
 	createClusterDiskGiB                int64
 	createClusterDryRun                 bool

--- a/pkg/kotsclient/cluster_create.go
+++ b/pkg/kotsclient/cluster_create.go
@@ -14,6 +14,7 @@ type CreateClusterRequest struct {
 	Name                   string      `json:"name"`
 	KubernetesDistribution string      `json:"kubernetes_distribution"`
 	KubernetesVersion      string      `json:"kubernetes_version"`
+	LicenseID              string      `json:"license_id"`
 	NodeCount              int         `json:"node_count"`
 	DiskGiB                int64       `json:"disk_gib"`
 	TTL                    string      `json:"ttl"`
@@ -32,6 +33,7 @@ type CreateClusterOpts struct {
 	Name                   string
 	KubernetesDistribution string
 	KubernetesVersion      string
+	LicenseID              string
 	NodeCount              int
 	DiskGiB                int64
 	TTL                    string
@@ -71,6 +73,7 @@ func (c *VendorV3Client) CreateCluster(opts CreateClusterOpts) (*types.Cluster, 
 		Name:                   opts.Name,
 		KubernetesDistribution: opts.KubernetesDistribution,
 		KubernetesVersion:      opts.KubernetesVersion,
+		LicenseID:              opts.LicenseID,
 		NodeCount:              opts.NodeCount,
 		DiskGiB:                opts.DiskGiB,
 		TTL:                    opts.TTL,


### PR DESCRIPTION
Adds the ability to create Embedded Cluster clusters with the cli, for example:

```
replicated cluster create --distribution embedded-cluster --license-id ABCD1234
```

```
replicated cluster create --distribution embedded-cluster --license-id ABCD1234 --version 1.0.1
```
