### PR TITLE
Don't send error to stdout

### DIFF
--- a/cli/cmd/customer_create.go
+++ b/cli/cmd/customer_create.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"time"
 
@@ -8,7 +9,6 @@ import (
 	"github.com/replicatedhq/replicated/cli/print"
 	"github.com/replicatedhq/replicated/client"
 	"github.com/replicatedhq/replicated/pkg/kotsclient"
-	"github.com/replicatedhq/replicated/pkg/logger"
 	"github.com/spf13/cobra"
 )
 
@@ -102,8 +102,9 @@ func (r *runners) createCustomer(cmd *cobra.Command, _ []string) (err error) {
 	}
 
 	if !foundDefaultChannel {
-		log := logger.NewLogger(os.Stdout)
-		log.Info("No default channel specified, defaulting to the first channel specified.")
+		if len(channels) > 1 {
+			fmt.Fprintln(os.Stderr, "No default channel specified, defaulting to the first channel specified.")
+		}
 		firstChannel := channels[0]
 		firstChannel.IsDefault = true
 		channels[0] = firstChannel

--- a/cli/cmd/customer_update.go
+++ b/cli/cmd/customer_update.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"time"
 
@@ -8,7 +9,6 @@ import (
 	"github.com/replicatedhq/replicated/cli/print"
 	"github.com/replicatedhq/replicated/client"
 	"github.com/replicatedhq/replicated/pkg/kotsclient"
-	"github.com/replicatedhq/replicated/pkg/logger"
 	"github.com/spf13/cobra"
 )
 
@@ -107,8 +107,9 @@ func (r *runners) updateCustomer(cmd *cobra.Command, _ []string) (err error) {
 	}
 
 	if !foundDefaultChannel {
-		log := logger.NewLogger(os.Stdout)
-		log.Info("No default channel specified, defaulting to the first channel specified.")
+		if len(channels) > 1 {
+			fmt.Fprintln(os.Stderr, "No default channel specified, defaulting to the first channel specified.")
+		}
 		firstChannel := channels[0]
 		firstChannel.IsDefault = true
 		channels[0] = firstChannel


### PR DESCRIPTION
No warning with 1 channel

```
$ ./bin/replicated customer create --name Geeglo --email zz2m8vguvo5n@geeglo.io --channel Stable --expires-in 720h --kots-install=false --output json --app app-create-test|jq
Update available: v0.79.0
To automatically upgrade, run "replicated version upgrade"
{
  "id": "2kFaTZIyRm1mMieen35Gqcq46WO",
  "customId": "",
  "name": "Geeglo",
  "email": "zz2m8vguvo5n@geeglo.io",
  "channels": [
    {
      "id": "2YEfvli3H2BGqb2UvIZyw3JvHrL",
      "name": "Stable",
      "description": "",
      "channelSlug": "stable",
      "releaseSequence": 0,
      "releaseLabel": "",
      "isArchived": false,
      "isHelmOnly": false
    }
  ],
  "type": "dev",
  ...
```

Warning with 2 channels, and `jq` still works

```
$ ./bin/replicated customer create --name Geeglo --email zz2m8vguvo5n@geeglo.io --channel Stable --channel Unstable --expires-in 720h --kots-install=false --output json --app app-create-test|jq
Update available: v0.79.0
To automatically upgrade, run "replicated version upgrade"
No default channel specified, defaulting to the first channel specified.
{
  "id": "2kFaZqvDWk9asrKEHmprDJw1dAb",
  "customId": "",
  "name": "Geeglo",
  "email": "zz2m8vguvo5n@geeglo.io",
  "channels": [
    {
      "id": "2YEfvhh92G5AAnSmLaYeAacrSAB",
      "name": "Unstable",
      "description": "",
      "channelSlug": "unstable",
      "releaseSequence": 0,
      "releaseLabel": "",
      "isArchived": false,
      "isHelmOnly": false
    },
    {
      "id": "2YEfvli3H2BGqb2UvIZyw3JvHrL",
      "name": "Stable",
      "description": "",
      "channelSlug": "stable",
      "releaseSequence": 0,
      "releaseLabel": "",
      "isArchived": false,
      "isHelmOnly": false
    }
  ],
...
```