### PR TITLE
Remove reference to KOTS in app_create and app_ls command descriptions

### DIFF
--- a/cli/cmd/app_create.go
+++ b/cli/cmd/app_create.go
@@ -11,8 +11,8 @@ import (
 func (r *runners) InitAppCreate(parent *cobra.Command) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "create NAME",
-		Short:        "create kots apps",
-		Long:         `create kots apps`,
+		Short:        "create apps",
+		Long:         `create apps`,
 		RunE:         r.createApp,
 		SilenceUsage: true,
 	}

--- a/cli/cmd/app_ls.go
+++ b/cli/cmd/app_ls.go
@@ -12,8 +12,8 @@ import (
 func (r *runners) InitAppList(parent *cobra.Command) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "ls [NAME]",
-		Short:        "list kots apps",
-		Long:         `list kots apps, or a single app by name`,
+		Short:        "list apps",
+		Long:         `list apps, or a single app by name`,
 		RunE:         r.listApps,
 		SilenceUsage: true,
 	}


### PR DESCRIPTION
`replicated app -h` describes the available commands as:

- `create kots apps`
- `delete kots apps`
- `list kots apps`

This PR removes the reference to `kots` in those descriptions because they are not necessarily KOTS apps.