### PR TITLE
Faster app lookup without channel data

### DIFF
--- a/cli/cmd/app_delete.go
+++ b/cli/cmd/app_delete.go
@@ -32,7 +32,7 @@ func (r *runners) deleteApp(_ *cobra.Command, args []string) error {
 	appName := args[0]
 
 	log.ActionWithSpinner("Fetching App")
-	app, err := r.kotsAPI.GetApp(appName)
+	app, err := r.kotsAPI.GetApp(appName, true)
 	if err != nil {
 		log.FinishSpinnerWithError()
 		return errors.Wrap(err, "list apps")

--- a/cli/cmd/app_ls.go
+++ b/cli/cmd/app_ls.go
@@ -24,7 +24,7 @@ func (r *runners) InitAppList(parent *cobra.Command) *cobra.Command {
 }
 
 func (r *runners) listApps(_ *cobra.Command, args []string) error {
-	kotsApps, err := r.kotsAPI.ListApps()
+	kotsApps, err := r.kotsAPI.ListApps(false)
 	if err != nil {
 		return errors.Wrap(err, "list apps")
 	}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -300,7 +300,7 @@ func Execute(rootCmd *cobra.Command, stdin io.Reader, stdout io.Writer, stderr i
 			appSlugOrID = os.Getenv("REPLICATED_APP")
 		}
 
-		app, appType, err := runCmds.api.GetAppType(appSlugOrID)
+		app, appType, err := runCmds.api.GetAppType(appSlugOrID, true)
 		if err != nil {
 			return errors.Wrap(err, "get app type")
 		}

--- a/client/app.go
+++ b/client/app.go
@@ -4,13 +4,13 @@ import (
 	"github.com/replicatedhq/replicated/pkg/types"
 )
 
-func (c *Client) ListApps() ([]types.AppAndChannels, error) {
+func (c *Client) ListApps(excludeChannels bool) ([]types.AppAndChannels, error) {
 	platformApps, err := c.PlatformClient.ListApps()
 	if err != nil {
 		return nil, err
 	}
 
-	kotsApps, err := c.KotsClient.ListApps()
+	kotsApps, err := c.KotsClient.ListApps(excludeChannels)
 	if err != nil {
 		return nil, err
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -22,7 +22,7 @@ func NewClient(platformOrigin string, apiToken string, kurlOrigin string) Client
 	return client
 }
 
-func (c *Client) GetAppType(appID string) (*types.App, string, error) {
+func (c *Client) GetAppType(appID string, excludeChannels bool) (*types.App, string, error) {
 	platformSwaggerApp, err1 := c.PlatformClient.GetApp(appID)
 	if err1 == nil && platformSwaggerApp != nil {
 		platformApp := &types.App{
@@ -34,7 +34,7 @@ func (c *Client) GetAppType(appID string) (*types.App, string, error) {
 		return platformApp, "platform", nil
 	}
 
-	kotsApp, err2 := c.KotsClient.GetApp(appID)
+	kotsApp, err2 := c.KotsClient.GetApp(appID, excludeChannels)
 	if err2 == nil && kotsApp != nil {
 		return kotsApp, "kots", nil
 	}

--- a/pkg/kotsclient/app.go
+++ b/pkg/kotsclient/app.go
@@ -1,6 +1,7 @@
 package kotsclient
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/pkg/errors"
@@ -11,10 +12,10 @@ type kotsAppResponse struct {
 	Apps []types.KotsAppWithChannels `json:"apps"`
 }
 
-func (c *VendorV3Client) ListApps() ([]types.AppAndChannels, error) {
+func (c *VendorV3Client) ListApps(excludeChannels bool) ([]types.AppAndChannels, error) {
 	var response = kotsAppResponse{}
 
-	err := c.DoJSON("GET", "/v3/apps", http.StatusOK, nil, &response)
+	err := c.DoJSON("GET", fmt.Sprintf("/v3/apps?excludeChannels=%t", excludeChannels), http.StatusOK, nil, &response)
 	if err != nil {
 		return nil, errors.Wrap(err, "list apps")
 	}
@@ -37,8 +38,8 @@ func (c *VendorV3Client) ListApps() ([]types.AppAndChannels, error) {
 	return results, nil
 }
 
-func (c *VendorV3Client) GetApp(appID string) (*types.App, error) {
-	apps, err := c.ListApps()
+func (c *VendorV3Client) GetApp(appID string, excludeChannels bool) (*types.App, error) {
+	apps, err := c.ListApps(excludeChannels)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kotsclient/app_test.go
+++ b/pkg/kotsclient/app_test.go
@@ -16,7 +16,7 @@ func Test_ListApps(t *testing.T) {
 		api := platformclient.NewHTTPClient(u, "replicated-cli-list-apps-token")
 		client := VendorV3Client{HTTPClient: *api}
 
-		apps, err := client.ListApps()
+		apps, err := client.ListApps(false)
 		assert.Nil(t, err)
 
 		assert.Len(t, apps, 1)
@@ -73,7 +73,7 @@ func Test_RemoveApp(t *testing.T) {
 		err = client.DeleteKOTSApp("replicated-cli-rm-app-app")
 		assert.Nil(t, err)
 
-		apps, err := client.ListApps()
+		apps, err := client.ListApps(false)
 		assert.Nil(t, err)
 
 		assert.Len(t, apps, 0)


### PR DESCRIPTION
During bootstrapping any command, CLI looks up application by listing all apps.  This can be slow for apps with a lot of channels and release. This change uses a query parameter currently supported by the API to not load unused channels data.

`replicated app ls --output json` still returns data will all channels.