### PR TITLE
Remove ./bin/replicated from build container

### DIFF
--- a/dagger/release.go
+++ b/dagger/release.go
@@ -116,6 +116,7 @@ func (r *Replicated) Release(
 	}).
 		From("golang:1.22").
 		WithMountedDirectory("/go/src/github.com/replicatedhq/replicated", updatedSource).
+		WithoutFile("/go/src/github.com/replicatedhq/replicated/bin/replicated").
 		WithWorkdir("/go/src/github.com/replicatedhq/replicated").
 		WithMountedCache("/go/pkg/mod", goModCache).
 		WithEnvVariable("GOMODCACHE", "/go/pkg/mod").


### PR DESCRIPTION
`make build` can fail with the following error if ./bin/replicated is present and is corrupted in some way

```
Stderr:
command-line-arguments: go build command-line-arguments: build output "bin/replicated" already exists and is not an object file
make: *** [Makefile:106: build] Error 1
```