### PR TITLE
Set GORELEASER_CURRENT_TAG for goreleaser

### DIFF
--- a/dagger/release.go
+++ b/dagger/release.go
@@ -160,7 +160,9 @@ func (r *Replicated) Release(
 
 	goreleaserContainer := dag.Goreleaser(dagger.GoreleaserOpts{
 		Version: goreleaserVersion,
-	}).Ctr().WithSecretVariable("GITHUB_TOKEN", githubToken)
+	}).Ctr().
+		WithSecretVariable("GITHUB_TOKEN", githubToken).
+		WithEnvVariable("GORELEASER_CURRENT_TAG", latestVersion)
 
 	if snapshot {
 		_, err := dag.


### PR DESCRIPTION
Tell goreleaser what the last version was so it can generate change log correctly.