### PR TITLE
Add omit details to promote payload for faster release promotions

### DIFF
--- a/pkg/kotsclient/release.go
+++ b/pkg/kotsclient/release.go
@@ -174,10 +174,11 @@ func (c *VendorV3Client) ListReleases(appID string) ([]types.ReleaseInfo, error)
 
 func (c *VendorV3Client) PromoteRelease(appID string, sequence int64, label string, notes string, required bool, channelIDs ...string) error {
 	request := types.KotsPromoteReleaseRequest{
-		ReleaseNotes: notes,
-		VersionLabel: label,
-		IsRequired:   required,
-		ChannelIDs:   channelIDs,
+		ReleaseNotes:          notes,
+		VersionLabel:          label,
+		IsRequired:            required,
+		ChannelIDs:            channelIDs,
+		OmitDetailsInResponse: true,
 	}
 
 	path := fmt.Sprintf("/v3/app/%s/release/%v/promote", appID, sequence)

--- a/pkg/kotsclient/release_test.go
+++ b/pkg/kotsclient/release_test.go
@@ -219,7 +219,8 @@ func Test_PromoteRelease(t *testing.T) {
 				"channelIds": []string{
 					"replicated-cli-promote-release-unstable",
 				},
-				"ignoreWarnings": false,
+				"ignoreWarnings":        false,
+				"omitDetailsInResponse": true,
 			},
 		}).
 		WillRespondWith(dsl.Response{

--- a/pkg/types/release.go
+++ b/pkg/types/release.go
@@ -69,6 +69,9 @@ type KotsPromoteReleaseRequest struct {
 	IsRequired     bool     `json:"isRequired"`
 	ChannelIDs     []string `json:"channelIds"`
 	IgnoreWarnings bool     `json:"ignoreWarnings"`
+
+	// Omits channels, charts, and compatibilityResults details in the response body
+	OmitDetailsInResponse bool `json:"omitDetailsInResponse"`
 }
 
 type KotsAppRelease struct {


### PR DESCRIPTION
For faster release promotions - excludes extraneous data in response object.