### PR TITLE
Add help text for "replicated default" command

### DIFF
--- a/cli/cmd/default.go
+++ b/cli/cmd/default.go
@@ -4,7 +4,10 @@ import "github.com/spf13/cobra"
 
 func (r *runners) InitDefaultCommand(parent *cobra.Command) *cobra.Command {
 	cmd := &cobra.Command{
-		Use: "default",
+		Use:     "default",
+		Short:   "Manage default values used by other commands",
+		Long:    ``,
+		Example: `  `,
 	}
 
 	parent.AddCommand(cmd)

--- a/cli/cmd/default_clear.go
+++ b/cli/cmd/default_clear.go
@@ -1,10 +1,23 @@
 package cmd
 
-import "github.com/spf13/cobra"
+import (
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
 
 func (r *runners) InitDefaultClearCommand(parent *cobra.Command) *cobra.Command {
 	cmd := &cobra.Command{
-		Use: "clear",
+		Use:   "clear KEY",
+		Short: "Clear default value for a key",
+		Long: `Clears default value for the specified key.
+
+This command removes default values that are used by other commands run by the current user.
+
+Supported keys:
+- app: the default application to use`,
+		Example: `  # Clear default application
+  replicated default clear app`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return r.clearDefault(cmd, args[0])
 		},
@@ -17,7 +30,7 @@ func (r *runners) InitDefaultClearCommand(parent *cobra.Command) *cobra.Command 
 
 func (r *runners) clearDefault(cmd *cobra.Command, defaultType string) error {
 	if err := cache.ClearDefault(defaultType); err != nil {
-		return err
+		return errors.Wrap(err, "clear default")
 	}
 
 	return nil

--- a/cli/cmd/default_clearall.go
+++ b/cli/cmd/default_clearall.go
@@ -4,7 +4,13 @@ import "github.com/spf13/cobra"
 
 func (r *runners) InitDefaultClearAllCommand(parent *cobra.Command) *cobra.Command {
 	cmd := &cobra.Command{
-		Use: "clear-all",
+		Use:   "clear-all",
+		Short: "Clear all default values",
+		Long: `Clears all default values that are used by other commands.
+
+This command removes all default values that are used by other commands run by the current user.`,
+		Example: `  # Clear all default values
+  replicated default clear-all`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return r.clearAllDefaults(cmd)
 		},

--- a/cli/cmd/default_set.go
+++ b/cli/cmd/default_set.go
@@ -11,7 +11,20 @@ func (r *runners) InitDefaultSetCommand(parent *cobra.Command) *cobra.Command {
 	var outputFormat string
 
 	cmd := &cobra.Command{
-		Use: "set",
+		Use:   "set KEY VALUE",
+		Short: "Set default value for a key",
+		Long: `Sets default value for the specified key.
+
+This command sets default values that will be used by other commands run by the current user.
+
+Supported keys:
+- app: the default application to use
+
+The output can be customized using the --output flag to display results in
+either table or JSON format.`,
+		Example: `  # Set default application
+  replicated default set app my-app-slug`,
+		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return r.setDefault(cmd, args[0], args[1], outputFormat)
 		},
@@ -24,19 +37,23 @@ func (r *runners) InitDefaultSetCommand(parent *cobra.Command) *cobra.Command {
 }
 
 func (r *runners) setDefault(cmd *cobra.Command, defaultType string, defaultValue string, outputFormat string) error {
-	app, err := getApp(defaultValue, r.api.KotsClient)
-	if err != nil {
-		return errors.Wrap(err, "get app")
-	}
+	switch defaultType {
+	case "app":
+		app, err := getApp(defaultValue, r.api.KotsClient)
+		if err != nil {
+			return errors.Wrap(err, "get app")
+		}
 
-	if err := cache.SetDefault(defaultType, defaultValue); err != nil {
-		return errors.Wrap(err, "set default in cache")
-	}
+		if err := cache.SetDefault(defaultType, defaultValue); err != nil {
+			return errors.Wrap(err, "set default in cache")
+		}
 
-	// print the default app
-	if err := print.Apps(outputFormat, r.w, []types.AppAndChannels{{App: app}}); err != nil {
-		return errors.Wrap(err, "print app")
-	}
+		if err := print.Apps(outputFormat, r.w, []types.AppAndChannels{{App: app}}); err != nil {
+			return errors.Wrap(err, "print app")
+		}
 
-	return nil
+		return nil
+	default:
+		return errors.Errorf("unknown default type: %s", defaultType)
+	}
 }

--- a/cli/cmd/default_show.go
+++ b/cli/cmd/default_show.go
@@ -13,7 +13,21 @@ func (r *runners) InitDefaultShowCommand(parent *cobra.Command) *cobra.Command {
 	var outputFormat string
 
 	cmd := &cobra.Command{
-		Use: "show",
+		Use:   "show KEY",
+		Short: "Show default value for a key",
+		Long: `Shows defaul values for the specified key.
+
+This command shows default values that will be used by other commands run by the current user.
+
+Supported keys:
+- app: the default application to use
+
+The output can be customized using the --output flag to display results in
+either table or JSON format.`,
+		Example: `  # Show default application
+  replicated default show app
+`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return r.showDefault(cmd, args[0], outputFormat)
 		},
@@ -26,22 +40,30 @@ func (r *runners) InitDefaultShowCommand(parent *cobra.Command) *cobra.Command {
 }
 
 func (r *runners) showDefault(cmd *cobra.Command, defaultType string, outputFormat string) error {
-	if cache.DefaultApp == "" {
+	defaultValue, err := cache.GetDefault(defaultType)
+	if err != nil {
+		return errors.Wrap(err, "get default value")
+	}
+
+	if defaultValue == "" {
 		if outputFormat == "json" {
 			fmt.Println("{}")
 		} else {
-			fmt.Println("No default app set")
+			fmt.Printf("No default set for %s\n", defaultType)
 		}
 		return nil
 	}
 
-	app, err := getApp(cache.DefaultApp, r.api.KotsClient)
-	if err != nil {
-		return errors.Wrap(err, "get app")
-	}
+	switch defaultType {
+	case "app":
+		app, err := getApp(defaultValue, r.api.KotsClient)
+		if err != nil {
+			return errors.Wrap(err, "get app")
+		}
 
-	if err := print.Apps(outputFormat, r.w, []types.AppAndChannels{{App: app}}); err != nil {
-		return errors.Wrap(err, "print app")
+		if err := print.Apps(outputFormat, r.w, []types.AppAndChannels{{App: app}}); err != nil {
+			return errors.Wrap(err, "print app")
+		}
 	}
 
 	return nil

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -115,6 +115,14 @@ func (c *Cache) SetDefault(defaultType string, defaultValue string) error {
 
 	return nil
 }
+func (c *Cache) GetDefault(defaultType string) (string, error) {
+	switch defaultType {
+	case "app":
+		return c.DefaultApp, nil
+	default:
+		return "", errors.Errorf("unknown default type: %s", defaultType)
+	}
+}
 
 func (c *Cache) ClearDefault(defaultType string) error {
 	switch defaultType {


### PR DESCRIPTION
Fixes for `replicated default` command and subcommands:

- Enforce argument counts for positional arguments to avoid panics
- Check `defaultType` value before looking up application
- Add help text