### PR TITLE
Add cluster port command

### DIFF
--- a/cli/cmd/cluster_port.go
+++ b/cli/cmd/cluster_port.go
@@ -1,0 +1,16 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func (r *runners) InitClusterPort(parent *cobra.Command) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "port",
+		SilenceUsage: true,
+		Hidden:       true, // this feature is not fully implemented and controlled behind a feature toggle in the api until ready
+	}
+	parent.AddCommand(cmd)
+
+	return cmd
+}

--- a/cli/cmd/cluster_port_expose.go
+++ b/cli/cmd/cluster_port_expose.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/pkg/errors"
 	"github.com/replicatedhq/replicated/cli/print"
 	"github.com/spf13/cobra"
 )
@@ -24,6 +25,10 @@ func (r *runners) InitClusterPortExpose(parent *cobra.Command) *cobra.Command {
 
 func (r *runners) clusterPortExpose(_ *cobra.Command, args []string) error {
 	clusterID := args[0]
+
+	if len(r.args.clusterExposePortProtocols) == 0 {
+		return errors.New("at least one protocol must be specified")
+	}
 
 	port, err := r.kotsAPI.ExposeClusterPort(clusterID, r.args.clusterExposePortPort, r.args.clusterExposePortProtocols)
 	if err != nil {

--- a/cli/cmd/cluster_port_expose.go
+++ b/cli/cmd/cluster_port_expose.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"github.com/replicatedhq/replicated/cli/print"
+	"github.com/spf13/cobra"
+)
+
+func (r *runners) InitClusterPortExpose(parent *cobra.Command) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:  "expose <cluster-id> --port <port> --protocol <protocol>",
+		RunE: r.clusterPortExpose,
+		Args: cobra.ExactArgs(1),
+	}
+	parent.AddCommand(cmd)
+
+	cmd.Flags().IntVar(&r.args.clusterExposePortPort, "port", 0, "Port to expose")
+	cmd.MarkFlagRequired("port")
+
+	cmd.Flags().StringArrayVar(&r.args.clusterExposePortProtocols, "protocol", []string{"http", "https"}, "Protocol to expose")
+	cmd.MarkFlagRequired("protocol")
+
+	return cmd
+}
+
+func (r *runners) clusterPortExpose(_ *cobra.Command, args []string) error {
+	clusterID := args[0]
+
+	port, err := r.kotsAPI.ExposeClusterPort(clusterID, r.args.clusterExposePortPort, r.args.clusterExposePortProtocols)
+	if err != nil {
+		return err
+	}
+
+	if err := print.ClusterPort(r.outputFormat, r.w, port); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cli/cmd/cluster_port_ls.go
+++ b/cli/cmd/cluster_port_ls.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"github.com/replicatedhq/replicated/cli/print"
+	"github.com/spf13/cobra"
+)
+
+func (r *runners) InitClusterPortLs(parent *cobra.Command) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:  "ls",
+		RunE: r.clusterPortList,
+		Args: cobra.ExactArgs(1),
+	}
+	parent.AddCommand(cmd)
+
+	return cmd
+}
+
+func (r *runners) clusterPortList(_ *cobra.Command, args []string) error {
+	clusterID := args[0]
+
+	ports, err := r.kotsAPI.ListClusterPorts(clusterID)
+	if err != nil {
+		return err
+	}
+
+	return print.ClusterPorts(r.outputFormat, r.w, ports, true)
+}

--- a/cli/cmd/cluster_port_rm.go
+++ b/cli/cmd/cluster_port_rm.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/pkg/errors"
 	"github.com/replicatedhq/replicated/cli/print"
 	"github.com/spf13/cobra"
 )
@@ -21,6 +22,10 @@ func (r *runners) InitClusterPortRm(parent *cobra.Command) *cobra.Command {
 
 func (r *runners) clusterPortRemove(_ *cobra.Command, args []string) error {
 	clusterID := args[0]
+
+	if len(r.args.clusterPortRemoveProtocols) == 0 {
+		return errors.New("at least one protocol must be specified")
+	}
 
 	ports, err := r.kotsAPI.RemoveClusterPort(clusterID, r.args.clusterPortRemovePort, r.args.clusterPortRemoveProtocols)
 	if err != nil {

--- a/cli/cmd/cluster_port_rm.go
+++ b/cli/cmd/cluster_port_rm.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"github.com/replicatedhq/replicated/cli/print"
+	"github.com/spf13/cobra"
+)
+
+func (r *runners) InitClusterPortRm(parent *cobra.Command) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:  "rm",
+		RunE: r.clusterPortRemove,
+		Args: cobra.ExactArgs(1),
+	}
+	parent.AddCommand(cmd)
+
+	cmd.Flags().IntVar(&r.args.clusterPortRemovePort, "port", 0, "Port to remove")
+	cmd.Flags().StringArrayVar(&r.args.clusterPortRemoveProtocols, "protocol", []string{"http"}, "Protocol to remove")
+
+	return cmd
+}
+
+func (r *runners) clusterPortRemove(_ *cobra.Command, args []string) error {
+	clusterID := args[0]
+
+	ports, err := r.kotsAPI.RemoveClusterPort(clusterID, r.args.clusterPortRemovePort, r.args.clusterPortRemoveProtocols)
+	if err != nil {
+		return err
+	}
+
+	print.ClusterPorts(r.outputFormat, r.w, ports, true)
+	return nil
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -231,6 +231,11 @@ func Execute(rootCmd *cobra.Command, stdin io.Reader, stdout io.Writer, stderr i
 	clusterAddOnIngressCmd := runCmds.InitClusterAddOnIngress(clusterAddOnCmd)
 	runCmds.InitClusterAddOnIngressCreate(clusterAddOnIngressCmd)
 
+	clusterPortCmd := runCmds.InitClusterPort(clusterCmd)
+	runCmds.InitClusterPortLs(clusterPortCmd)
+	runCmds.InitClusterPortExpose(clusterPortCmd)
+	runCmds.InitClusterPortRm(clusterPortCmd)
+
 	clusterPrepareCmd := runCmds.InitClusterPrepare(clusterCmd)
 
 	clusterUpdateCmd := runCmds.InitClusterUpdateCommand(clusterCmd)

--- a/cli/cmd/runner.go
+++ b/cli/cmd/runner.go
@@ -232,6 +232,12 @@ type runnerArgs struct {
 	clusterCreateIngressPort      int
 	clusterCreateIngressNamespace string
 
+	clusterExposePortPort      int
+	clusterExposePortProtocols []string
+
+	clusterPortRemovePort      int
+	clusterPortRemoveProtocols []string
+
 	loginEndpoint string
 
 	apiPostBody string

--- a/cli/print/cluster_ports.go
+++ b/cli/print/cluster_ports.go
@@ -1,0 +1,83 @@
+package print
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"text/tabwriter"
+	"text/template"
+
+	"github.com/replicatedhq/replicated/pkg/types"
+)
+
+var portsTmplHeaderSrc = `CLUSTER PORT	PROTOCOL	EXPOSED PORT	STATUS`
+var portsTmplRowSrc = `{{- range . }}
+{{- $upstreamPort := .UpstreamPort }}
+{{- $hostname := .Hostname }}
+{{- $state := .State }}
+{{- range .ExposedPorts }}
+{{ $upstreamPort }}	{{ .Protocol }}	{{ formatURL .Protocol $hostname }}	{{ printf "%-12s" $state }}
+{{ end }}
+{{ end }}`
+var portsTmplSrc = fmt.Sprintln(portsTmplHeaderSrc) + portsTmplRowSrc
+var portsTmpl = template.Must(template.New("ports").Funcs(funcs).Parse(portsTmplSrc))
+var portsTmplNoHeader = template.Must(template.New("ports").Funcs(funcs).Parse(portsTmplRowSrc))
+
+const (
+	clusterPortsMinWidth = 16
+	clusterPortsTabWidth = 8
+	clusterPortsPadding  = 4
+	clusterPortsPadChar  = ' '
+)
+
+func ClusterPorts(outputFormat string, w *tabwriter.Writer, ports []*types.ClusterPort, header bool) error {
+	// we need a custom tab writer here because our column widths are large
+	portsWriter := tabwriter.NewWriter(os.Stdout, clusterPortsMinWidth, clusterPortsTabWidth, clusterPortsPadding, clusterPortsPadChar, tabwriter.TabIndent)
+
+	switch outputFormat {
+	case "table":
+		if header {
+			if err := portsTmpl.Execute(portsWriter, ports); err != nil {
+				return err
+			}
+		} else {
+			if err := portsTmplNoHeader.Execute(portsWriter, ports); err != nil {
+				return err
+			}
+		}
+	case "json":
+		cAsByte, err := json.MarshalIndent(ports, "", "  ")
+		if err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintln(portsWriter, string(cAsByte)); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unsupported output format: %s", outputFormat)
+	}
+	return w.Flush()
+}
+
+func ClusterPort(outputFormat string, w *tabwriter.Writer, port *types.ClusterPort) error {
+	// we need a custom tab writer here because our column widths are large
+	portsWriter := tabwriter.NewWriter(os.Stdout, clusterPortsMinWidth, clusterPortsTabWidth, clusterPortsPadding, clusterPortsPadChar, tabwriter.TabIndent)
+
+	switch outputFormat {
+	case "table":
+		if err := portsTmpl.Execute(portsWriter, []*types.ClusterPort{port}); err != nil {
+			return err
+		}
+	case "json":
+		cAsByte, err := json.MarshalIndent(port, "", "  ")
+		if err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintln(portsWriter, string(cAsByte)); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unsupported output format: %s", outputFormat)
+	}
+	return w.Flush()
+}

--- a/cli/print/util.go
+++ b/cli/print/util.go
@@ -1,6 +1,7 @@
 package print
 
 import (
+	"fmt"
 	"text/template"
 	"time"
 )
@@ -18,5 +19,8 @@ var funcs = template.FuncMap{
 	},
 	"add": func(a, b int) int {
 		return a + b
+	},
+	"formatURL": func(protocol, hostname string) string {
+		return fmt.Sprintf("%s://%s", protocol, hostname)
 	},
 }

--- a/pkg/kotsclient/cluster_port_expose.go
+++ b/pkg/kotsclient/cluster_port_expose.go
@@ -1,0 +1,32 @@
+package kotsclient
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/replicatedhq/replicated/pkg/types"
+)
+
+type ExportClusterPortRequest struct {
+	Port      int      `json:"port"`
+	Protocols []string `json:"protocols"`
+}
+
+type ExposeClusterPortResponse struct {
+	Port *types.ClusterPort `json:"port"`
+}
+
+func (c *VendorV3Client) ExposeClusterPort(clusterID string, portNumber int, protocols []string) (*types.ClusterPort, error) {
+	req := ExportClusterPortRequest{
+		Port:      portNumber,
+		Protocols: protocols,
+	}
+
+	resp := ExposeClusterPortResponse{}
+	err := c.DoJSON("POST", fmt.Sprintf("/v3/cluster/%s/port", clusterID), http.StatusCreated, req, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.Port, nil
+}

--- a/pkg/kotsclient/cluster_port_list.go
+++ b/pkg/kotsclient/cluster_port_list.go
@@ -1,0 +1,22 @@
+package kotsclient
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/replicatedhq/replicated/pkg/types"
+)
+
+type ListClusterPortsResponse struct {
+	Ports []*types.ClusterPort `json:"ports"`
+}
+
+func (c *VendorV3Client) ListClusterPorts(clusterID string) ([]*types.ClusterPort, error) {
+	resp := ListClusterPortsResponse{}
+	err := c.DoJSON("GET", fmt.Sprintf("/v3/cluster/%s/ports", clusterID), http.StatusOK, nil, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.Ports, nil
+}

--- a/pkg/kotsclient/cluster_port_remove.go
+++ b/pkg/kotsclient/cluster_port_remove.go
@@ -1,0 +1,25 @@
+package kotsclient
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/replicatedhq/replicated/pkg/types"
+)
+
+type RemoveClusterPortResponse struct {
+	Ports []*types.ClusterPort `json:"ports"`
+}
+
+func (c *VendorV3Client) RemoveClusterPort(clusterID string, portNumber int, protocols []string) ([]*types.ClusterPort, error) {
+	urlProtocols := strings.Join(protocols, ",")
+
+	resp := RemoveClusterPortResponse{}
+	err := c.DoJSON("PUT", fmt.Sprintf("/v3/cluster/%s/ports/%d?protocols=%s", clusterID, portNumber, urlProtocols), http.StatusOK, nil, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.Ports, nil
+}

--- a/pkg/types/cluster.go
+++ b/pkg/types/cluster.go
@@ -87,3 +87,16 @@ type ClusterIngressAddOn struct {
 	Target    string `json:"target"`
 	Namespace string `json:"namespace"`
 }
+
+type ClusterExposedPort struct {
+	Protocol    string `json:"protocol"`
+	ExposedPort int    `json:"exposed_port"`
+}
+
+type ClusterPort struct {
+	UpstreamPort int                  `json:"upstream_port"`
+	ExposedPorts []ClusterExposedPort `json:"exposed_ports"`
+	CreatedAt    time.Time            `json:"created_at"`
+	Hostname     string               `json:"hostname"`
+	State        AddOnState           `json:"state"`
+}


### PR DESCRIPTION
This adds the initial (hidden) implementation of port expose (and ls, rm) for CMX clusters.