### PR TITLE
Use correct output flag in customer inspect

### DIFF
--- a/cli/cmd/customer_inspect.go
+++ b/cli/cmd/customer_inspect.go
@@ -75,7 +75,7 @@ func (r *runners) inspectCustomer(cmd *cobra.Command, customer string, outputFor
 		return errors.Wrapf(err, "get registry hostname for customer %q", customer)
 	}
 
-	if err = print.CustomerAttrs(r.outputFormat, r.w, r.appType, r.appSlug, ch, regHost, c); err != nil {
+	if err = print.CustomerAttrs(outputFormat, r.w, r.appType, r.appSlug, ch, regHost, c); err != nil {
 		return errors.Wrap(err, "print customer attrs")
 	}
 


### PR DESCRIPTION
Fixes the --output flag in the `customer inspect` command.