### PR TITLE
Expose overlay network

### DIFF
--- a/pkg/types/cluster.go
+++ b/pkg/types/cluster.go
@@ -36,6 +36,9 @@ type Cluster struct {
 
 	EstimatedCost int64 `json:"estimated_cost"` // Represents estimated credits for this cluster based on the TTL
 
+	OverlayEndpoint string `json:"overlay_endpoint,omitempty"`
+	OverlayToken    string `json:"overlay_token,omitempty"`
+
 	Tags []Tag `json:"tags"`
 }
 


### PR DESCRIPTION
Part of [SC 110563](https://app.shortcut.com/replicated/story/110563/first-look-get-ssh-access-to-a-running-vm-kind-k3s-or-similar)