### PR TITLE
Add support for install types when creating and updating customers

### DIFF
--- a/cli/cmd/customer_create.go
+++ b/cli/cmd/customer_create.go
@@ -23,6 +23,8 @@ type createCustomerOpts struct {
 	IsGitopsSupported            bool
 	IsSnapshotSupported          bool
 	IsKotsInstallEnabled         bool
+	IsHelmInstallEnabled         bool
+	IsKurlInstallEnabled         bool
 	IsEmbeddedClusterEnabled     bool
 	IsGeoaxisSupported           bool
 	IsHelmVMDownloadEnabled      bool
@@ -84,6 +86,8 @@ The --app flag must be set to specify the target application.`,
 	cmd.Flags().BoolVar(&opts.IsGitopsSupported, "gitops", false, "If set, the license will allow the GitOps usage.")
 	cmd.Flags().BoolVar(&opts.IsSnapshotSupported, "snapshot", false, "If set, the license will allow Snapshots.")
 	cmd.Flags().BoolVar(&opts.IsKotsInstallEnabled, "kots-install", true, "If set, the license will allow KOTS install. Otherwise license will allow Helm CLI installs only.")
+	cmd.Flags().BoolVar(&opts.IsHelmInstallEnabled, "helm-install", false, "If set, the license will allow Helm installs.")
+	cmd.Flags().BoolVar(&opts.IsKurlInstallEnabled, "kurl-install", false, "If set, the license will allow kURL installs.")
 	cmd.Flags().BoolVar(&opts.IsEmbeddedClusterEnabled, "embedded-cluster-download", false, "If set, the license will allow embedded cluster downloads.")
 	cmd.Flags().BoolVar(&opts.IsGeoaxisSupported, "geo-axis", false, "If set, the license will allow Geo Axis usage.")
 	cmd.Flags().BoolVar(&opts.IsHelmVMDownloadEnabled, "helmvm-cluster-download", false, "If set, the license will allow helmvm cluster downloads.")
@@ -185,6 +189,13 @@ func (r *runners) createCustomer(cmd *cobra.Command, opts createCustomerOpts, ou
 		IsDeveloperModeEnabled:           opts.IsDeveloperModeEnabled,
 		LicenseType:                      opts.CustomerType,
 		Email:                            opts.Email,
+	}
+
+	if cmd.Flags().Changed("helm-install") {
+		createOpts.IsHelmInstallEnabled = &opts.IsHelmInstallEnabled
+	}
+	if cmd.Flags().Changed("kurl-install") {
+		createOpts.IsKurlInstallEnabled = &opts.IsKurlInstallEnabled
 	}
 
 	customer, err := r.api.CreateCustomer(r.appType, createOpts)

--- a/pkg/kotsclient/customer_create.go
+++ b/pkg/kotsclient/customer_create.go
@@ -40,6 +40,11 @@ type CreateCustomerRequest struct {
 	IsDeveloperModeEnabled           bool               `json:"is_dev_mode_enabled"`
 	Email                            string             `json:"email,omitempty"`
 	EntitlementValues                []EntitlementValue `json:"entitlementValues"`
+
+	// These fields were added after the "built in" fields feature was released.
+	// If they are not pointer types, they will override the defaults.
+	IsHelmInstallEnabled *bool `json:"is_helm_install_enabled,omitempty"`
+	IsKurlInstallEnabled *bool `json:"is_kurl_install_enabled,omitempty"`
 }
 
 type CreateCustomerResponse struct {
@@ -57,6 +62,8 @@ type CreateCustomerOpts struct {
 	IsGitopsSupported                bool
 	IsSnapshotSupported              bool
 	IsKotsInstallEnabled             bool
+	IsHelmInstallEnabled             *bool
+	IsKurlInstallEnabled             *bool
 	IsEmbeddedClusterDownloadEnabled bool
 	IsGeoaxisSupported               bool
 	IsHelmVMDownloadEnabled          bool
@@ -80,6 +87,8 @@ func (c *VendorV3Client) CreateCustomer(opts CreateCustomerOpts) (*types.Custome
 		IsGitopsSupported:                opts.IsGitopsSupported,
 		IsSnapshotSupported:              opts.IsSnapshotSupported,
 		IsKotsInstallEnabled:             opts.IsKotsInstallEnabled,
+		IsHelmInstallEnabled:             opts.IsHelmInstallEnabled,
+		IsKurlInstallEnabled:             opts.IsKurlInstallEnabled,
 		IsEmbeddedClusterDownloadEnabled: opts.IsEmbeddedClusterDownloadEnabled,
 		IsGeoaxisSupported:               opts.IsGeoaxisSupported,
 		IsHelmVMDownloadEnabled:          opts.IsHelmVMDownloadEnabled,

--- a/pkg/kotsclient/customer_update.go
+++ b/pkg/kotsclient/customer_update.go
@@ -29,6 +29,11 @@ type UpdateCustomerRequest struct {
 	IsDeveloperModeEnabled           bool               `json:"is_dev_mode_enabled"`
 	Email                            string             `json:"email,omitempty"`
 	EntitlementValues                []EntitlementValue `json:"entitlementValues"`
+
+	// These fields were added after the "built in" fields feature was released.
+	// If they are not pointer types, they will override the defaults.
+	IsHelmInstallEnabled *bool `json:"is_helm_install_enabled,omitempty"`
+	IsKurlInstallEnabled *bool `json:"is_kurl_install_enabled,omitempty"`
 }
 
 type UpdateCustomerResponse struct {
@@ -46,6 +51,8 @@ type UpdateCustomerOpts struct {
 	IsGitopsSupported                bool
 	IsSnapshotSupported              bool
 	IsKotsInstallEnabled             bool
+	IsHelmInstallEnabled             *bool
+	IsKurlInstallEnabled             *bool
 	IsEmbeddedClusterDownloadEnabled bool
 	IsGeoaxisSupported               bool
 	IsHelmVMDownloadEnabled          bool
@@ -68,6 +75,8 @@ func (c *VendorV3Client) UpdateCustomer(customerID string, opts UpdateCustomerOp
 		IsGitopsSupported:                opts.IsGitopsSupported,
 		IsSnapshotSupported:              opts.IsSnapshotSupported,
 		IsKotsInstallEnabled:             opts.IsKotsInstallEnabled,
+		IsHelmInstallEnabled:             opts.IsHelmInstallEnabled,
+		IsKurlInstallEnabled:             opts.IsKurlInstallEnabled,
 		IsEmbeddedClusterDownloadEnabled: opts.IsEmbeddedClusterDownloadEnabled,
 		IsGeoaxisSupported:               opts.IsGeoaxisSupported,
 		IsHelmVMDownloadEnabled:          opts.IsHelmVMDownloadEnabled,


### PR DESCRIPTION
This adds `--helm-install` and `--kurl-install` flags to customer create and customer update commands.

Since we now support defining default customer values, these new flags will be omitted from the request if not specified in order to not override defaults. In order for these install types to be disabled, the explicit `=false` value must be specified on the command line. This is done for backwards compatibility with previous CLI releases.


https://app.shortcut.com/replicated/story/118967/add-support-for-install-types-when-creating-and-updating-customers-using-replicated-cli