### PR TITLE
Don't list all customers and channels for the customer inspect command

### DIFF
--- a/cli/cmd/customer_inspect.go
+++ b/cli/cmd/customer_inspect.go
@@ -92,20 +92,12 @@ func (r *runners) customerChannel(customer *types.Customer) (*types.KotsChannel,
 	}
 	ch = &customer.Channels[0]
 
-	// TODO: fix GET /v3/app/{appID}/customer/{customerID} and/or GET /v3/app/{appID}/channel/{channelID} to
-	// include chartNames in channels, like List does. Also ?channelName selector wrongly excludes details
-	channels, err := r.kotsAPI.ListKotsChannels(r.appID, "", false)
+	channel, err := r.kotsAPI.GetKotsChannel(r.appID, ch.ID)
 	if err != nil {
 		return nil, errors.Wrapf(err, "list channels for customer %q", customer.Name)
 	}
 
-	for _, detailedChan := range channels {
-		if ch.ID == detailedChan.Id {
-			return detailedChan, nil
-		}
-	}
-
-	return nil, nil
+	return channel, nil
 }
 
 func (r *runners) registryHostname(customer *types.Customer, ch *types.KotsChannel) (string, error) {

--- a/pkg/kotsclient/channel.go
+++ b/pkg/kotsclient/channel.go
@@ -68,6 +68,15 @@ func (c *VendorV3Client) CreateChannel(appID, name, description string) (*types.
 }
 
 func (c *VendorV3Client) GetChannel(appID string, channelID string) (*types.Channel, error) {
+	channel, err := c.GetKotsChannel(appID, channelID)
+	if err != nil {
+		return nil, errors.Wrap(err, "get kots channel")
+	}
+
+	return channel.ToChannel(), nil
+}
+
+func (c *VendorV3Client) GetKotsChannel(appID string, channelID string) (*types.KotsChannel, error) {
 	type getChannelResponse struct {
 		Channel types.KotsChannel `json:"channel"`
 	}
@@ -79,7 +88,7 @@ func (c *VendorV3Client) GetChannel(appID string, channelID string) (*types.Chan
 		return nil, errors.Wrap(err, "get app channel")
 	}
 
-	return response.Channel.ToChannel(), nil
+	return &response.Channel, nil
 }
 
 func (c *VendorV3Client) ArchiveChannel(appID, channelID string) error {

--- a/pkg/kotsclient/customer_list.go
+++ b/pkg/kotsclient/customer_list.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/pkg/errors"
+	"github.com/replicatedhq/replicated/pkg/platformclient"
 	"github.com/replicatedhq/replicated/pkg/types"
 )
 
@@ -50,13 +52,31 @@ func (c *VendorV3Client) ListCustomers(appID string, includeTest bool) ([]types.
 	return allCustomers, nil
 }
 
+func (c *VendorV3Client) GetCustomerByNameOrId(appID string, nameOrId string) (*types.Customer, error) {
+	customer, err := c.GetCustomerByID(nameOrId)
+	if err != nil && errors.Cause(err) != platformclient.ErrNotFound {
+		return nil, errors.Wrap(err, "get customer by id")
+	}
+
+	if customer != nil {
+		return customer, nil
+	}
+
+	customer, err = c.GetCustomerByName(appID, nameOrId)
+	if err != nil {
+		return nil, errors.Wrap(err, "get customer by name")
+	}
+
+	return customer, nil
+}
+
 type CustomerGetResponse struct {
 	Customer types.Customer `json:"customer"`
 }
 
 func (c *VendorV3Client) GetCustomerByID(customerID string) (*types.Customer, error) {
 	resp := CustomerGetResponse{}
-	err := c.DoJSON(context.TODO(), "GET", fmt.Sprintf("/v3/customer/%s", customerID), http.StatusOK, nil, &resp)
+	err := c.DoJSON(context.TODO(), "GET", fmt.Sprintf("/v3/customer/%s", url.PathEscape(customerID)), http.StatusOK, nil, &resp)
 	if err != nil {
 		return nil, err
 	}
@@ -64,28 +84,96 @@ func (c *VendorV3Client) GetCustomerByID(customerID string) (*types.Customer, er
 }
 
 func (c *VendorV3Client) GetCustomerByName(appID string, name string) (*types.Customer, error) {
-	return c.GetCustomerByNameOrId(appID, name)
-}
-
-func (c *VendorV3Client) GetCustomerByNameOrId(appID string, nameOrId string) (*types.Customer, error) {
-	allCustomers, err := c.ListCustomers(appID, false)
+	// Using the search API, we first to narrow down fuzzy matches to one exact match.
+	// Since search API may return stale data, we then also need to use the customer ID to get the exact customer record.
+	customers, err := c.listCustomersByName(appID, name)
 	if err != nil {
 		return nil, err
 	}
 
-	matchingCustomers := make([]types.Customer, 0)
-	for _, customer := range allCustomers {
-		if customer.ID == nameOrId || customer.Name == nameOrId {
-			matchingCustomers = append(matchingCustomers, customer)
+	if len(customers) == 0 {
+		return nil, platformclient.ErrNotFound
+	}
+
+	exactMatches := make([]*types.Customer, 0)
+	for _, customer := range customers {
+		if customer.Name == name {
+			exactMatches = append(exactMatches, &customer)
 		}
 	}
 
-	if len(matchingCustomers) == 0 {
-		return nil, ErrCustomerNotFound{Name: nameOrId}
+	if len(exactMatches) == 0 {
+		return nil, ErrCustomerNotFound{Name: name}
 	}
 
-	if len(matchingCustomers) > 1 {
-		return nil, fmt.Errorf("customer %q is ambiguous, please use customer ID", nameOrId)
+	if len(exactMatches) > 1 {
+		return nil, fmt.Errorf("customer %q is ambiguous, please use customer ID", name)
 	}
-	return &matchingCustomers[0], nil
+
+	customer, err := c.GetCustomerByID(exactMatches[0].ID)
+	if err != nil {
+		return nil, err
+	}
+
+	return customer, nil
+}
+
+// This function will use the search API to find customers by name, which uses fuzzy matching, so it may return multiple customers with similar names.
+// In most practical cases, this is still faster than using the /cutomers API to list all customers for the app.
+func (c *VendorV3Client) listCustomersByName(appID string, name string) ([]types.Customer, error) {
+	if name == "" {
+		return nil, errors.New("name is required to search customers")
+	}
+
+	allCustomers := []types.Customer{}
+	offset := 0
+	pageSize := 100
+	for {
+		payload := struct {
+			AppID            string `json:"app_id"`
+			Offset           int    `json:"offset"`
+			PageSize         int    `json:"page_size"`
+			Query            string `json:"query"`
+			IncludeActive    bool   `json:"include_active"`
+			IncluseArchived  bool   `json:"include_archived"`
+			IncludeCommunity bool   `json:"include_community"`
+			IncludeDev       bool   `json:"include_dev"`
+			IncludeInactive  bool   `json:"include_inactive"`
+			IncludePaid      bool   `json:"include_paid"`
+			IncludeTrial     bool   `json:"include_trial"`
+			InstancePreview  bool   `json:"instance_preview"`
+		}{
+			AppID:            appID,
+			Offset:           offset,
+			PageSize:         100,
+			Query:            fmt.Sprintf("name:%s", name),
+			IncludeActive:    true,
+			IncluseArchived:  false,
+			IncludeCommunity: true,
+			IncludeDev:       true,
+			IncludeInactive:  true,
+			IncludePaid:      true,
+			IncludeTrial:     true,
+			InstancePreview:  false,
+		}
+
+		resp := struct {
+			Customers []types.Customer `json:"customers"`
+			TotalHits int              `json:"total_hits"`
+		}{}
+
+		err := c.DoJSON(context.TODO(), "POST", "/v3/customers/search", http.StatusOK, payload, &resp)
+		if err != nil {
+			return nil, errors.Wrapf(err, "search customers offset %d", offset)
+		}
+
+		allCustomers = append(allCustomers, resp.Customers...)
+
+		offset = offset + pageSize
+		if offset > resp.TotalHits {
+			break
+		}
+	}
+
+	return allCustomers, nil
 }


### PR DESCRIPTION
Don't list all customers and app channels when running `replicated customer inspect` command.

1. First attempt to get customer by ID
2. If customer is not found, try using search API to search by name.
3. If there is only one match by name, get customer using the ID of the matching object.