### PR TITLE
Support creating addons as part of 'cluster create' command

### DIFF
--- a/cli/cmd/cluster_addon_create_objectstore.go
+++ b/cli/cmd/cluster_addon_create_objectstore.go
@@ -83,7 +83,7 @@ func (r *runners) clusterAddonCreateObjectStoreCreateRun() error {
 	}
 
 	if opts.DryRun {
-		_, err := fmt.Fprintln(r.w, "Dry run succeeded.")
+		_, err := fmt.Fprintln(r.w, "Dry run succeeded for addon object-store creation.")
 		return err
 	}
 

--- a/cli/cmd/cluster_create.go
+++ b/cli/cmd/cluster_create.go
@@ -72,6 +72,7 @@ Use the '--dry-run' flag to simulate the creation process and get an estimated c
 	cmd.Flags().StringArrayVar(&r.args.createClusterTags, "tag", []string{}, "Tag to apply to the cluster (key=value format, can be specified multiple times)")
 
 	cmd.Flags().StringArrayVar(&r.args.createClusterAddons, "addon", []string{}, "Addons to install on the cluster (can be specified multiple times)")
+	cmd.Flags().StringVar(&r.args.clusterAddonCreateObjectStoreBucket, "bucket-prefix", "", "A prefix for the bucket name to be created (required by '--addon object-store')")
 
 	cmd.Flags().BoolVar(&r.args.createClusterDryRun, "dry-run", false, "Dry run")
 
@@ -82,7 +83,24 @@ Use the '--dry-run' flag to simulate the creation process and get an estimated c
 	return cmd
 }
 
-func (r *runners) createCluster(_ *cobra.Command, args []string) error {
+func (r *runners) validateAddonArgs(cmd *cobra.Command) error {
+	for _, addon := range r.args.createClusterAddons {
+		if addon == "object-store" {
+			if r.args.clusterAddonCreateObjectStoreBucket == "" {
+				if err := cmd.Help(); err != nil {
+					return err
+				}
+				return errors.New("bucket-prefix is required for object-store addon")
+			}
+		} else {
+			return errors.Errorf("unknown addon: %s", addon)
+		}
+	}
+
+	return nil
+}
+
+func (r *runners) createCluster(cmd *cobra.Command, args []string) error {
 	if r.args.createClusterName == "" {
 		r.args.createClusterName = generateClusterName()
 	}
@@ -95,6 +113,10 @@ func (r *runners) createCluster(_ *cobra.Command, args []string) error {
 	nodeGroups, err := parseClusterNodeGroups(r.args.createClusterNodeGroups)
 	if err != nil {
 		return errors.Wrap(err, "parse node groups")
+	}
+
+	if err := r.validateAddonArgs(cmd); err != nil {
+		return errors.Wrap(err, "validate addon args")
 	}
 
 	opts := kotsclient.CreateClusterOpts{
@@ -143,21 +165,10 @@ func (r *runners) createCluster(_ *cobra.Command, args []string) error {
 	}
 
 	if r.args.createClusterAddons != nil {
-		for _, addon := range r.args.createClusterAddons {
-			if addon == "object-store" {
-				err := r.clusterAddonCreateObjectStoreCreateRun(clusterAddonCreateObjectStoreArgs{
-					clusterID:    cl.ID,
-					dryRun:       r.args.createClusterDryRun,
-					waitDuration: r.args.createClusterWaitDuration,
-				})
-				if err != nil {
-					return err
-				}
-			}
+		if err := r.createAndWaitForAddons(cl.ID); err != nil {
+			return err
 		}
 	}
-
-	r.createAndWaitForClusterAddonCreateObjectStore()
 
 	if opts.DryRun {
 		estimatedCostMessage := fmt.Sprintf("Estimated cost: %s (if run to TTL of %s)", print.CreditsToDollarsDisplay(cl.EstimatedCost), cl.TTL)
@@ -165,11 +176,32 @@ func (r *runners) createCluster(_ *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		_, err = fmt.Fprintln(r.w, "Dry run succeeded.")
+		_, err = fmt.Fprintln(r.w, "Dry run succeeded for cluster create.")
 		return err
 	}
 
 	return print.Cluster(r.outputFormat, r.w, cl)
+}
+
+func (r *runners) createAndWaitForAddons(clusterID string) error {
+	for _, addon := range r.args.createClusterAddons {
+		if addon == "object-store" {
+			// ClusterID, DryRun, Duration and Output are common to all
+			// addons and cluster create, so they are inherited from the
+			// cluster create command.
+			r.args.clusterAddonCreateObjectStoreClusterID = clusterID
+			r.args.clusterAddonCreateObjectStoreDryRun = r.args.createClusterDryRun
+			r.args.clusterAddonCreateObjectStoreDuration = r.args.createClusterWaitDuration
+			r.args.clusterAddonCreateObjectStoreOutput = r.outputFormat
+
+			err := r.clusterAddonCreateObjectStoreCreateRun()
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
 }
 
 func (r *runners) createAndWaitForCluster(opts kotsclient.CreateClusterOpts) (*types.Cluster, error) {

--- a/cli/cmd/runner.go
+++ b/cli/cmd/runner.go
@@ -129,6 +129,7 @@ type runnerArgs struct {
 	createClusterInstanceType           string
 	createClusterNodeGroups             []string
 	createClusterTags                   []string
+	createClusterAddons                 []string
 
 	upgradeClusterKubernetesVersion string
 	upgradeClusterDryRun            bool
@@ -247,4 +248,10 @@ type runnerArgs struct {
 	lsNetworkStartTime string
 	lsNetworkEndTime   string
 	lsNetworkWatch     bool
+
+	clusterAddonCreateObjectStoreBucket    string
+	clusterAddonCreateObjectStoreClusterID string
+	clusterAddonCreateObjectStoreDuration  time.Duration
+	clusterAddonCreateObjectStoreDryRun    bool
+	clusterAddonCreateObjectStoreOutput    string
 }


### PR DESCRIPTION
This adds a new flag to the `cluster create` command called `--addon`.  The addon flag is a `StringArrayVar` so it can be specified multiple times to add multiple types of addons, since we only support `object-store` at this time an example was added for that:

```
  # Create a cluster with addons
  replicated cluster create --distribution eks --version 1.21 --nodes 3 --addon object-store --ttl 24h
```

Since addons share the arguments for `ClusterID`, `OutputFormat`, `Duration` and `DryRun` those all get inherited by values used in the `clusterCreate` command.

The only unique flag is `bucket-prefix` which has been added as an argument to `clusterCreate` with some validation added to ensure it is used when the `addons` array contains `object-store`.

I also refactored the existing args into runnerArgs so the args can more easily shared across different commands.

# Testing
## Validation
```
bin/replicated cluster create --distribution eks --version 1.31 --nodes 3 --addon not-object-store --ttl 24h
Error: validate addon args: unknown addon: not-object-store

bin/replicated cluster create --distribution eks --version 1.31 --nodes 3 --addon object-store --ttl 24h
<Omitted cmd.Help printing>
Error: validate addon args: bucket-prefix is required for object-store addon
```

## Cluster Create
Works still without `--addon` specified:
```
bin/replicated cluster create --distribution eks --version 1.31 --nodes 3
ID          NAME                           DISTRIBUTION    VERSION       STATUS          CREATED                           EXPIRES                           COST
52db2783    silly_beaver                   eks             1.31          queued          2025-01-02 12:10 PST              -                                 $0.85
```

Adds an `object-store` when `--addon` specified:

```
bin/replicated cluster create --distribution eks --version 1.31 --nodes 3 --addon object-store --ttl 24h --bucket-prefix "banana"
ID          TYPE            STATUS          DATA
9b0ffa24    Object Store    pending         {"bucket_prefix":"banana"}
ID          NAME                           DISTRIBUTION    VERSION       STATUS          CREATED                           EXPIRES                           COST
6a7652cc    nostalgic_wing                 eks             1.31          queued          2025-01-02 12:13 PST              -                                 $8.79

# Addon goes ready
bin/replicated cluster addon ls 6a7652cc
ID          TYPE            STATUS          DATA
9b0ffa24    Object Store    ready           {"bucket_prefix":"banana","bucket_name":"banana-9b0ffa24-cmx","service_account_namespace":"cmx","service_account_name":"banana-9b0ffa24-cmx","service_account_name_read_only":"banana-9b0ffa24-cmx-ro"}
```



