### PR TITLE
bubble up more detailed git errors

### DIFF
--- a/cli/cmd/release_create.go
+++ b/cli/cmd/release_create.go
@@ -109,7 +109,7 @@ func (r *runners) setKOTSDefaultReleaseParams() error {
 
 	rev, branch, isDirty, err := r.gitSHABranch()
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "get git properties")
 	}
 	dirtyStatus := ""
 	if isDirty {

--- a/cli/cmd/release_create.go
+++ b/cli/cmd/release_create.go
@@ -71,24 +71,24 @@ func (r *runners) gitSHABranch() (sha string, branch string, dirty bool, err err
 	rev := "HEAD"
 	repository, err := git.PlainOpenWithOptions(path, &git.PlainOpenOptions{DetectDotGit: true})
 	if err != nil {
-		return "", "", false, errors.Wrapf(err, "open %q", path)
+		return "", "", false, fmt.Errorf("git open '%q' failed: %w", path, err)
 	}
 	h, err := repository.ResolveRevision(plumbing.Revision(rev))
 	if err != nil {
-		return "", "", false, errors.Wrapf(err, "resolve revision")
+		return "", "", false, fmt.Errorf("git resolve revision '%q' failed: %w", rev, err)
 	}
 	head, err := repository.Head()
 	if err != nil {
-		return "", "", false, errors.Wrapf(err, "resolve HEAD")
+		return "", "", false, fmt.Errorf("git resolve HEAD failed: %w", err)
 	}
 
 	worktree, err := repository.Worktree()
 	if err != nil {
-		return "", "", false, errors.Wrap(err, "get git worktree")
+		return "", "", false, fmt.Errorf("git get worktree failed: %w", err)
 	}
 	status, err := worktree.Status()
 	if err != nil {
-		return "", "", false, errors.Wrap(err, "get git status")
+		return "", "", false, fmt.Errorf("git get status failed: %w", err)
 	}
 
 	branchName := head.Name().Short()
@@ -109,7 +109,7 @@ func (r *runners) setKOTSDefaultReleaseParams() error {
 
 	rev, branch, isDirty, err := r.gitSHABranch()
 	if err != nil {
-		return errors.Wrapf(err, "get git properties")
+		return err
 	}
 	dirtyStatus := ""
 	if isDirty {


### PR DESCRIPTION
Right now when go-git encounters an error we end up not printing a very useful error since it ends being unwrapped. e.g.

```
ERROR: reference not found
```

With this change we should bubble up a more detailed error that should more directly hint at the problem:

```
ERROR: git resolve revision '"HEAD"' failed: reference not found
```