### PR TITLE
Cache and default app

### DIFF
--- a/cli/cmd/cache_helper.go
+++ b/cli/cmd/cache_helper.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/replicated/pkg/kotsclient"
+	"github.com/replicatedhq/replicated/pkg/types"
+)
+
+func getApp(appSlugOrID string, kotsClient *kotsclient.VendorV3Client) (*types.App, error) {
+	app, err := cache.GetApp(appSlugOrID)
+	if err == nil && app != nil {
+		return app, nil
+	}
+
+	if err != nil {
+		return nil, errors.Wrap(err, "get app from cache")
+	}
+
+	if app == nil {
+		a, err := kotsClient.GetApp(appSlugOrID, true)
+		if err != nil {
+			return nil, errors.Wrap(err, "get app from api")
+		}
+
+		if err := cache.SetApp(a); err != nil {
+			return nil, errors.Wrap(err, "set app in cache")
+		}
+
+		return a, nil
+	}
+
+	return nil, errors.New("app not found")
+}

--- a/cli/cmd/default.go
+++ b/cli/cmd/default.go
@@ -1,0 +1,13 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+func (r *runners) InitDefaultCommand(parent *cobra.Command) *cobra.Command {
+	cmd := &cobra.Command{
+		Use: "default",
+	}
+
+	parent.AddCommand(cmd)
+
+	return cmd
+}

--- a/cli/cmd/default_clear.go
+++ b/cli/cmd/default_clear.go
@@ -1,0 +1,24 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+func (r *runners) InitDefaultClearCommand(parent *cobra.Command) *cobra.Command {
+	cmd := &cobra.Command{
+		Use: "clear",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return r.clearDefault(cmd, args[0])
+		},
+	}
+
+	parent.AddCommand(cmd)
+
+	return cmd
+}
+
+func (r *runners) clearDefault(cmd *cobra.Command, defaultType string) error {
+	if err := cache.ClearDefault(defaultType); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cli/cmd/default_clearall.go
+++ b/cli/cmd/default_clearall.go
@@ -1,0 +1,24 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+func (r *runners) InitDefaultClearAllCommand(parent *cobra.Command) *cobra.Command {
+	cmd := &cobra.Command{
+		Use: "clear-all",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return r.clearAllDefaults(cmd)
+		},
+	}
+
+	parent.AddCommand(cmd)
+
+	return cmd
+}
+
+func (r *runners) clearAllDefaults(cmd *cobra.Command) error {
+	if err := cache.ClearDefault("app"); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cli/cmd/default_set.go
+++ b/cli/cmd/default_set.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/replicated/cli/print"
+	"github.com/replicatedhq/replicated/pkg/types"
+	"github.com/spf13/cobra"
+)
+
+func (r *runners) InitDefaultSetCommand(parent *cobra.Command) *cobra.Command {
+	var outputFormat string
+
+	cmd := &cobra.Command{
+		Use: "set",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return r.setDefault(cmd, args[0], args[1], outputFormat)
+		},
+	}
+
+	cmd.Flags().StringVar(&outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
+	parent.AddCommand(cmd)
+
+	return cmd
+}
+
+func (r *runners) setDefault(cmd *cobra.Command, defaultType string, defaultValue string, outputFormat string) error {
+	app, err := getApp(defaultValue, r.api.KotsClient)
+	if err != nil {
+		return errors.Wrap(err, "get app")
+	}
+
+	if err := cache.SetDefault(defaultType, defaultValue); err != nil {
+		return errors.Wrap(err, "set default in cache")
+	}
+
+	// print the default app
+	if err := print.Apps(outputFormat, r.w, []types.AppAndChannels{{App: app}}); err != nil {
+		return errors.Wrap(err, "print app")
+	}
+
+	return nil
+}

--- a/cli/cmd/default_show.go
+++ b/cli/cmd/default_show.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/replicated/cli/print"
+	"github.com/replicatedhq/replicated/pkg/types"
+	"github.com/spf13/cobra"
+)
+
+func (r *runners) InitDefaultShowCommand(parent *cobra.Command) *cobra.Command {
+	var outputFormat string
+
+	cmd := &cobra.Command{
+		Use: "show",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return r.showDefault(cmd, args[0], outputFormat)
+		},
+	}
+
+	cmd.Flags().StringVar(&outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
+	parent.AddCommand(cmd)
+
+	return cmd
+}
+
+func (r *runners) showDefault(cmd *cobra.Command, defaultType string, outputFormat string) error {
+	if cache.DefaultApp == "" {
+		if outputFormat == "json" {
+			fmt.Println("{}")
+		} else {
+			fmt.Println("No default app set")
+		}
+		return nil
+	}
+
+	app, err := getApp(cache.DefaultApp, r.api.KotsClient)
+	if err != nil {
+		return errors.Wrap(err, "get app")
+	}
+
+	if err := print.Apps(outputFormat, r.w, []types.AppAndChannels{{App: app}}); err != nil {
+		return errors.Wrap(err, "print app")
+	}
+
+	return nil
+}

--- a/pkg/cache/app.go
+++ b/pkg/cache/app.go
@@ -1,0 +1,26 @@
+package cache
+
+import (
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/replicated/pkg/types"
+)
+
+func (c Cache) GetApp(appSlugOrID string) (*types.App, error) {
+	for _, app := range c.Apps {
+		if app.Slug == appSlugOrID || app.ID == appSlugOrID {
+			return &app, nil
+		}
+	}
+
+	// App not found
+	return nil, nil
+}
+
+func (c *Cache) SetApp(app *types.App) error {
+	c.Apps = append(c.Apps, *app)
+
+	if err := c.Save(); err != nil {
+		return errors.Wrap(err, "failed to save cache")
+	}
+	return nil
+}

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -1,0 +1,132 @@
+package cache
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/replicated/pkg/types"
+)
+
+const cacheFileName = "replicated.cache"
+
+type Cache struct {
+	DefaultApp string `json:"default_app"`
+
+	LastAppRefresh *time.Time  `json:"last_app_refresh"`
+	Apps           []types.App `json:"apps"`
+}
+
+func InitCache() (*Cache, error) {
+	cacheDir, err := getCacheDir()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get cache directory")
+	}
+
+	cacheFilePath := filepath.Join(cacheDir, cacheFileName)
+
+	// Try to load existing cache
+	cache, err := loadCache(cacheFilePath)
+	if err != nil {
+		// If the file doesn't exist, create a new cache
+		if os.IsNotExist(errors.Cause(err)) {
+			cache = &Cache{
+				Apps:           []types.App{},
+				LastAppRefresh: nil,
+				DefaultApp:     "",
+			}
+
+			// save it
+			err = cache.Save()
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to save cache")
+			}
+		} else {
+			return nil, errors.Wrap(err, "failed to load cache")
+		}
+	}
+
+	return cache, nil
+}
+
+func (c *Cache) Save() error {
+	cacheDir, err := getCacheDir()
+	if err != nil {
+		return errors.Wrap(err, "failed to get cache directory")
+	}
+
+	cacheFilePath := filepath.Join(cacheDir, cacheFileName)
+
+	data, err := json.Marshal(c)
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal cache data")
+	}
+
+	err = os.MkdirAll(filepath.Dir(cacheFilePath), 0755)
+	if err != nil {
+		return errors.Wrap(err, "failed to create cache directory")
+	}
+
+	err = os.WriteFile(cacheFilePath, data, 0644)
+	if err != nil {
+		return errors.Wrap(err, "failed to write cache file")
+	}
+
+	return nil
+}
+
+func loadCache(path string) (*Cache, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read cache file")
+	}
+
+	var cache Cache
+	err = json.Unmarshal(data, &cache)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal cache data")
+	}
+
+	return &cache, nil
+}
+
+func getCacheDir() (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", errors.Wrap(err, "failed to get user home directory")
+	}
+
+	return filepath.Join(homeDir, ".replicated", "cache"), nil
+}
+
+func (c *Cache) SetDefault(defaultType string, defaultValue string) error {
+	switch defaultType {
+	case "app":
+		c.DefaultApp = defaultValue
+	default:
+		return errors.Errorf("unknown default type: %s", defaultType)
+	}
+
+	if err := c.Save(); err != nil {
+		return errors.Wrap(err, "failed to save cache")
+	}
+
+	return nil
+}
+
+func (c *Cache) ClearDefault(defaultType string) error {
+	switch defaultType {
+	case "app":
+		c.DefaultApp = ""
+	default:
+		return errors.Errorf("unknown default type: %s", defaultType)
+	}
+
+	if err := c.Save(); err != nil {
+		return errors.Wrap(err, "failed to save cache")
+	}
+
+	return nil
+}


### PR DESCRIPTION
Performance improvements:
- When we currently init the CLI on most commands, we hit the API to find the app. This introduces a cache where that API slug/id are stored.  there's no expiration on it right now, but these are immutable values generally?

Usability:
- Add a new "default" command:
`replicated default set app slackernews`
`replicated default show app`
`replicated default clear app`

These set the defaultApp value in the cache, so that we no longer need to pass it into every CLI function.