### PR TITLE
Hide enterprise and unhide channel commands

### DIFF
--- a/cli/cmd/channel_create.go
+++ b/cli/cmd/channel_create.go
@@ -15,7 +15,6 @@ func (r *runners) InitChannelCreate(parent *cobra.Command) {
   Example:
   replicated channel create --name Beta --description 'New features subject to change'`,
 	}
-	cmd.Hidden = true // Not supported in KOTS
 	parent.AddCommand(cmd)
 
 	cmd.Flags().StringVar(&r.args.channelCreateName, "name", "", "The name of this channel")

--- a/cli/cmd/channel_disable_semantic_versioning.go
+++ b/cli/cmd/channel_disable_semantic_versioning.go
@@ -16,7 +16,6 @@ func (r *runners) InitChannelDisableSemanticVersioning(parent *cobra.Command) {
  Example:
  replicated channel disable-semantic-versioning CHANNEL_ID`,
 	}
-	cmd.Hidden = true // Not supported in KOTS
 	parent.AddCommand(cmd)
 	cmd.RunE = r.channelDisableSemanticVersioning
 }

--- a/cli/cmd/channel_enable_semantic_versioning.go
+++ b/cli/cmd/channel_enable_semantic_versioning.go
@@ -16,7 +16,6 @@ func (r *runners) InitChannelEnableSemanticVersioning(parent *cobra.Command) {
  Example:
  replicated channel enable-semantic-versioning CHANNEL_ID`,
 	}
-	cmd.Hidden = true // Not supported in KOTS
 	parent.AddCommand(cmd)
 	cmd.RunE = r.channelEnableSemanticVersioning
 }

--- a/cli/cmd/enterpriseportal.go
+++ b/cli/cmd/enterpriseportal.go
@@ -10,6 +10,7 @@ func (r *runners) InitEnterprisePortalCommand(parent *cobra.Command) *cobra.Comm
 		Short:   "Manage enterprise portal",
 		Long:    ``,
 		Example: `  `,
+		Hidden:  true,
 	}
 	parent.AddCommand(cmd)
 


### PR DESCRIPTION
Hide the Enterprise Portal command because the feature has not been released yet
Unhiding channel commands because they are supported for KOTS (despite what the comment on the removed lines says"