### PR TITLE
Populate flag variables

### DIFF
--- a/cli/cmd/customer_download_license.go
+++ b/cli/cmd/customer_download_license.go
@@ -32,7 +32,16 @@ You must specify the customer using either their name or ID with the --customer 
 
   # Download license for a customer in a specific app (if you have multiple apps)
   replicated customer download-license --app myapp --customer "Acme Inc" --output license.yaml`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+
+			if customer, err = cmd.Flags().GetString("customer"); err != nil {
+				return err
+			}
+
+			if output, err = cmd.Flags().GetString("output"); err != nil {
+				return err
+			}
+
 			return r.downloadCustomerLicense(cmd, customer, output)
 		},
 		SilenceUsage: true,


### PR DESCRIPTION
I'm not 100% on the intentions behind switching away from setting the flags with `stringVar` but in doing so the flags weren't populating the variables used by the rest of the code. 

this patch populates the `var`s with the string values, but you could equally roll back to using `stringVar` and `stringVarp` instead. 