### PR TITLE
add common aliases

### DIFF
--- a/cli/cmd/app_ls.go
+++ b/cli/cmd/app_ls.go
@@ -15,8 +15,9 @@ func (r *runners) InitAppList(parent *cobra.Command) *cobra.Command {
 	var outputFormat string
 
 	cmd := &cobra.Command{
-		Use:   "ls [NAME]",
-		Short: "List applications",
+		Use:     "ls [NAME]",
+		Aliases: []string{"list"},
+		Short:   "List applications",
 		Long: `List all applications in your Replicated account,
 or search for a specific application by name or ID.
 

--- a/cli/cmd/channel_ls.go
+++ b/cli/cmd/channel_ls.go
@@ -8,9 +8,10 @@ import (
 
 func (r *runners) InitChannelList(parent *cobra.Command) {
 	cmd := &cobra.Command{
-		Use:   "ls",
-		Short: "List all channels in your app",
-		Long:  "List all channels in your app",
+		Use:     "ls",
+		Aliases: []string{"list"},
+		Short:   "List all channels in your app",
+		Long:    "List all channels in your app",
 	}
 
 	parent.AddCommand(cmd)

--- a/cli/cmd/channel_rm.go
+++ b/cli/cmd/channel_rm.go
@@ -9,9 +9,10 @@ import (
 
 func (r *runners) InitChannelRemove(parent *cobra.Command) {
 	cmd := &cobra.Command{
-		Use:   "rm CHANNEL_ID",
-		Short: "Remove (archive) a channel",
-		Long:  "Remove (archive) a channel",
+		Use:     "rm CHANNEL_ID",
+		Aliases: []string{"delete"},
+		Short:   "Remove (archive) a channel",
+		Long:    "Remove (archive) a channel",
 	}
 	parent.AddCommand(cmd)
 	cmd.RunE = r.channelRemove

--- a/cli/cmd/cluster_addon_ls.go
+++ b/cli/cmd/cluster_addon_ls.go
@@ -14,8 +14,9 @@ func (r *runners) InitClusterAddonLs(parent *cobra.Command) *cobra.Command {
 	args := clusterAddonLsArgs{}
 
 	cmd := &cobra.Command{
-		Use:   "ls CLUSTER_ID",
-		Short: "List cluster add-ons for a cluster.",
+		Use:     "ls CLUSTER_ID",
+		Aliases: []string{"list"},
+		Short:   "List cluster add-ons for a cluster.",
 		Long: `The 'cluster addon ls' command allows you to list all add-ons for a specific cluster. This command provides a detailed overview of the add-ons currently installed on the cluster, including their status and any relevant configuration details.
 
 This can be useful for monitoring the health and configuration of add-ons or performing troubleshooting tasks.`,

--- a/cli/cmd/cluster_addon_rm.go
+++ b/cli/cmd/cluster_addon_rm.go
@@ -15,8 +15,9 @@ func (r *runners) InitClusterAddonRm(parent *cobra.Command) *cobra.Command {
 	args := clusterAddonRmArgs{}
 
 	cmd := &cobra.Command{
-		Use:   "rm CLUSTER_ID --id ADDON_ID",
-		Short: "Remove cluster add-on by ID.",
+		Use:     "rm CLUSTER_ID --id ADDON_ID",
+		Aliases: []string{"delete"},
+		Short:   "Remove cluster add-on by ID.",
 		Long: `The 'cluster addon rm' command allows you to remove a specific add-on from a cluster by specifying the cluster ID and the add-on ID.
 
 This command is useful when you want to deprovision an add-on that is no longer needed or when troubleshooting issues related to specific add-ons. The add-on will be removed immediately, and you will receive confirmation upon successful removal.`,

--- a/cli/cmd/cluster_ls.go
+++ b/cli/cmd/cluster_ls.go
@@ -14,8 +14,9 @@ import (
 
 func (r *runners) InitClusterList(parent *cobra.Command) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "ls",
-		Short: "List test clusters.",
+		Use:     "ls",
+		Aliases: []string{"list"},
+		Short:   "List test clusters.",
 		Long: `The 'cluster ls' command lists all test clusters. This command provides information about the clusters, such as their status, name, distribution, version, and creation time. The output can be formatted in different ways, depending on your needs.
 
 You can filter the list of clusters by time range and status (e.g., show only terminated clusters). You can also watch clusters in real-time, which updates the list every few seconds.

--- a/cli/cmd/cluster_nodegroup_ls.go
+++ b/cli/cmd/cluster_nodegroup_ls.go
@@ -9,8 +9,9 @@ import (
 
 func (r *runners) InitClusterNodeGroupList(parent *cobra.Command) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "ls [ID]",
-		Short: "List node groups for a cluster.",
+		Use:     "ls [ID]",
+		Aliases: []string{"list"},
+		Short:   "List node groups for a cluster.",
 		Long: `The 'cluster nodegroup ls' command lists all the node groups associated with a given cluster. Each node group defines a specific set of nodes with particular configurations, such as instance types and scaling options.
 
 You can view information about the node groups within the specified cluster, including their ID, name, node count, and other configuration details.

--- a/cli/cmd/cluster_port_ls.go
+++ b/cli/cmd/cluster_port_ls.go
@@ -7,8 +7,9 @@ import (
 
 func (r *runners) InitClusterPortLs(parent *cobra.Command) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "ls CLUSTER_ID",
-		Short: "List cluster ports for a cluster.",
+		Use:     "ls CLUSTER_ID",
+		Aliases: []string{"list"},
+		Short:   "List cluster ports for a cluster.",
 		Long: `The 'cluster port ls' command lists all the ports configured for a specific cluster. You must provide the cluster ID to retrieve and display the ports.
 
 This command is useful for viewing the current port configurations, protocols, and other related settings of your test cluster. The output format can be customized to suit your needs, and the available formats include table, JSON, and wide views.`,

--- a/cli/cmd/cluster_port_rm.go
+++ b/cli/cmd/cluster_port_rm.go
@@ -8,8 +8,9 @@ import (
 
 func (r *runners) InitClusterPortRm(parent *cobra.Command) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "rm CLUSTER_ID --id PORT_ID",
-		Short: "Remove cluster port by ID.",
+		Use:     "rm CLUSTER_ID --id PORT_ID",
+		Aliases: []string{"delete"},
+		Short:   "Remove cluster port by ID.",
 		Long: `The 'cluster port rm' command removes a specific port from a cluster. You must provide either the ID of the port or the port number and protocol(s) to remove.
 
 This command is useful for managing the network settings of your test clusters by allowing you to clean up unused or incorrect ports. After removing a port, the updated list of ports will be displayed.

--- a/cli/cmd/cluster_rm.go
+++ b/cli/cmd/cluster_rm.go
@@ -10,8 +10,9 @@ import (
 
 func (r *runners) InitClusterRemove(parent *cobra.Command) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "rm ID [ID …]",
-		Short: "Remove test clusters.",
+		Use:     "rm ID [ID …]",
+		Aliases: []string{"delete"},
+		Short:   "Remove test clusters.",
 		Long: `The 'rm' command removes test clusters immediately.
 
 You can remove clusters by specifying a cluster ID, or by using other criteria such as cluster names or tags. Alternatively, you can remove all clusters in your account at once.

--- a/cli/cmd/collection_ls.go
+++ b/cli/cmd/collection_ls.go
@@ -9,6 +9,7 @@ import (
 func (r *runners) InitCollectionList(parent *cobra.Command) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "ls",
+		Aliases:      []string{"list"},
 		Short:        "list model collections",
 		Long:         `list model collections`,
 		RunE:         r.listCollections,

--- a/cli/cmd/collection_rm.go
+++ b/cli/cmd/collection_rm.go
@@ -9,6 +9,7 @@ import (
 func (r *runners) InitCollectionRemove(parent *cobra.Command) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "rm COLLECTION_ID",
+		Aliases:      []string{"delete"},
 		Short:        "remove a collection",
 		Long:         `remove a collection, unlinking any model from the collection (but not deleting the model)`,
 		RunE:         r.removeCollection,

--- a/cli/cmd/collector_ls.go
+++ b/cli/cmd/collector_ls.go
@@ -8,9 +8,10 @@ import (
 
 func (r *runners) InitCollectorList(parent *cobra.Command) {
 	cmd := &cobra.Command{
-		Use:   "ls",
-		Short: "List all of an app's collectors",
-		Long:  "List all of an app's collectors",
+		Use:     "ls",
+		Aliases: []string{"list"},
+		Short:   "List all of an app's collectors",
+		Long:    "List all of an app's collectors",
 	}
 	cmd.Hidden = true // Not supported in KOTS
 	parent.AddCommand(cmd)

--- a/cli/cmd/customer_ls.go
+++ b/cli/cmd/customer_ls.go
@@ -14,8 +14,9 @@ func (r *runners) InitCustomersLSCommand(parent *cobra.Command) *cobra.Command {
 	)
 
 	customersLsCmd := &cobra.Command{
-		Use:   "ls",
-		Short: "List customers for the current application",
+		Use:     "ls",
+		Aliases: []string{"list"},
+		Short:   "List customers for the current application",
 		Long: `List customers associated with the current application.
 
 This command displays information about customers linked to your application.

--- a/cli/cmd/enterprise_portal_user_ls.go
+++ b/cli/cmd/enterprise_portal_user_ls.go
@@ -15,8 +15,9 @@ func (r *runners) InitEnterprisePortalUserLsCmd(parent *cobra.Command) *cobra.Co
 	var outputFormat string
 
 	cmd := &cobra.Command{
-		Use:   "ls",
-		Short: "List Enterprise Portal users",
+		Use:     "ls",
+		Aliases: []string{"list"},
+		Short:   "List Enterprise Portal users",
 		Long: `List all users associated with the Enterprise Portal for an application.
 
 This command retrieves and displays information about users who have access to

--- a/cli/cmd/installer_ls.go
+++ b/cli/cmd/installer_ls.go
@@ -8,9 +8,10 @@ import (
 
 func (r *runners) InitInstallerList(parent *cobra.Command) {
 	cmd := &cobra.Command{
-		Use:   "ls",
-		Short: "List an app's Kubernetes Installers",
-		Long:  "List an app's https://kurl.sh Kubernetes Installers",
+		Use:     "ls",
+		Aliases: []string{"list"},
+		Short:   "List an app's Kubernetes Installers",
+		Long:    "List an app's https://kurl.sh Kubernetes Installers",
 	}
 
 	parent.AddCommand(cmd)

--- a/cli/cmd/instance_ls.go
+++ b/cli/cmd/instance_ls.go
@@ -9,6 +9,7 @@ import (
 func (r *runners) InitInstanceLSCommand(parent *cobra.Command) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "ls",
+		Aliases:       []string{"list"},
 		Short:         "list customer instances",
 		Long:          `list customer instances`,
 		RunE:          r.listInstances,

--- a/cli/cmd/model_ls.go
+++ b/cli/cmd/model_ls.go
@@ -8,6 +8,7 @@ import (
 func (r *runners) InitModelList(parent *cobra.Command) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "ls",
+		Aliases:      []string{"list"},
 		Short:        "list models",
 		Long:         `list models`,
 		RunE:         r.listModels,

--- a/cli/cmd/model_rm.go
+++ b/cli/cmd/model_rm.go
@@ -8,6 +8,7 @@ import (
 func (r *runners) InitModelRemove(parent *cobra.Command) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "rm NAME",
+		Aliases:      []string{"delete"},
 		Short:        "remove a model",
 		Long:         `remove a model`,
 		RunE:         r.removeModel,

--- a/cli/cmd/network_ls.go
+++ b/cli/cmd/network_ls.go
@@ -6,10 +6,11 @@ import (
 
 func (r *runners) InitNetworkList(parent *cobra.Command) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "ls",
-		Short: "List test networks",
-		Long:  ``,
-		RunE:  r.listNetworks,
+		Use:     "ls",
+		Aliases: []string{"list"},
+		Short:   "List test networks",
+		Long:    ``,
+		RunE:    r.listNetworks,
 	}
 	parent.AddCommand(cmd)
 

--- a/cli/cmd/network_rm.go
+++ b/cli/cmd/network_rm.go
@@ -6,10 +6,11 @@ import (
 
 func (r *runners) InitNetworkRemove(parent *cobra.Command) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "rm ID [ID …]",
-		Short: "Remove test network",
-		Long:  ``,
-		RunE:  r.removeNetworks,
+		Use:     "rm ID [ID …]",
+		Aliases: []string{"delete"},
+		Short:   "Remove test network",
+		Long:    ``,
+		RunE:    r.removeNetworks,
 	}
 	parent.AddCommand(cmd)
 

--- a/cli/cmd/registry_ls.go
+++ b/cli/cmd/registry_ls.go
@@ -12,6 +12,7 @@ import (
 func (r *runners) InitRegistryList(parent *cobra.Command) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "ls [NAME]",
+		Aliases:      []string{"list"},
 		Short:        "list registries",
 		Long:         `list registries, or a single registry by name`,
 		RunE:         r.listRegistries,

--- a/cli/cmd/registry_rm.go
+++ b/cli/cmd/registry_rm.go
@@ -10,6 +10,7 @@ import (
 func (r *runners) InitRegistryRemove(parent *cobra.Command) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "rm [ENDPOINT]",
+		Aliases:      []string{"delete"},
 		Short:        "remove registry",
 		Long:         `remove registry by endpoint`,
 		RunE:         r.removeRegistry,

--- a/cli/cmd/release_ls.go
+++ b/cli/cmd/release_ls.go
@@ -8,9 +8,10 @@ import (
 
 func (r *runners) IniReleaseList(parent *cobra.Command) {
 	cmd := &cobra.Command{
-		Use:   "ls",
-		Short: "List all of an app's releases",
-		Long:  "List all of an app's releases",
+		Use:     "ls",
+		Aliases: []string{"list"},
+		Short:   "List all of an app's releases",
+		Long:    "List all of an app's releases",
 	}
 
 	parent.AddCommand(cmd)

--- a/cli/cmd/vm_ls.go
+++ b/cli/cmd/vm_ls.go
@@ -14,8 +14,9 @@ import (
 
 func (r *runners) InitVMList(parent *cobra.Command) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "ls",
-		Short: "List test VMs and their status, with optional filters for start/end time and terminated VMs.",
+		Use:     "ls",
+		Aliases: []string{"list"},
+		Short:   "List test VMs and their status, with optional filters for start/end time and terminated VMs.",
 		Long: `List all test VMs in your account, including their current status, distribution, version, and more. You can use optional flags to filter the output based on VM termination status, start time, or end time. This command can also watch the VM status in real-time.
 
 By default, the command will return a table of all VMs, but you can switch to JSON or wide output formats for more detailed information. The command supports filtering to show only terminated VMs or to specify a time range for the query.

--- a/cli/cmd/vm_rm.go
+++ b/cli/cmd/vm_rm.go
@@ -10,8 +10,9 @@ import (
 
 func (r *runners) InitVMRemove(parent *cobra.Command) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "rm ID [ID …]",
-		Short: "Remove test VM(s) immediately, with options to filter by name, tag, or remove all VMs.",
+		Use:     "rm ID [ID …]",
+		Aliases: []string{"delete"},
+		Short:   "Remove test VM(s) immediately, with options to filter by name, tag, or remove all VMs.",
 		Long: `The 'rm' command allows you to remove test VMs from your account immediately. You can specify one or more VM IDs directly, or use flags to filter which VMs to remove based on their name, tags, or simply remove all VMs at once.
 
 This command supports multiple filtering options, including removing VMs by their name, by specific tags, or by specifying the '--all' flag to remove all VMs in your account.


### PR DESCRIPTION
These aliases are common across cli applications that get used in the same spaces as replicated, i.e: podman. 