### PR TITLE
Check app has been specified in all commands that use it

### DIFF
--- a/cli/cmd/channel_adoption.go
+++ b/cli/cmd/channel_adoption.go
@@ -19,6 +19,10 @@ func (r *runners) InitChannelAdoption(parent *cobra.Command) {
 }
 
 func (r *runners) channelAdoption(cmd *cobra.Command, args []string) error {
+	if !r.hasApp() {
+		return errors.New("no app specified")
+	}
+
 	if len(args) != 1 {
 		return errors.New("channel ID is required")
 	}

--- a/cli/cmd/channel_counts.go
+++ b/cli/cmd/channel_counts.go
@@ -19,6 +19,10 @@ func (r *runners) InitChannelCounts(parent *cobra.Command) {
 }
 
 func (r *runners) channelCounts(cmd *cobra.Command, args []string) error {
+	if !r.hasApp() {
+		return errors.New("no app specified")
+	}
+
 	if len(args) != 1 {
 		return errors.New("channel ID is required")
 	}

--- a/cli/cmd/channel_create.go
+++ b/cli/cmd/channel_create.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/pkg/errors"
 	"github.com/replicatedhq/replicated/cli/print"
 	"github.com/spf13/cobra"
 )
@@ -25,6 +26,10 @@ func (r *runners) InitChannelCreate(parent *cobra.Command) {
 }
 
 func (r *runners) channelCreate(cmd *cobra.Command, args []string) error {
+	if !r.hasApp() {
+		return errors.New("no app specified")
+	}
+
 	allChannels, err := r.api.CreateChannel(r.appID, r.appType, r.args.channelCreateName, r.args.channelCreateDescription)
 	if err != nil {
 		return err

--- a/cli/cmd/channel_disable_semantic_versioning.go
+++ b/cli/cmd/channel_disable_semantic_versioning.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+
 	"github.com/spf13/cobra"
 )
 
@@ -21,6 +22,10 @@ func (r *runners) InitChannelDisableSemanticVersioning(parent *cobra.Command) {
 }
 
 func (r *runners) channelDisableSemanticVersioning(cmd *cobra.Command, args []string) error {
+	if !r.hasApp() {
+		return errors.New("no app specified")
+	}
+
 	if len(args) != 1 {
 		return errors.New("channel ID is required")
 	}

--- a/cli/cmd/channel_enable_semantic_versioning.go
+++ b/cli/cmd/channel_enable_semantic_versioning.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+
 	"github.com/spf13/cobra"
 )
 
@@ -21,6 +22,10 @@ func (r *runners) InitChannelEnableSemanticVersioning(parent *cobra.Command) {
 }
 
 func (r *runners) channelEnableSemanticVersioning(cmd *cobra.Command, args []string) error {
+	if !r.hasApp() {
+		return errors.New("no app specified")
+	}
+
 	if len(args) != 1 {
 		return errors.New("channel ID is required")
 	}

--- a/cli/cmd/channel_inspect.go
+++ b/cli/cmd/channel_inspect.go
@@ -21,6 +21,10 @@ func (r *runners) InitChannelInspect(parent *cobra.Command) {
 }
 
 func (r *runners) channelInspect(_ *cobra.Command, args []string) error {
+	if !r.hasApp() {
+		return errors.New("no app specified")
+	}
+
 	if len(args) != 1 {
 		return errors.New("channel name or ID is required")
 	}

--- a/cli/cmd/channel_ls.go
+++ b/cli/cmd/channel_ls.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/pkg/errors"
 	"github.com/replicatedhq/replicated/cli/print"
 	"github.com/spf13/cobra"
 )
@@ -19,6 +20,10 @@ func (r *runners) InitChannelList(parent *cobra.Command) {
 }
 
 func (r *runners) channelList(cmd *cobra.Command, args []string) error {
+	if !r.hasApp() {
+		return errors.New("no app specified")
+	}
+
 	channels, err := r.api.ListChannels(r.appID, r.appType, "")
 	if err != nil {
 		return err

--- a/cli/cmd/channel_releases.go
+++ b/cli/cmd/channel_releases.go
@@ -19,6 +19,10 @@ func (r *runners) InitChannelReleases(parent *cobra.Command) {
 }
 
 func (r *runners) channelReleases(cmd *cobra.Command, args []string) error {
+	if !r.hasApp() {
+		return errors.New("no app specified")
+	}
+
 	if len(args) != 1 {
 		return errors.New("channel ID is required")
 	}

--- a/cli/cmd/channel_rm.go
+++ b/cli/cmd/channel_rm.go
@@ -18,6 +18,10 @@ func (r *runners) InitChannelRemove(parent *cobra.Command) {
 }
 
 func (r *runners) channelRemove(cmd *cobra.Command, args []string) error {
+	if !r.hasApp() {
+		return errors.New("no app specified")
+	}
+
 	if len(args) != 1 {
 		return errors.New("channel ID is required")
 	}

--- a/cli/cmd/cluster_prepare.go
+++ b/cli/cmd/cluster_prepare.go
@@ -150,6 +150,10 @@ func validateClusterPrepareFlags(args runnerArgs) error {
 }
 
 func (r *runners) prepareCluster(_ *cobra.Command, args []string) error {
+	if !r.hasApp() {
+		return errors.New("no app specified")
+	}
+
 	log := logger.NewLogger(r.w)
 
 	release, err := prepareRelease(r, log)

--- a/cli/cmd/collector_create.go
+++ b/cli/cmd/collector_create.go
@@ -26,6 +26,10 @@ func (r *runners) InitCollectorCreate(parent *cobra.Command) {
 }
 
 func (r *runners) collectorCreate(cmd *cobra.Command, args []string) error {
+	if !r.hasApp() {
+		return errors.New("no app specified")
+	}
+
 	if r.args.createCollectorName == "" {
 		return errors.New("collector name is required")
 	}

--- a/cli/cmd/collector_ls.go
+++ b/cli/cmd/collector_ls.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/pkg/errors"
 	"github.com/replicatedhq/replicated/cli/print"
 	"github.com/spf13/cobra"
 )
@@ -17,6 +18,10 @@ func (r *runners) InitCollectorList(parent *cobra.Command) {
 }
 
 func (r *runners) collectorList(cmd *cobra.Command, args []string) error {
+	if !r.hasApp() {
+		return errors.New("no app specified")
+	}
+
 	collectors, err := r.api.ListCollectors(r.appID, r.appType)
 	if err != nil {
 		return err

--- a/cli/cmd/collector_promote.go
+++ b/cli/cmd/collector_promote.go
@@ -22,6 +22,10 @@ func (r *runners) InitCollectorPromote(parent *cobra.Command) {
 }
 
 func (r *runners) collectorPromote(cmd *cobra.Command, args []string) error {
+	if !r.hasApp() {
+		return errors.New("no app specified")
+	}
+
 	// parse spec ID and channel ID positional arguments
 	if len(args) != 2 {
 		return errors.New("collector spec ID and channel ID are required")

--- a/cli/cmd/customer_archive.go
+++ b/cli/cmd/customer_archive.go
@@ -55,6 +55,10 @@ The customer can be specified by either their name or ID.`,
 	return cmd
 }
 func (r *runners) archiveCustomer(cmd *cobra.Command, customers []string, app string) error {
+	if !r.hasApp() {
+		return errors.New("no app specified")
+	}
+
 	if len(customers) == 0 {
 		return errors.Errorf("missing or invalid parameters: customer")
 	}

--- a/cli/cmd/customer_create.go
+++ b/cli/cmd/customer_create.go
@@ -104,6 +104,10 @@ func (r *runners) createCustomer(cmd *cobra.Command, opts createCustomerOpts, ou
 	}()
 
 	// Validation
+	if !r.hasApp() {
+		return errors.New("no app specified")
+	}
+
 	if err := validateCustomerType(opts.CustomerType); err != nil {
 		return errors.Wrap(err, "validate customer type")
 	}

--- a/cli/cmd/customer_download_license.go
+++ b/cli/cmd/customer_download_license.go
@@ -46,6 +46,10 @@ You must specify the customer using either their name or ID with the --customer 
 }
 
 func (r *runners) downloadCustomerLicense(cmd *cobra.Command, customer string, output string) error {
+	if !r.hasApp() {
+		return errors.New("no app specified")
+	}
+
 	customerNameOrId, err := cmd.Flags().GetString("customer")
 	if err != nil {
 		return errors.Wrap(err, "get customer flag")

--- a/cli/cmd/customer_inspect.go
+++ b/cli/cmd/customer_inspect.go
@@ -52,6 +52,10 @@ func (r *runners) InitCustomersInspectCommand(parent *cobra.Command) *cobra.Comm
 }
 
 func (r *runners) inspectCustomer(cmd *cobra.Command, customer string, outputFormat string) error {
+	if !r.hasApp() {
+		return errors.New("no app specified")
+	}
+
 	if customer == "" {
 		return errors.Errorf("missing or invalid parameters: customer")
 	}

--- a/cli/cmd/customer_ls.go
+++ b/cli/cmd/customer_ls.go
@@ -46,6 +46,10 @@ The command requires an app to be set using the --app flag.`,
 }
 
 func (r *runners) listCustomers(appVersion string, includeTest bool, outputFormat string) error {
+	if !r.hasApp() {
+		return errors.New("no app specified")
+	}
+
 	if appVersion == "" {
 		customers, err := r.api.ListCustomers(r.appID, r.appType, includeTest)
 		if err != nil {

--- a/cli/cmd/customer_update.go
+++ b/cli/cmd/customer_update.go
@@ -104,8 +104,13 @@ func (r *runners) updateCustomer(cmd *cobra.Command, opts updateCustomerOpts, ou
 	defer func() {
 		printIfError(cmd, err)
 	}()
+
+	if !r.hasApp() {
+		return errors.New("no app specified")
+	}
+
 	if opts.CustomerID == "" {
-		return errors.Errorf("missing or invalid parameters: customer")
+		return errors.New("missing or invalid parameters: customer")
 	}
 
 	// all of the following validation occurs in the API also, but

--- a/cli/cmd/installer_ls.go
+++ b/cli/cmd/installer_ls.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/pkg/errors"
 	"github.com/replicatedhq/replicated/cli/print"
 	"github.com/spf13/cobra"
 )
@@ -19,6 +20,10 @@ func (r *runners) InitInstallerList(parent *cobra.Command) {
 }
 
 func (r *runners) installerList(_ *cobra.Command, _ []string) error {
+	if !r.hasApp() {
+		return errors.New("no app specified")
+	}
+
 	installers, err := r.api.ListInstallers(r.appID, r.appType)
 	if err != nil {
 		return err

--- a/cli/cmd/instance_inspect.go
+++ b/cli/cmd/instance_inspect.go
@@ -29,6 +29,10 @@ func (r *runners) inspectInstance(cmd *cobra.Command, _ []string) (err error) {
 		printIfError(cmd, err)
 	}()
 
+	if !r.hasApp() {
+		return errors.New("no app specified")
+	}
+
 	if r.args.instanceInspectCustomer == "" {
 		return errors.Errorf("missing or invalid parameters: customer")
 	}

--- a/cli/cmd/instance_ls.go
+++ b/cli/cmd/instance_ls.go
@@ -29,6 +29,10 @@ func (r *runners) listInstances(cmd *cobra.Command, _ []string) (err error) {
 		printIfError(cmd, err)
 	}()
 
+	if !r.hasApp() {
+		return errors.New("no app specified")
+	}
+
 	if r.args.instanceListCustomer == "" {
 		return errors.Errorf("missing or invalid parameters: customer")
 	}

--- a/cli/cmd/instance_tag.go
+++ b/cli/cmd/instance_tag.go
@@ -29,6 +29,10 @@ func (r *runners) tagInstance(cmd *cobra.Command, _ []string) (err error) {
 		printIfError(cmd, err)
 	}()
 
+	if !r.hasApp() {
+		return errors.New("no app specified")
+	}
+
 	if r.args.instanceTagCustomer == "" {
 		return errors.Errorf("missing or invalid parameters: customer")
 	}

--- a/cli/cmd/release_create.go
+++ b/cli/cmd/release_create.go
@@ -160,6 +160,10 @@ func (r *runners) releaseCreate(cmd *cobra.Command, args []string) (err error) {
 
 	log := logger.NewLogger(r.w)
 
+	if !r.hasApp() {
+		return errors.New("no app specified")
+	}
+
 	if r.appType == "kots" && r.args.createReleaseAutoDefaults {
 		log.ActionWithSpinner("Reading Environment")
 		err = r.setKOTSDefaultReleaseParams()

--- a/cli/cmd/release_download.go
+++ b/cli/cmd/release_download.go
@@ -23,6 +23,10 @@ func (r *runners) InitReleaseDownload(parent *cobra.Command) {
 }
 
 func (r *runners) releaseDownload(command *cobra.Command, args []string) error {
+	if !r.hasApp() {
+		return errors.New("no app specified")
+	}
+
 	if r.appType != "kots" {
 		return r.releaseInspect(command, args)
 	}

--- a/cli/cmd/release_inspect.go
+++ b/cli/cmd/release_inspect.go
@@ -22,6 +22,10 @@ func (r *runners) InitReleaseInspect(parent *cobra.Command) {
 }
 
 func (r *runners) releaseInspect(_ *cobra.Command, args []string) error {
+	if !r.hasApp() {
+		return errors.New("no app specified")
+	}
+
 	if len(args) != 1 {
 		return errors.New("release sequence is required")
 	}

--- a/cli/cmd/release_lint.go
+++ b/cli/cmd/release_lint.go
@@ -44,6 +44,10 @@ func (r *runners) InitReleaseLint(parent *cobra.Command) {
 // the hosted version (lint.replicated.com). There are not changes and no auth required or sent.
 // This could be vendored in and run locally (respecting the size of the polcy files)
 func (r *runners) releaseLint(cmd *cobra.Command, args []string) error {
+	if !r.hasApp() {
+		return errors.New("no app specified")
+	}
+
 	var isBuildersRelease bool
 	var lintReleaseData []byte
 	var contentType string

--- a/cli/cmd/release_ls.go
+++ b/cli/cmd/release_ls.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/pkg/errors"
 	"github.com/replicatedhq/replicated/cli/print"
 	"github.com/spf13/cobra"
 )
@@ -19,6 +20,10 @@ func (r *runners) IniReleaseList(parent *cobra.Command) {
 }
 
 func (r *runners) releaseList(cmd *cobra.Command, args []string) error {
+	if !r.hasApp() {
+		return errors.New("no app specified")
+	}
+
 	releases, err := r.api.ListReleases(r.appID, r.appType)
 	if err != nil {
 		return err

--- a/cli/cmd/release_promote.go
+++ b/cli/cmd/release_promote.go
@@ -34,6 +34,10 @@ func (r *runners) releasePromote(cmd *cobra.Command, args []string) (err error) 
 		printIfError(cmd, err)
 	}()
 
+	if !r.hasApp() {
+		return errors.New("no app specified")
+	}
+
 	// parse sequence and channel ID positional arguments
 	if len(args) != 2 {
 		return errors.New("release sequence and channel ID are required")

--- a/cli/cmd/release_update.go
+++ b/cli/cmd/release_update.go
@@ -28,6 +28,10 @@ func (r *runners) InitReleaseUpdate(parent *cobra.Command) {
 }
 
 func (r *runners) releaseUpdate(cmd *cobra.Command, args []string) error {
+	if !r.hasApp() {
+		return errors.New("no app specified")
+	}
+
 	specSources := []string{
 		r.args.updateReleaseYaml,
 		r.args.updateReleaseYamlFile,

--- a/cli/cmd/release_validate.go
+++ b/cli/cmd/release_validate.go
@@ -19,6 +19,10 @@ func (r *runners) InitReleaseTest(parent *cobra.Command) {
 }
 
 func (r *runners) releaseTest(command *cobra.Command, args []string) error {
+	if !r.hasApp() {
+		return errors.New("no app specified")
+	}
+
 	if len(args) != 1 {
 		return errors.New("release sequence is required")
 	}

--- a/cli/cmd/runner.go
+++ b/cli/cmd/runner.go
@@ -31,6 +31,13 @@ type runners struct {
 	args    runnerArgs
 }
 
+func (r *runners) hasApp() bool {
+	if r.appID == "" && r.appType == "" && r.appSlug == "" {
+		return false
+	}
+	return true
+}
+
 type runnerArgs struct {
 	channelCreateName        string
 	channelCreateDescription string


### PR DESCRIPTION
Check app is specified to avoid confusing errors:

Before:
```
replicated release create --lint --yaml-dir kots --promote Unstable --version 0.1.6 
ERROR: one of --yaml or --yaml-file must be provided
```

After:
```
replicated release create --lint --yaml-dir kots --promote Unstable --version 0.1.6 
ERROR: no app specified
```

