### PR TITLE
feat(cmx): expose addon object store data

### DIFF
--- a/cli/cmd/cluster_addon_ls.go
+++ b/cli/cmd/cluster_addon_ls.go
@@ -40,5 +40,5 @@ func (r *runners) addonClusterLsRun(args clusterAddonLsArgs) error {
 		return err
 	}
 
-	return print.Addons(r.outputFormat, r.w, addons, true)
+	return print.Addons(args.outputFormat, r.w, addons, true)
 }

--- a/cli/print/cluster_addons.go
+++ b/cli/print/cluster_addons.go
@@ -3,6 +3,7 @@ package print
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"text/tabwriter"
 	"text/template"
 
@@ -21,14 +22,7 @@ var addonsFuncs = template.FuncMap{
 	"Type": func(addon *types.ClusterAddon) string {
 		return addon.TypeName()
 	},
-	"Data": func(addon *types.ClusterAddon) string {
-		switch {
-		case addon.ObjectStore != nil:
-			return fmt.Sprintf("Bucket: %s", addon.ObjectStore.Bucket)
-		default:
-			return ""
-		}
-	},
+	"Data": addonData,
 }
 
 func init() {
@@ -81,4 +75,21 @@ func Addon(outputFormat string, w *tabwriter.Writer, addon *types.ClusterAddon) 
 		return fmt.Errorf("unsupported output format: %s", outputFormat)
 	}
 	return w.Flush()
+}
+
+func addonData(addon *types.ClusterAddon) string {
+	switch {
+	case addon.ObjectStore != nil:
+		return addonObjectStoreData(*addon.ObjectStore)
+	default:
+		return ""
+	}
+}
+
+func addonObjectStoreData(data types.ClusterAddonObjectStore) string {
+	b, err := json.Marshal(data)
+	if err != nil {
+		log.Printf("failed to marshal object store data: %v", err)
+	}
+	return string(b)
 }

--- a/pkg/types/cluster.go
+++ b/pkg/types/cluster.go
@@ -85,7 +85,11 @@ type ClusterAddon struct {
 }
 
 type ClusterAddonObjectStore struct {
-	Bucket string `json:"bucket"`
+	BucketPrefix               string `json:"bucket_prefix"`
+	BucketName                 string `json:"bucket_name,omitempty"`
+	ServiceAccountNamespace    string `json:"service_account_namespace,omitempty"`
+	ServiceAccountName         string `json:"service_account_name,omitempty"`
+	ServiceAccountNameReadOnly string `json:"service_account_name_read_only,omitempty"`
 }
 
 func (addon *ClusterAddon) TypeName() string {


### PR DESCRIPTION
Adds s3 object store data to output.

```bash
$ replicated cluster addon ls 4d2f7e70
ID          TYPE            STATUS          DATA
d07cb204    Object Store    pending         {"bucket_prefix":"ethan"}
05929b24    Object Store    ready           {"bucket_prefix":"ethan","bucket_name":"ethan-05929b24-cmx","service_account_namespace":"cmx","service_account_name":"ethan-05929b24-cmx","service_account_name_read_only":"ethan-05929b24-cmx-ro"}
```