### PR TITLE
chore(cmx): update cluster subcommand example to use nodegroup ls

### DIFF
--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -26,8 +26,8 @@ func (r *runners) InitClusterCommand(parent *cobra.Command) *cobra.Command {
   # Remove a specific cluster by ID
   replicated cluster rm <cluster-id>
 
-  # Create a node group within a specific cluster
-  replicated cluster nodegroup create --cluster-id <cluster-id> --instance-type m6.large --nodes 3`,
+  # List all nodegroups in a specific cluster
+  replicated cluster nodegroup ls <cluster-id>`,
 	}
 	parent.AddCommand(cmd)
 


### PR DESCRIPTION
Following #478 I caught another example which doesn't work, at the root of the `replicated cluster` command, it referenced the `nodegroup create` command which doesn't exist.  I changed the example to reference `nodegroup ls` for now since that actually does exist and will work.