### PR TITLE
feat(cmx): cluster port expose wildcards

### DIFF
--- a/cli/cmd/cluster_port_ls.go
+++ b/cli/cmd/cluster_port_ls.go
@@ -13,6 +13,8 @@ func (r *runners) InitClusterPortLs(parent *cobra.Command) *cobra.Command {
 	}
 	parent.AddCommand(cmd)
 
+	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table|wide (default: table)")
+
 	return cmd
 }
 

--- a/cli/cmd/cluster_port_rm.go
+++ b/cli/cmd/cluster_port_rm.go
@@ -8,20 +8,52 @@ import (
 
 func (r *runners) InitClusterPortRm(parent *cobra.Command) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:  "rm CLUSTER_ID",
+		Use:  "rm CLUSTER_ID --id PORT_ID",
 		RunE: r.clusterPortRemove,
 		Args: cobra.ExactArgs(1),
 	}
 	parent.AddCommand(cmd)
 
+	cmd.Flags().StringVar(&r.args.clusterPortRemoveAddonID, "id", "", "ID of the port to remove (required)")
+	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table|wide (default: table)")
+
+	// Deprecated flags
 	cmd.Flags().IntVar(&r.args.clusterPortRemovePort, "port", 0, "Port to remove")
-	cmd.Flags().StringArrayVar(&r.args.clusterPortRemoveProtocols, "protocol", []string{"http"}, "Protocol to remove")
+	err := cmd.Flags().MarkHidden("port")
+	if err != nil {
+		panic(err)
+	}
+	cmd.Flags().StringArrayVar(&r.args.clusterPortRemoveProtocols, "protocol", []string{"http", "https"}, "Protocol to remove")
+	err = cmd.Flags().MarkHidden("protocol")
+	if err != nil {
+		panic(err)
+	}
 
 	return cmd
 }
 
 func (r *runners) clusterPortRemove(_ *cobra.Command, args []string) error {
 	clusterID := args[0]
+
+	if r.args.clusterPortRemoveAddonID == "" && r.args.clusterPortRemovePort == 0 {
+		return errors.New("either --id or --port must be specified")
+	} else if r.args.clusterPortRemoveAddonID != "" && r.args.clusterPortRemovePort > 0 {
+		return errors.New("only one o  --id or --port can be specified")
+	}
+
+	if r.args.clusterPortRemoveAddonID != "" {
+		err := r.kotsAPI.DeleteClusterAddon(clusterID, r.args.clusterPortRemoveAddonID)
+		if err != nil {
+			return err
+		}
+
+		ports, err := r.kotsAPI.ListClusterPorts(clusterID)
+		if err != nil {
+			return err
+		}
+
+		return print.ClusterPorts(r.outputFormat, r.w, ports, true)
+	}
 
 	if len(r.args.clusterPortRemoveProtocols) == 0 {
 		return errors.New("at least one protocol must be specified")
@@ -32,6 +64,5 @@ func (r *runners) clusterPortRemove(_ *cobra.Command, args []string) error {
 		return err
 	}
 
-	print.ClusterPorts(r.outputFormat, r.w, ports, true)
-	return nil
+	return print.ClusterPorts(r.outputFormat, r.w, ports, true)
 }

--- a/cli/cmd/runner.go
+++ b/cli/cmd/runner.go
@@ -255,9 +255,11 @@ type runnerArgs struct {
 	shellClusterName string
 	shellClusterID   string
 
-	clusterExposePortPort      int
-	clusterExposePortProtocols []string
+	clusterExposePortPort       int
+	clusterExposePortProtocols  []string
+	clusterExposePortIsWildcard bool
 
+	clusterPortRemoveAddonID   string
 	clusterPortRemovePort      int
 	clusterPortRemoveProtocols []string
 

--- a/cli/print/cluster_ports.go
+++ b/cli/print/cluster_ports.go
@@ -10,13 +10,15 @@ import (
 	"github.com/replicatedhq/replicated/pkg/types"
 )
 
-var portsTmplHeaderSrc = `CLUSTER PORT	PROTOCOL	EXPOSED PORT	STATUS`
+var portsTmplHeaderSrc = `ID	CLUSTER PORT	PROTOCOL	EXPOSED PORT	WILDCARD	STATUS`
 var portsTmplRowSrc = `{{- range . }}
+{{- $id := .AddonID }}
 {{- $upstreamPort := .UpstreamPort }}
 {{- $hostname := .Hostname }}
+{{- $isWildcard := .IsWildcard }}
 {{- $state := .State }}
 {{- range .ExposedPorts }}
-{{ $upstreamPort }}	{{ .Protocol }}	{{ formatURL .Protocol $hostname }}	{{ printf "%-12s" $state }}
+{{ $id }}	{{ $upstreamPort }}	{{ .Protocol }}	{{ formatURL .Protocol $hostname }}	{{ $isWildcard }}	{{ printf "%-12s" $state }}
 {{ end }}
 {{ end }}`
 var portsTmplSrc = fmt.Sprintln(portsTmplHeaderSrc) + portsTmplRowSrc
@@ -35,7 +37,7 @@ func ClusterPorts(outputFormat string, w *tabwriter.Writer, ports []*types.Clust
 	portsWriter := tabwriter.NewWriter(os.Stdout, clusterPortsMinWidth, clusterPortsTabWidth, clusterPortsPadding, clusterPortsPadChar, tabwriter.TabIndent)
 
 	switch outputFormat {
-	case "table":
+	case "table", "wide":
 		if header {
 			if err := portsTmpl.Execute(portsWriter, ports); err != nil {
 				return err

--- a/pkg/kotsclient/cluster_port_expose.go
+++ b/pkg/kotsclient/cluster_port_expose.go
@@ -8,18 +8,20 @@ import (
 )
 
 type ExportClusterPortRequest struct {
-	Port      int      `json:"port"`
-	Protocols []string `json:"protocols"`
+	Port       int      `json:"port"`
+	Protocols  []string `json:"protocols"`
+	IsWildcard bool     `json:"is_wildcard"`
 }
 
 type ExposeClusterPortResponse struct {
 	Port *types.ClusterPort `json:"port"`
 }
 
-func (c *VendorV3Client) ExposeClusterPort(clusterID string, portNumber int, protocols []string) (*types.ClusterPort, error) {
+func (c *VendorV3Client) ExposeClusterPort(clusterID string, portNumber int, protocols []string, isWildcard bool) (*types.ClusterPort, error) {
 	req := ExportClusterPortRequest{
-		Port:      portNumber,
-		Protocols: protocols,
+		Port:       portNumber,
+		Protocols:  protocols,
+		IsWildcard: isWildcard,
 	}
 
 	resp := ExposeClusterPortResponse{}

--- a/pkg/types/cluster.go
+++ b/pkg/types/cluster.go
@@ -112,24 +112,19 @@ func (addon *ClusterAddon) TypeName() string {
 	}
 }
 
-type ClusterPortState string
-
-const (
-	ClusterPortStatePending ClusterPortState = "pending"
-	ClusterPortStateReady   ClusterPortState = "ready"
-	ClusterPortStateError   ClusterPortState = "error"
-	ClusterPortStateRemoved ClusterPortState = "removed"
-)
-
 type ClusterExposedPort struct {
 	Protocol    string `json:"protocol"`
 	ExposedPort int    `json:"exposed_port"`
 }
 
 type ClusterPort struct {
+	ClusterID    string               `json:"cluster_id"`
+	AddonID      string               `json:"addon_id"`
 	UpstreamPort int                  `json:"upstream_port"`
 	ExposedPorts []ClusterExposedPort `json:"exposed_ports"`
+	IsWildcard   bool                 `json:"is_wildcard"`
 	CreatedAt    time.Time            `json:"created_at"`
 	Hostname     string               `json:"hostname"`
-	State        ClusterPortState     `json:"state"`
+	PortName     string               `json:"port_name"`
+	State        ClusterAddonStatus   `json:"state"`
 }


### PR DESCRIPTION
Support for creating wildcard ports.

Fixes an issue where removing by port number is ambiguous and removes all ports with same number.

```
$ ./bin/replicated cluster port expose --help   

Usage:
  replicated cluster port expose CLUSTER_ID --port PORT --protocol PROTOCOL [flags]

Flags:
  -h, --help                   help for expose
      --output string          The output format to use. One of: json|table|wide (default: table) (default "table")
      --port int               Port to expose (required)
      --protocol stringArray   Protocol to expose (default [http,https])
      --wildcard               Create a wildcard DNS entry and TLS certificate for this port

Global Flags:
      --app string     The app slug or app id to use in all calls
      --token string   The API token to use to access your app in the Vendor API
```

```
$ ./bin/replicated cluster port ls --help    

Usage:
  replicated cluster port ls CLUSTER_ID [flags]

Flags:
  -h, --help            help for ls
      --output string   The output format to use. One of: json|table|wide (default: table) (default "table")

Global Flags:
      --app string     The app slug or app id to use in all calls
      --token string   The API token to use to access your app in the Vendor API
```

```
$ ./bin/replicated cluster port rm --help

Usage:
  replicated cluster port rm CLUSTER_ID --id PORT_ID [flags]

Flags:
  -h, --help            help for rm
      --id string       ID of the port to remove (required)
      --output string   The output format to use. One of: json|table|wide (default: table) (default "table")

Global Flags:
      --app string     The app slug or app id to use in all calls
      --token string   The API token to use to access your app in the Vendor API
```