### PR TITLE
Generate CLI docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,14 +109,16 @@ build:
 		-o bin/replicated \
 		cli/main.go
 
-.PHONY: docs
-docs:
-	go run ./docs/
-
-.PHONE: release
+.PHONY: release
 release:
 	dagger call release \
 		--one-password-service-account-production env:OP_SERVICE_ACCOUNT_PRODUCTION \
 		--version $(version) \
+		--github-token env:GITHUB_TOKEN \
+		--progress plain
+
+.PHONY: docs
+docs:
+	dagger --progress plain call generate-docs \
 		--github-token env:GITHUB_TOKEN \
 		--progress plain

--- a/cli/cmd/api_get.go
+++ b/cli/cmd/api_get.go
@@ -17,12 +17,8 @@ uses your local credentials and prints the response unmodified.
 
 We recommend piping the output to jq for easier reading.
 
-Pass the PATH of the request as the final argument. Do not include the host or version.
-
-Example:
-  replicated api get /v3/apps
-  
-`,
+Pass the PATH of the request as the final argument. Do not include the host or version.`,
+		Example:      `replicated api get /v3/apps`,
 		RunE:         r.apiGet,
 		SilenceUsage: true,
 		Args:         cobra.ExactArgs(1),

--- a/cli/cmd/api_patch.go
+++ b/cli/cmd/api_patch.go
@@ -17,12 +17,8 @@ uses your local credentials and prints the response unmodified.
 
 We recommend piping the output to jq for easier reading.
 
-Pass the PATH of the request as the final argument. Do not include the host or version.
-
-Example:
-  replicated api patch /v3/customer/2VffY549paATVfHSGpJhjh6Ehpy -b '{"name":"Valuable Customer"}'
-  
-`,
+Pass the PATH of the request as the final argument. Do not include the host or version.`,
+		Example:      `replicated api patch /v3/customer/2VffY549paATVfHSGpJhjh6Ehpy -b '{"name":"Valuable Customer"}'`,
 		RunE:         r.apiPatch,
 		SilenceUsage: true,
 		Args:         cobra.ExactArgs(1),

--- a/cli/cmd/api_post.go
+++ b/cli/cmd/api_post.go
@@ -17,12 +17,8 @@ uses your local credentials and prints the response unmodified.
 
 We recommend piping the output to jq for easier reading.
 
-Pass the PATH of the request as the final argument. Do not include the host or version.
-
-Example:
-  replicated api post /v3/app/2EuFxKLDxKjPNk2jxMTmF6Vxvxu/channel -b '{"name":"marc-waz-here"}'
-  
-`,
+Pass the PATH of the request as the final argument. Do not include the host or version.`,
+		Example:      `replicated api post /v3/app/2EuFxKLDxKjPNk2jxMTmF6Vxvxu/channel -b '{"name":"marc-waz-here"}'`,
 		RunE:         r.apiPost,
 		SilenceUsage: true,
 		Args:         cobra.ExactArgs(1),

--- a/cli/cmd/api_put.go
+++ b/cli/cmd/api_put.go
@@ -17,12 +17,8 @@ uses your local credentials and prints the response unmodified.
 
 We recommend piping the output to jq for easier reading.
 
-Pass the PATH of the request as the final argument. Do not include the host or version.
-
-Example:
-  replicated api put /v3/app/2EuFxKLDxKjPNk2jxMTmF6Vxvxu/channel/2QLPm10JPkta7jO3Z3Mk4aXTPyZ -b '{"name":"marc-waz-here2"}'
-  
-`,
+Pass the PATH of the request as the final argument. Do not include the host or version.`,
+		Example:      `replicated api put /v3/app/2EuFxKLDxKjPNk2jxMTmF6Vxvxu/channel/2QLPm10JPkta7jO3Z3Mk4aXTPyZ -b '{"name":"marc-waz-here2"}'`,
 		RunE:         r.apiPut,
 		SilenceUsage: true,
 		Args:         cobra.ExactArgs(1),

--- a/cli/cmd/app.go
+++ b/cli/cmd/app.go
@@ -20,23 +20,23 @@ Use the various subcommands to:
 - View details of a specific application
 - Update application settings
 - Delete applications from your account`,
-		Example: `  # List all applications
-  replicated app ls
+		Example: `# List all applications
+replicated app ls
 
-  # Create a new application
-  replicated app create "My New App"
+# Create a new application
+replicated app create "My New App"
 
-  # View details of a specific application
-  replicated app inspect "My App Name"
+# View details of a specific application
+replicated app inspect "My App Name"
 
-  # Delete an application
-  replicated app delete "App to Remove"
+# Delete an application
+replicated app delete "App to Remove"
 
-  # Update an application's settings
-  replicated app update "My App" --channel stable
+# Update an application's settings
+replicated app update "My App" --channel stable
 
-  # List applications with custom output format
-  replicated app ls --output json`,
+# List applications with custom output format
+replicated app ls --output json`,
 	}
 	parent.AddCommand(cmd)
 

--- a/cli/cmd/app_create.go
+++ b/cli/cmd/app_create.go
@@ -29,14 +29,15 @@ and managed using the KOTS platform. When you create a new app, it will be set u
 with default configurations, which you can later customize.
 
 The NAME argument is required and will be used as the application's name.`,
-		Example: `  # Create a new app named "My App"
-  replicated app create "My App"
+		Example: `# Create a new app named "My App"
+replicated app create "My App"
 
-  # Create a new app and output the result in JSON format
-  replicated app create "Another App" --output json
+# Create a new app and output the result in JSON format
+replicated app create "Another App" --output json
 
-  # Create a new app with a specific name and view details in table format
-  replicated app create "Custom App" --output table`,
+# Create a new app with a specific name and view details in table format
+replicated app create "Custom App" --output table`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 			if integrationTest != "" {

--- a/cli/cmd/app_ls.go
+++ b/cli/cmd/app_ls.go
@@ -27,17 +27,17 @@ filter the results to show only applications that match the given name or ID.
 
 The output can be customized using the --output flag to display results in
 either table or JSON format.`,
-		Example: `  # List all applications
-  replicated app ls
+		Example: `# List all applications
+replicated app ls
 
-  # Search for a specific application by name
-  replicated app ls "My App"
+# Search for a specific application by name
+replicated app ls "My App"
 
-  # List applications and output in JSON format
-  replicated app ls --output json
+# List applications and output in JSON format
+replicated app ls --output json
 
-  # Search for an application and display results in table format
-  replicated app ls "App Name" --output table`,
+# Search for an application and display results in table format
+replicated app ls "App Name" --output table`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 			if integrationTest != "" {

--- a/cli/cmd/app_rm.go
+++ b/cli/cmd/app_rm.go
@@ -30,14 +30,14 @@ This command allows you to permanently remove an application from your account.
 Once deleted, the application and all associated data will be irretrievably lost.
 
 Use this command with caution as there is no way to undo this operation.`,
-		Example: `  # Delete a app named "My App"
-  replicated app delete "My App"
+		Example: `# Delete a app named "My App"
+replicated app delete "My App"
 
-  # Delete an app and skip the confirmation prompt
-  replicated app delete "Another App" --force
+# Delete an app and skip the confirmation prompt
+replicated app delete "Another App" --force
 
-  # Delete an app and output the result in JSON format
-  replicated app delete "Custom App" --output json`,
+# Delete an app and output the result in JSON format
+replicated app delete "Custom App" --output json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 			if integrationTest != "" {

--- a/cli/cmd/channel_create.go
+++ b/cli/cmd/channel_create.go
@@ -8,12 +8,10 @@ import (
 
 func (r *runners) InitChannelCreate(parent *cobra.Command) {
 	cmd := &cobra.Command{
-		Use:   "create",
-		Short: "Create a new channel in your app",
-		Long: `Create a new channel in your app and print the channel on success.
-
-  Example:
-  replicated channel create --name Beta --description 'New features subject to change'`,
+		Use:     "create",
+		Short:   "Create a new channel in your app",
+		Long:    `Create a new channel in your app and print the channel on success.`,
+		Example: `replicated channel create --name Beta --description 'New features subject to change'`,
 	}
 	parent.AddCommand(cmd)
 

--- a/cli/cmd/channel_disable_semantic_versioning.go
+++ b/cli/cmd/channel_disable_semantic_versioning.go
@@ -9,12 +9,10 @@ import (
 
 func (r *runners) InitChannelDisableSemanticVersioning(parent *cobra.Command) {
 	cmd := &cobra.Command{
-		Use:   "disable-semantic-versioning CHANNEL_ID",
-		Short: "Disable semantic versioning for CHANNEL_ID",
-		Long: `Disable semantic versioning for the CHANNEL_ID.
-
- Example:
- replicated channel disable-semantic-versioning CHANNEL_ID`,
+		Use:     "disable-semantic-versioning CHANNEL_ID",
+		Short:   "Disable semantic versioning for CHANNEL_ID",
+		Long:    `Disable semantic versioning for the CHANNEL_ID.`,
+		Example: `replicated channel disable-semantic-versioning CHANNEL_ID`,
 	}
 	parent.AddCommand(cmd)
 	cmd.RunE = r.channelDisableSemanticVersioning

--- a/cli/cmd/channel_enable_semantic_versioning.go
+++ b/cli/cmd/channel_enable_semantic_versioning.go
@@ -9,12 +9,10 @@ import (
 
 func (r *runners) InitChannelEnableSemanticVersioning(parent *cobra.Command) {
 	cmd := &cobra.Command{
-		Use:   "enable-semantic-versioning CHANNEL_ID",
-		Short: "Enable semantic versioning for CHANNEL_ID",
-		Long: `Enable semantic versioning for the CHANNEL_ID.
-
- Example:
- replicated channel enable-semantic-versioning CHANNEL_ID`,
+		Use:     "enable-semantic-versioning CHANNEL_ID",
+		Short:   "Enable semantic versioning for CHANNEL_ID",
+		Long:    `Enable semantic versioning for the CHANNEL_ID.`,
+		Example: `replicated channel enable-semantic-versioning CHANNEL_ID`,
 	}
 	parent.AddCommand(cmd)
 	cmd.RunE = r.channelEnableSemanticVersioning

--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -17,17 +17,17 @@ func (r *runners) InitClusterCommand(parent *cobra.Command) *cobra.Command {
 		Use:   "cluster",
 		Short: "Manage test Kubernetes clusters.",
 		Long:  `The 'cluster' command allows you to manage and interact with Kubernetes clusters used for testing purposes. With this command, you can create, list, remove, and manage node groups within clusters, as well as retrieve information about available clusters.`,
-		Example: `  # Create a single-node EKS cluster
-  replicated cluster create --distribution eks --version 1.31
+		Example: `# Create a single-node EKS cluster
+replicated cluster create --distribution eks --version 1.31
 
-  # List all clusters
-  replicated cluster ls
+# List all clusters
+replicated cluster ls
 
-  # Remove a specific cluster by ID
-  replicated cluster rm <cluster-id>
+# Remove a specific cluster by ID
+replicated cluster rm <cluster-id>
 
-  # List all nodegroups in a specific cluster
-  replicated cluster nodegroup ls <cluster-id>`,
+# List all nodegroups in a specific cluster
+replicated cluster nodegroup ls <cluster-id>`,
 	}
 	parent.AddCommand(cmd)
 

--- a/cli/cmd/cluster_addon.go
+++ b/cli/cmd/cluster_addon.go
@@ -16,17 +16,17 @@ func (r *runners) InitClusterAddon(parent *cobra.Command) *cobra.Command {
 		Long: `The 'cluster addon' command allows you to manage add-ons installed on a test cluster. Add-ons are additional components or services that can be installed and configured to enhance or extend the functionality of the cluster.
 
 You can use various subcommands to create, list, remove, or check the status of add-ons on a cluster. This command is useful for adding databases, object storage, monitoring, security, or other specialized tools to your cluster environment.`,
-		Example: `  # List all add-ons installed on a cluster
-  replicated cluster addon ls CLUSTER_ID
+		Example: `# List all add-ons installed on a cluster
+replicated cluster addon ls CLUSTER_ID
 
-  # Remove an add-on from a cluster
-  replicated cluster addon rm CLUSTER_ID --id ADDON_ID
+# Remove an add-on from a cluster
+replicated cluster addon rm CLUSTER_ID --id ADDON_ID
 
-  # Create an object store bucket add-on for a cluster
-  replicated cluster addon create object-store CLUSTER_ID --bucket-prefix mybucket
+# Create an object store bucket add-on for a cluster
+replicated cluster addon create object-store CLUSTER_ID --bucket-prefix mybucket
 
-  # List add-ons with JSON output
-  replicated cluster addon ls CLUSTER_ID --output json`,
+# List add-ons with JSON output
+replicated cluster addon ls CLUSTER_ID --output json`,
 	}
 	parent.AddCommand(cmd)
 

--- a/cli/cmd/cluster_addon_create.go
+++ b/cli/cmd/cluster_addon_create.go
@@ -9,11 +9,11 @@ func (r *runners) InitClusterAddonCreate(parent *cobra.Command) *cobra.Command {
 		Use:   "create",
 		Short: "Create cluster add-ons.",
 		Long:  `Create new add-ons for a cluster. This command allows you to add functionality or services to a cluster by provisioning the required add-ons.`,
-		Example: `  # Create an object store bucket add-on for a cluster
-  replicated cluster addon create object-store CLUSTER_ID --bucket-prefix mybucket
+		Example: `# Create an object store bucket add-on for a cluster
+replicated cluster addon create object-store CLUSTER_ID --bucket-prefix mybucket
 
-  # Perform a dry run for creating an object store add-on
-  replicated cluster addon create object-store CLUSTER_ID --bucket-prefix mybucket --dry-run`,
+# Perform a dry run for creating an object store add-on
+replicated cluster addon create object-store CLUSTER_ID --bucket-prefix mybucket --dry-run`,
 	}
 	parent.AddCommand(cmd)
 

--- a/cli/cmd/cluster_addon_create_objectstore.go
+++ b/cli/cmd/cluster_addon_create_objectstore.go
@@ -17,25 +17,21 @@ func (r *runners) InitClusterAddonCreateObjectStore(parent *cobra.Command) *cobr
 	cmd := &cobra.Command{
 		Use:   "object-store CLUSTER_ID --bucket-prefix BUCKET_PREFIX",
 		Short: "Create an object store bucket for a cluster.",
-		Long: `Creates an object store bucket for a cluster, requiring a bucket name prefix. The bucket name will be auto-generated using the format "[BUCKET_PREFIX]-[ADDON_ID]-cmx". This feature provisions an object storage bucket that can be used for storage in your cluster environment.
+		Long:  `Creates an object store bucket for a cluster, requiring a bucket name prefix. The bucket name will be auto-generated using the format "[BUCKET_PREFIX]-[ADDON_ID]-cmx". This feature provisions an object storage bucket that can be used for storage in your cluster environment.`,
+		Example: `# Create an object store bucket with a specified prefix
+replicated cluster addon create object-store 05929b24 --bucket-prefix mybucket
 
-Examples:
-  # Create an object store bucket with a specified prefix
-  replicated cluster addon create object-store CLUSTER_ID --bucket-prefix mybucket
+# Create an object store bucket and wait for it to be ready (up to 5 minutes)
+replicated cluster addon create object-store 05929b24 --bucket-prefix mybucket --wait 5m
 
-  # Create an object store bucket and wait for it to be ready (up to 5 minutes)
-  replicated cluster addon create object-store CLUSTER_ID --bucket-prefix mybucket --wait 5m
+# Perform a dry run to validate inputs without creating the bucket
+replicated cluster addon create object-store 05929b24 --bucket-prefix mybucket --dry-run
 
-  # Perform a dry run to validate inputs without creating the bucket
-  replicated cluster addon create object-store CLUSTER_ID --bucket-prefix mybucket --dry-run
+# Create an object store bucket and output the result in JSON format
+replicated cluster addon create object-store 05929b24 --bucket-prefix mybucket --output json
 
-  # Create an object store bucket and output the result in JSON format
-  replicated cluster addon create object-store CLUSTER_ID --bucket-prefix mybucket --output json
-
-  # Create an object store bucket with a custom prefix and wait for 10 minutes
-  replicated cluster addon create object-store CLUSTER_ID --bucket-prefix custom-prefix --wait 10m`,
-		Example: `$ replicated cluster addon create object-store 05929b24 --bucket-prefix mybucket
-  05929b24    Object Store    pending         {"bucket_prefix":"mybucket"}`,
+# Create an object store bucket with a custom prefix and wait for 10 minutes
+replicated cluster addon create object-store 05929b24 --bucket-prefix custom-prefix --wait 10m`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, cmdArgs []string) error {
 			r.args.clusterAddonCreateObjectStoreClusterID = cmdArgs[0]

--- a/cli/cmd/cluster_addon_ls.go
+++ b/cli/cmd/cluster_addon_ls.go
@@ -20,14 +20,14 @@ func (r *runners) InitClusterAddonLs(parent *cobra.Command) *cobra.Command {
 		Long: `The 'cluster addon ls' command allows you to list all add-ons for a specific cluster. This command provides a detailed overview of the add-ons currently installed on the cluster, including their status and any relevant configuration details.
 
 This can be useful for monitoring the health and configuration of add-ons or performing troubleshooting tasks.`,
-		Example: `  # List add-ons for a cluster with default table output
-  replicated cluster addon ls CLUSTER_ID
+		Example: `# List add-ons for a cluster with default table output
+replicated cluster addon ls CLUSTER_ID
 
-  # List add-ons for a cluster with JSON output
-  replicated cluster addon ls CLUSTER_ID --output json
+# List add-ons for a cluster with JSON output
+replicated cluster addon ls CLUSTER_ID --output json
 
-  # List add-ons for a cluster with wide table output
-  replicated cluster addon ls CLUSTER_ID --output wide`,
+# List add-ons for a cluster with wide table output
+replicated cluster addon ls CLUSTER_ID --output wide`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, cmdArgs []string) error {
 			args.clusterID = cmdArgs[0]

--- a/cli/cmd/cluster_addon_rm.go
+++ b/cli/cmd/cluster_addon_rm.go
@@ -21,8 +21,8 @@ func (r *runners) InitClusterAddonRm(parent *cobra.Command) *cobra.Command {
 		Long: `The 'cluster addon rm' command allows you to remove a specific add-on from a cluster by specifying the cluster ID and the add-on ID.
 
 This command is useful when you want to deprovision an add-on that is no longer needed or when troubleshooting issues related to specific add-ons. The add-on will be removed immediately, and you will receive confirmation upon successful removal.`,
-		Example: `  # Remove an add-on with ID 'abc123' from cluster 'cluster456'
-  replicated cluster addon rm cluster456 --id abc123`,
+		Example: `# Remove an add-on with ID 'abc123' from cluster 'cluster456'
+replicated cluster addon rm cluster456 --id abc123`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, cmdArgs []string) error {
 			args.clusterID = cmdArgs[0]

--- a/cli/cmd/cluster_create.go
+++ b/cli/cmd/cluster_create.go
@@ -27,29 +27,29 @@ func (r *runners) InitClusterCreate(parent *cobra.Command) *cobra.Command {
 This command supports creating clusters on multiple Kubernetes distributions, including setting up node groups with different instance types and counts. You can also specify a TTL (Time-To-Live) to automatically terminate the cluster after a set duration.
 
 Use the '--dry-run' flag to simulate the creation process and get an estimated cost without actually provisioning the cluster.`,
-		Example: `  # Create a new cluster with basic configuration
-  replicated cluster create --distribution eks --version 1.21 --nodes 3 --instance-type t3.large --disk 100 --ttl 24h
+		Example: `# Create a new cluster with basic configuration
+replicated cluster create --distribution eks --version 1.21 --nodes 3 --instance-type t3.large --disk 100 --ttl 24h
 
-  # Create a cluster with a custom node group
-  replicated cluster create --distribution eks --version 1.21 --nodegroup name=workers,instance-type=t3.large,nodes=5 --ttl 24h
+# Create a cluster with a custom node group
+replicated cluster create --distribution eks --version 1.21 --nodegroup name=workers,instance-type=t3.large,nodes=5 --ttl 24h
 
-  # Simulate cluster creation (dry-run)
-  replicated cluster create --distribution eks --version 1.21 --nodes 3 --disk 100 --ttl 24h --dry-run
+# Simulate cluster creation (dry-run)
+replicated cluster create --distribution eks --version 1.21 --nodes 3 --disk 100 --ttl 24h --dry-run
 
-  # Create a cluster with autoscaling configuration
-  replicated cluster create --distribution eks --version 1.21 --min-nodes 2 --max-nodes 5 --instance-type t3.large --ttl 24h
+# Create a cluster with autoscaling configuration
+replicated cluster create --distribution eks --version 1.21 --min-nodes 2 --max-nodes 5 --instance-type t3.large --ttl 24h
 
-  # Create a cluster with multiple node groups
-  replicated cluster create --distribution eks --version 1.21 \
-    --nodegroup name=workers,instance-type=t3.large,nodes=3 \
-    --nodegroup name=cpu-intensive,instance-type=c5.2xlarge,nodes=2 \
-    --ttl 24h
+# Create a cluster with multiple node groups
+replicated cluster create --distribution eks --version 1.21 \
+--nodegroup name=workers,instance-type=t3.large,nodes=3 \
+--nodegroup name=cpu-intensive,instance-type=c5.2xlarge,nodes=2 \
+--ttl 24h
 
-  # Create a cluster with custom tags
-  replicated cluster create --distribution eks --version 1.21 --nodes 3 --tag env=test --tag project=demo --ttl 24h
+# Create a cluster with custom tags
+replicated cluster create --distribution eks --version 1.21 --nodes 3 --tag env=test --tag project=demo --ttl 24h
 
-  # Create a cluster with addons
-  replicated cluster create --distribution eks --version 1.21 --nodes 3 --addon object-store --ttl 24h`,
+# Create a cluster with addons
+replicated cluster create --distribution eks --version 1.21 --nodes 3 --addon object-store --ttl 24h`,
 		SilenceUsage: true,
 		RunE:         r.createCluster,
 		Args:         cobra.NoArgs,

--- a/cli/cmd/cluster_kubeconfig.go
+++ b/cli/cmd/cluster_kubeconfig.go
@@ -29,20 +29,20 @@ func (r *runners) InitClusterKubeconfig(parent *cobra.Command) *cobra.Command {
 This command ensures that the kubeconfig is correctly configured for use with your Kubernetes tools. You can specify the cluster by ID or by name. Additionally, the kubeconfig can be written to a specific file path or printed to stdout.
 
 You can also use this command to automatically update your current Kubernetes context with the downloaded credentials.`,
-		Example: `  # Download and merge kubeconfig into your existing configuration
-  replicated cluster kubeconfig CLUSTER_ID
+		Example: `# Download and merge kubeconfig into your existing configuration
+replicated cluster kubeconfig CLUSTER_ID
 
-  # Save the kubeconfig to a specific file
-  replicated cluster kubeconfig CLUSTER_ID --output-path ./kubeconfig
+# Save the kubeconfig to a specific file
+replicated cluster kubeconfig CLUSTER_ID --output-path ./kubeconfig
 
-  # Print the kubeconfig to stdout
-  replicated cluster kubeconfig CLUSTER_ID --stdout
+# Print the kubeconfig to stdout
+replicated cluster kubeconfig CLUSTER_ID --stdout
 
-  # Download kubeconfig for a cluster by name
-  replicated cluster kubeconfig --name "My Cluster"
+# Download kubeconfig for a cluster by name
+replicated cluster kubeconfig --name "My Cluster"
 
-  # Download kubeconfig for a cluster by ID
-  replicated cluster kubeconfig --id CLUSTER_ID`,
+# Download kubeconfig for a cluster by ID
+replicated cluster kubeconfig --id CLUSTER_ID`,
 		RunE:              r.kubeconfigCluster,
 		ValidArgsFunction: r.completeClusterIDs,
 	}

--- a/cli/cmd/cluster_ls.go
+++ b/cli/cmd/cluster_ls.go
@@ -22,23 +22,23 @@ func (r *runners) InitClusterList(parent *cobra.Command) *cobra.Command {
 You can filter the list of clusters by time range and status (e.g., show only terminated clusters). You can also watch clusters in real-time, which updates the list every few seconds.
 
 Clusters that have been deleted will be shown with a 'deleted' status.`,
-		Example: `  # List all clusters with default table output
-  replicated cluster ls
+		Example: `# List all clusters with default table output
+replicated cluster ls
 
-  # Show clusters created after a specific date
-  replicated cluster ls --start-time 2023-01-01T00:00:00Z
+# Show clusters created after a specific date
+replicated cluster ls --start-time 2023-01-01T00:00:00Z
 
-  # Watch for real-time updates
-  replicated cluster ls --watch
+# Watch for real-time updates
+replicated cluster ls --watch
 
-  # List clusters with JSON output
-  replicated cluster ls --output json
+# List clusters with JSON output
+replicated cluster ls --output json
 
-  # List only terminated clusters
-  replicated cluster ls --show-terminated
+# List only terminated clusters
+replicated cluster ls --show-terminated
 
-  # List clusters with wide table output
-  replicated cluster ls --output wide`,
+# List clusters with wide table output
+replicated cluster ls --output wide`,
 		RunE: r.listClusters,
 	}
 	parent.AddCommand(cmd)

--- a/cli/cmd/cluster_nodegroup.go
+++ b/cli/cmd/cluster_nodegroup.go
@@ -11,8 +11,8 @@ func (r *runners) InitClusterNodeGroup(parent *cobra.Command) *cobra.Command {
 		Long: `The 'cluster nodegroup' command provides functionality to manage node groups within a cluster. This command allows you to list node groups in a Kubernetes or VM-based cluster.
 
 Node groups define a set of nodes with specific configurations, such as instance types, node counts, or scaling rules. You can use subcommands to perform various actions on node groups.`,
-		Example: `  # List all node groups for a cluster
-  replicated cluster nodegroup ls CLUSTER_ID`,
+		Example: `# List all node groups for a cluster
+replicated cluster nodegroup ls CLUSTER_ID`,
 	}
 	parent.AddCommand(cmd)
 

--- a/cli/cmd/cluster_nodegroup_ls.go
+++ b/cli/cmd/cluster_nodegroup_ls.go
@@ -17,14 +17,14 @@ func (r *runners) InitClusterNodeGroupList(parent *cobra.Command) *cobra.Command
 You can view information about the node groups within the specified cluster, including their ID, name, node count, and other configuration details.
 
 You must provide the cluster ID to list its node groups.`,
-		Example: `  # List all node groups in a cluster with default table output
-  replicated cluster nodegroup ls CLUSTER_ID
+		Example: `# List all node groups in a cluster with default table output
+replicated cluster nodegroup ls CLUSTER_ID
 
-  # List node groups with JSON output
-  replicated cluster nodegroup ls CLUSTER_ID --output json
+# List node groups with JSON output
+replicated cluster nodegroup ls CLUSTER_ID --output json
 
-  # List node groups with wide table output
-  replicated cluster nodegroup ls CLUSTER_ID --output wide`,
+# List node groups with wide table output
+replicated cluster nodegroup ls CLUSTER_ID --output wide`,
 		Args:              cobra.ExactArgs(1),
 		RunE:              r.listNodeGroups,
 		ValidArgsFunction: r.completeClusterIDs,

--- a/cli/cmd/cluster_port.go
+++ b/cli/cmd/cluster_port.go
@@ -11,14 +11,14 @@ func (r *runners) InitClusterPort(parent *cobra.Command) *cobra.Command {
 		Long: `The 'cluster port' command is a parent command for managing ports in a cluster. It allows users to list, remove, or expose specific ports used by the cluster. Use the subcommands (such as 'ls', 'rm', and 'expose') to manage port configurations effectively.
 
 This command provides flexibility for handling ports in various test clusters, ensuring efficient management of cluster networking settings.`,
-		Example: `  # List all exposed ports in a cluster
-  replicated cluster port ls [CLUSTER_ID]
+		Example: `# List all exposed ports in a cluster
+replicated cluster port ls [CLUSTER_ID]
 
-  # Remove an exposed port from a cluster
-  replicated cluster port rm [CLUSTER_ID] [PORT]
+# Remove an exposed port from a cluster
+replicated cluster port rm [CLUSTER_ID] [PORT]
 
-  # Expose a new port in a cluster
-  replicated cluster port expose [CLUSTER_ID] [PORT]`,
+# Expose a new port in a cluster
+replicated cluster port expose [CLUSTER_ID] [PORT]`,
 		SilenceUsage: true,
 		Hidden:       false,
 	}

--- a/cli/cmd/cluster_port_expose.go
+++ b/cli/cmd/cluster_port_expose.go
@@ -17,17 +17,17 @@ You can also create a wildcard DNS entry and TLS certificate by specifying the "
 This command supports different protocols including "http", "https", "ws", and "wss" for web traffic and web socket communication.
 
 NOTE: Currently, this feature only supports VM-based cluster distributions.`,
-		Example: `  # Expose port 8080 with HTTPS protocol and wildcard DNS
-  replicated cluster port expose CLUSTER_ID --port 8080 --protocol https --wildcard
+		Example: `# Expose port 8080 with HTTPS protocol and wildcard DNS
+replicated cluster port expose CLUSTER_ID --port 8080 --protocol https --wildcard
 
-  # Expose port 3000 with HTTP protocol
-  replicated cluster port expose CLUSTER_ID --port 3000 --protocol http
+# Expose port 3000 with HTTP protocol
+replicated cluster port expose CLUSTER_ID --port 3000 --protocol http
 
-  # Expose port 8080 with multiple protocols
-  replicated cluster port expose CLUSTER_ID --port 8080 --protocol http,https
+# Expose port 8080 with multiple protocols
+replicated cluster port expose CLUSTER_ID --port 8080 --protocol http,https
 
-  # Expose port 8080 and display the result in JSON format
-  replicated cluster port expose CLUSTER_ID --port 8080 --protocol https --output json`,
+# Expose port 8080 and display the result in JSON format
+replicated cluster port expose CLUSTER_ID --port 8080 --protocol https --output json`,
 		RunE:              r.clusterPortExpose,
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: r.completeClusterIDs,

--- a/cli/cmd/cluster_port_ls.go
+++ b/cli/cmd/cluster_port_ls.go
@@ -13,14 +13,14 @@ func (r *runners) InitClusterPortLs(parent *cobra.Command) *cobra.Command {
 		Long: `The 'cluster port ls' command lists all the ports configured for a specific cluster. You must provide the cluster ID to retrieve and display the ports.
 
 This command is useful for viewing the current port configurations, protocols, and other related settings of your test cluster. The output format can be customized to suit your needs, and the available formats include table, JSON, and wide views.`,
-		Example: `  # List ports for a cluster in the default table format
-  replicated cluster port ls CLUSTER_ID
+		Example: `# List ports for a cluster in the default table format
+replicated cluster port ls CLUSTER_ID
 
-  # List ports for a cluster in JSON format
-  replicated cluster port ls CLUSTER_ID --output json
+# List ports for a cluster in JSON format
+replicated cluster port ls CLUSTER_ID --output json
 
-  # List ports for a cluster in wide format
-  replicated cluster port ls CLUSTER_ID --output wide`,
+# List ports for a cluster in wide format
+replicated cluster port ls CLUSTER_ID --output wide`,
 		RunE:              r.clusterPortList,
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: r.completeClusterIDs,

--- a/cli/cmd/cluster_port_rm.go
+++ b/cli/cmd/cluster_port_rm.go
@@ -16,14 +16,14 @@ func (r *runners) InitClusterPortRm(parent *cobra.Command) *cobra.Command {
 This command is useful for managing the network settings of your test clusters by allowing you to clean up unused or incorrect ports. After removing a port, the updated list of ports will be displayed.
 
 Note that you can only use either the port ID or port number when removing a port, not both at the same time.`,
-		Example: `  # Remove a port using its ID
-  replicated cluster port rm CLUSTER_ID --id PORT_ID
+		Example: `# Remove a port using its ID
+replicated cluster port rm CLUSTER_ID --id PORT_ID
 
-  # Remove a port using its number (deprecated)
-  replicated cluster port rm CLUSTER_ID --port 8080 --protocol http,https
+# Remove a port using its number (deprecated)
+replicated cluster port rm CLUSTER_ID --port 8080 --protocol http,https
 
-  # Remove a port and display the result in JSON format
-  replicated cluster port rm CLUSTER_ID --id PORT_ID --output json`,
+# Remove a port and display the result in JSON format
+replicated cluster port rm CLUSTER_ID --id PORT_ID --output json`,
 		RunE:              r.clusterPortRemove,
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: r.completeClusterIDs,

--- a/cli/cmd/cluster_prepare.go
+++ b/cli/cmd/cluster_prepare.go
@@ -56,7 +56,7 @@ You can also pass entitlement values to configure the cluster's customer entitle
 Note:
 - The '--chart' flag cannot be used with '--yaml', '--yaml-file', or '--yaml-dir'.
 - If deploying a Helm chart, use the '--set' flags to pass chart values. When deploying a KOTS application, the '--shared-password' flag is required.`,
-		Example: `  replicated cluster prepare --distribution eks --version 1.27 --instance-type c6.xlarge --node-count 3 --chart ./your-chart.tgz --values ./values.yaml --set chart-key=value --set chart-key2=value2`,
+		Example: `replicated cluster prepare --distribution eks --version 1.27 --instance-type c6.xlarge --node-count 3 --chart ./your-chart.tgz --values ./values.yaml --set chart-key=value --set chart-key2=value2`,
 		RunE:    r.prepareCluster,
 	}
 

--- a/cli/cmd/cluster_rm.go
+++ b/cli/cmd/cluster_rm.go
@@ -20,11 +20,11 @@ You can remove clusters by specifying a cluster ID, or by using other criteria s
 This command can also be used in a dry-run mode to simulate the removal without actually deleting anything.
 
 You cannot mix the use of cluster IDs with other options like removing by name, tag, or removing all clusters at once.`,
-		Example: `  # Remove a specific cluster by ID
-  replicated cluster rm CLUSTER_ID
+		Example: `# Remove a specific cluster by ID
+replicated cluster rm CLUSTER_ID
 
-  # Remove all clusters
-  replicated cluster rm --all`,
+# Remove all clusters
+replicated cluster rm --all`,
 		RunE:              r.removeClusters,
 		ValidArgsFunction: r.completeClusterIDs,
 	}

--- a/cli/cmd/cluster_shell.go
+++ b/cli/cmd/cluster_shell.go
@@ -26,11 +26,11 @@ func (r *runners) InitClusterShell(parent *cobra.Command) *cobra.Command {
 You can either specify the cluster ID directly or provide the cluster name to resolve the corresponding cluster ID. The shell will inherit your existing environment and add the necessary kubeconfig context for interacting with the Kubernetes cluster.
 
 Once inside the shell, you can use 'kubectl' to interact with the cluster. To exit the shell, press Ctrl-D or type 'exit'. When the shell closes, the kubeconfig will be reset back to your default configuration.`,
-		Example: `  # Open a shell for a cluster by ID
-  replicated cluster shell CLUSTER_ID
+		Example: `# Open a shell for a cluster by ID
+replicated cluster shell CLUSTER_ID
 
-  # Open a shell for a cluster by name
-  replicated cluster shell --name "My Cluster"`,
+# Open a shell for a cluster by name
+replicated cluster shell --name "My Cluster"`,
 		RunE:              r.shellCluster,
 		ValidArgsFunction: r.completeClusterIDs,
 	}

--- a/cli/cmd/cluster_update.go
+++ b/cli/cmd/cluster_update.go
@@ -13,11 +13,11 @@ func (r *runners) InitClusterUpdateCommand(parent *cobra.Command) *cobra.Command
 		Long: `The 'update' command allows you to update various settings of a test cluster, such as its name or ID.
 
 You can either specify the cluster ID directly or provide the cluster name, and the command will resolve the corresponding cluster ID. This allows you to modify the cluster's configuration based on the unique identifier or the name of the cluster.`,
-		Example: `  # Update a cluster using its ID
-  replicated cluster update --id <cluster-id> [subcommand]
+		Example: `# Update a cluster using its ID
+replicated cluster update --id <cluster-id> [subcommand]
 
-  # Update a cluster using its name
-  replicated cluster update --name <cluster-name> [subcommand]`,
+# Update a cluster using its name
+replicated cluster update --name <cluster-name> [subcommand]`,
 	}
 	parent.AddCommand(cmd)
 

--- a/cli/cmd/cluster_update_nodegroup.go
+++ b/cli/cmd/cluster_update_nodegroup.go
@@ -17,11 +17,11 @@ func (r *runners) InitClusterUpdateNodegroup(parent *cobra.Command) *cobra.Comma
 		Long: `The 'nodegroup' command allows you to update the configuration of a nodegroup within a test cluster. You can update attributes like the number of nodes, minimum and maximum node counts for autoscaling, and more.
 
 If you do not provide the nodegroup ID, the command will try to resolve it based on the nodegroup name provided.`,
-		Example: `  # Update the number of nodes in a nodegroup
-  replicated cluster update nodegroup CLUSTER_ID --nodegroup-id NODEGROUP_ID --nodes 3
+		Example: `# Update the number of nodes in a nodegroup
+replicated cluster update nodegroup CLUSTER_ID --nodegroup-id NODEGROUP_ID --nodes 3
 
-  # Update the autoscaling limits for a nodegroup
-  replicated cluster update nodegroup CLUSTER_ID --nodegroup-id NODEGROUP_ID --min-nodes 2 --max-nodes 5`,
+# Update the autoscaling limits for a nodegroup
+replicated cluster update nodegroup CLUSTER_ID --nodegroup-id NODEGROUP_ID --min-nodes 2 --max-nodes 5`,
 		RunE:              r.updateClusterNodegroup,
 		SilenceUsage:      true,
 		ValidArgsFunction: r.completeClusterIDs,

--- a/cli/cmd/cluster_update_ttl.go
+++ b/cli/cmd/cluster_update_ttl.go
@@ -13,8 +13,8 @@ func (r *runners) InitClusterUpdateTTL(parent *cobra.Command) *cobra.Command {
 		Use:   "ttl [ID]",
 		Short: "Update TTL for a test cluster.",
 		Long:  `The 'ttl' command allows you to update the Time-To-Live (TTL) of a test cluster. The TTL represents the duration for which the cluster will remain active before it is automatically terminated. The duration starts from the moment the cluster becomes active. You must provide a valid duration, with a maximum limit of 48 hours.`,
-		Example: `  # Update the TTL for a specific cluster
-  replicated cluster update ttl CLUSTER_ID --ttl 24h`,
+		Example: `# Update the TTL for a specific cluster
+replicated cluster update ttl CLUSTER_ID --ttl 24h`,
 		RunE:              r.updateClusterTTL,
 		SilenceUsage:      true,
 		ValidArgsFunction: r.completeClusterIDs,

--- a/cli/cmd/cluster_upgrade.go
+++ b/cli/cmd/cluster_upgrade.go
@@ -17,14 +17,14 @@ func (r *runners) InitClusterUpgrade(parent *cobra.Command) *cobra.Command {
 		Use:   "upgrade [ID]",
 		Short: "Upgrade a test cluster.",
 		Long:  `The 'upgrade' command upgrades a Kubernetes test cluster to a specified version. You must provide a cluster ID and the version to upgrade to. The upgrade can be simulated with a dry-run option, or you can choose to wait for the cluster to be fully upgraded.`,
-		Example: `  # Upgrade a cluster to a new Kubernetes version
-  replicated cluster upgrade [CLUSTER_ID] --version 1.31
+		Example: `# Upgrade a cluster to a new Kubernetes version
+replicated cluster upgrade [CLUSTER_ID] --version 1.31
 
-  # Perform a dry run of a cluster upgrade without making any changes
-  replicated cluster upgrade [CLUSTER_ID] --version 1.31 --dry-run
+# Perform a dry run of a cluster upgrade without making any changes
+replicated cluster upgrade [CLUSTER_ID] --version 1.31 --dry-run
 
-  # Upgrade a cluster and wait for it to be ready
-  replicated cluster upgrade [CLUSTER_ID] --version 1.31 --wait 30m`,
+# Upgrade a cluster and wait for it to be ready
+replicated cluster upgrade [CLUSTER_ID] --version 1.31 --wait 30m`,
 		Args:              cobra.ExactArgs(1),
 		RunE:              r.upgradeCluster,
 		SilenceUsage:      true,

--- a/cli/cmd/cluster_versions.go
+++ b/cli/cmd/cluster_versions.go
@@ -13,14 +13,14 @@ func (r *runners) InitClusterVersions(parent *cobra.Command) *cobra.Command {
 		Use:   "versions",
 		Short: "List cluster versions.",
 		Long:  `The 'versions' command lists available Kubernetes versions for supported distributions. You can filter the versions by specifying a distribution and choose between different output formats.`,
-		Example: `  # List all available Kubernetes cluster versions
-  replicated cluster versions
+		Example: `# List all available Kubernetes cluster versions
+replicated cluster versions
 
-  # List available versions for a specific distribution (e.g., eks)
-  replicated cluster versions --distribution eks
+# List available versions for a specific distribution (e.g., eks)
+replicated cluster versions --distribution eks
 
-  # Output the versions in JSON format
-  replicated cluster versions --output json`,
+# Output the versions in JSON format
+replicated cluster versions --output json`,
 		RunE: r.listClusterVersions,
 	}
 	parent.AddCommand(cmd)

--- a/cli/cmd/collector_promote.go
+++ b/cli/cmd/collector_promote.go
@@ -9,11 +9,10 @@ import (
 
 func (r *runners) InitCollectorPromote(parent *cobra.Command) {
 	cmd := &cobra.Command{
-		Use:   "promote SPEC_ID CHANNEL_ID",
-		Short: "Set the collector for a channel",
-		Long: `Set the collector for a channel
-
-  Example: replicated collectors promote skd204095829040 fe4901690971757689f022f7a460f9b2`,
+		Use:     "promote SPEC_ID CHANNEL_ID",
+		Short:   "Set the collector for a channel",
+		Long:    `Set the collector for a channel`,
+		Example: `replicated collectors promote skd204095829040 fe4901690971757689f022f7a460f9b2`,
 	}
 	cmd.Hidden = true // Not supported in KOTS
 	parent.AddCommand(cmd)

--- a/cli/cmd/completion.go
+++ b/cli/cmd/completion.go
@@ -24,48 +24,48 @@ func NewCmdCompletion(out io.Writer, parentName string) *cobra.Command {
 	return &cobra.Command{
 		Use:   "completion [bash|zsh|fish|powershell]",
 		Short: "Generate completion script",
-		Long: fmt.Sprintf(`To load completions:
+		Example: fmt.Sprintf(`To load completions:
 
-	Bash:
+Bash:
 
-	  This script depends on the 'bash-completion' package.
-	  If it is not installed already, you can install it via your OS's package manager.
+	This script depends on the 'bash-completion' package.
+	If it is not installed already, you can install it via your OS's package manager.
 
-	  $ source <(%[1]s completion bash)
+	$ source <(%[1]s completion bash)
 
-	  # To load completions for each session, execute once:
-	  # Linux:
-	  $ %[1]s completion bash > /etc/bash_completion.d/%[1]s
-	  # macOS:
-	  $ %[1]s completion bash > $(brew --prefix)/etc/bash_completion.d/%[1]s
+	# To load completions for each session, execute once:
+	# Linux:
+	$ %[1]s completion bash > /etc/bash_completion.d/%[1]s
+	# macOS:
+	$ %[1]s completion bash > $(brew --prefix)/etc/bash_completion.d/%[1]s
 
-	Zsh:
+Zsh:
 
-	  # If shell completion is not already enabled in your environment,
-	  # you will need to enable it.  You can execute the following once:
+	# If shell completion is not already enabled in your environment,
+	# you will need to enable it.  You can execute the following once:
 
-	  $ echo "autoload -U compinit; compinit" >> ~/.zshrc
+	$ echo "autoload -U compinit; compinit" >> ~/.zshrc
 
-	  # To load completions for each session, execute once:
-	  $ %[1]s completion zsh > "${fpath[1]}/_%[1]s"
+	# To load completions for each session, execute once:
+	$ %[1]s completion zsh > "${fpath[1]}/_%[1]s"
 
-	  # You will need to start a new shell for this setup to take effect.
+	# You will need to start a new shell for this setup to take effect.
 
-	fish:
+fish:
 
-	  $ %[1]s completion fish | source
+	$ %[1]s completion fish | source
 
-	  # To load completions for each session, execute once:
-	  $ %[1]s completion fish > ~/.config/fish/completions/%[1]s.fish
+	# To load completions for each session, execute once:
+	$ %[1]s completion fish > ~/.config/fish/completions/%[1]s.fish
 
-	PowerShell:
+PowerShell:
 
-	  PS> %[1]s completion powershell | Out-String | Invoke-Expression
+	PS> %[1]s completion powershell | Out-String | Invoke-Expression
 
-	  # To load completions for every new session, run:
-	  PS> %[1]s completion powershell > %[1]s.ps1
-	  # and source this file from your PowerShell profile.
-	`, parentName),
+	# To load completions for every new session, run:
+	PS> %[1]s completion powershell > %[1]s.ps1
+	# and source this file from your PowerShell profile.
+`, parentName),
 
 		DisableFlagsInUseLine: true,
 		ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},

--- a/cli/cmd/customer_archive.go
+++ b/cli/cmd/customer_archive.go
@@ -23,17 +23,17 @@ will make their license inactive and remove them from active customer lists.
 This action is reversible - you can unarchive a customer later if needed.
 
 The customer can be specified by either their name or ID.`,
-		Example: `  # Archive a customer by name
-  replicated customer archive "Acme Inc"
+		Example: `# Archive a customer by name
+replicated customer archive "Acme Inc"
 
-  # Archive a customer by ID
-  replicated customer archive cus_abcdef123456
+# Archive a customer by ID
+replicated customer archive cus_abcdef123456
 
-  # Archive multiple customers by ID
-  replicated customer archive cus_abcdef123456 cus_xyz9876543210
+# Archive multiple customers by ID
+replicated customer archive cus_abcdef123456 cus_xyz9876543210
 
-  # Archive a customer in a specific app (if you have multiple apps)
-  replicated customer archive --app myapp "Acme Inc"`,
+# Archive a customer in a specific app (if you have multiple apps)
+replicated customer archive --app myapp "Acme Inc"`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// for compatibility reasons, we want to continue to support --customer but also read from args[0] if that's set
 			customers := []string{}

--- a/cli/cmd/customer_create.go
+++ b/cli/cmd/customer_create.go
@@ -50,24 +50,24 @@ custom ID, channels, license type, and feature flags. You can set expiration dat
 enable or disable specific features, and assign the customer to one or more channels.
 
 The --app flag must be set to specify the target application.`,
-		Example: `  # Create a basic customer with a name and assigned to a channel
-  replicated customer create --app myapp --name "Acme Inc" --channel stable
+		Example: `# Create a basic customer with a name and assigned to a channel
+replicated customer create --app myapp --name "Acme Inc" --channel stable
 
-  # Create a customer with multiple channels and a custom ID
-  replicated customer create --app myapp --name "Beta Corp" --custom-id "BETA123" --channel beta --channel stable
+# Create a customer with multiple channels and a custom ID
+replicated customer create --app myapp --name "Beta Corp" --custom-id "BETA123" --channel beta --channel stable
 
-  # Create a paid customer with specific features enabled
-  replicated customer create --app myapp --name "Enterprise Ltd" --type paid --channel enterprise --airgap --snapshot
+# Create a paid customer with specific features enabled
+replicated customer create --app myapp --name "Enterprise Ltd" --type paid --channel enterprise --airgap --snapshot
 
-  # Create a trial customer with an expiration date
-  replicated customer create --app myapp --name "Trial User" --type trial --channel stable --expires-in 720h
+# Create a trial customer with an expiration date
+replicated customer create --app myapp --name "Trial User" --type trial --channel stable --expires-in 720h
 
-  # Create a customer with all available options
-  replicated customer create --app myapp --name "Full Options Inc" --custom-id "FULL001" \
-    --channel stable --channel beta --default-channel stable --type paid \
-    --email "contact@fulloptions.com" --expires-in 8760h \
-    --airgap --snapshot --kots-install --embedded-cluster-download \
-    --support-bundle-upload --ensure-channel`,
+# Create a customer with all available options
+replicated customer create --app myapp --name "Full Options Inc" --custom-id "FULL001" \
+	--channel stable --channel beta --default-channel stable --type paid \
+	--email "contact@fulloptions.com" --expires-in 8760h \
+	--airgap --snapshot --kots-install --embedded-cluster-download \
+	--support-bundle-upload --ensure-channel`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return r.createCustomer(cmd, opts, outputFormat)
 		},

--- a/cli/cmd/customer_download_license.go
+++ b/cli/cmd/customer_download_license.go
@@ -24,14 +24,14 @@ to stdout or saves it to a file. The license contains crucial information about
 the customer's subscription and usage rights.
 
 You must specify the customer using either their name or ID with the --customer flag.`,
-		Example: `  # Download license for a customer by ID and output to stdout
-  replicated customer download-license --customer cus_abcdef123456
+		Example: `# Download license for a customer by ID and output to stdout
+replicated customer download-license --customer cus_abcdef123456
 
-  # Download license for a customer by name and save to a file
-  replicated customer download-license --customer "Acme Inc" --output license.yaml
+# Download license for a customer by name and save to a file
+replicated customer download-license --customer "Acme Inc" --output license.yaml
 
-  # Download license for a customer in a specific app (if you have multiple apps)
-  replicated customer download-license --app myapp --customer "Acme Inc" --output license.yaml`,
+# Download license for a customer in a specific app (if you have multiple apps)
+replicated customer download-license --app myapp --customer "Acme Inc" --output license.yaml`,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			return r.downloadCustomerLicense(cmd, customer, output)
 		},

--- a/cli/cmd/customer_inspect.go
+++ b/cli/cmd/customer_inspect.go
@@ -26,17 +26,17 @@ func (r *runners) InitCustomersInspectCommand(parent *cobra.Command) *cobra.Comm
 	It's useful for getting an in-depth view of a customer's configuration and status.
 
 	You must specify the customer using either their name or ID with the --customer flag.`,
-		Example: `  # Inspect a customer by ID
-	  replicated customer inspect --customer cus_abcdef123456
+		Example: `# Inspect a customer by ID
+replicated customer inspect --customer cus_abcdef123456
 
-	  # Inspect a customer by name
-	  replicated customer inspect --customer "Acme Inc"
+# Inspect a customer by name
+replicated customer inspect --customer "Acme Inc"
 
-	  # Inspect a customer and output in JSON format
-	  replicated customer inspect --customer cus_abcdef123456 --output json
+# Inspect a customer and output in JSON format
+replicated customer inspect --customer cus_abcdef123456 --output json
 
-	  # Inspect a customer for a specific app (if you have multiple apps)
-	  replicated customer inspect --app myapp --customer "Acme Inc"`,
+# Inspect a customer for a specific app (if you have multiple apps)
+replicated customer inspect --app myapp --customer "Acme Inc"`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return r.inspectCustomer(cmd, customer, outputFormat)
 		},

--- a/cli/cmd/customer_ls.go
+++ b/cli/cmd/customer_ls.go
@@ -26,13 +26,13 @@ By default, it shows all non-test customers. You can use flags to:
 - Change the output format (table or JSON)
 
 The command requires an app to be set using the --app flag.`,
-		Example: `  # List all customers for the current application
-  replicated customer ls --app myapp
-  # Output results in JSON format
-  replicated customer ls --app myapp --output json
+		Example: `# List all customers for the current application
+replicated customer ls --app myapp
+# Output results in JSON format
+replicated customer ls --app myapp --output json
 
-  # Combine multiple flags
-  replicated customer ls --app myapp --output json`,
+# Combine multiple flags
+replicated customer ls --app myapp --output json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return r.listCustomers(appVersion, includeTest, outputFormat)
 		},

--- a/cli/cmd/customer_update.go
+++ b/cli/cmd/customer_update.go
@@ -49,23 +49,23 @@ func (r *runners) InitCustomerUpdateCommand(parent *cobra.Command) *cobra.Comman
 	enable or disable specific features, and change channel assignments.
 
 	The --customer flag is required to specify which customer to update.`,
-		Example: `  # Update a customer's name
-	  replicated customer update --customer cus_abcdef123456 --name "New Company Name"
+		Example: `# Update a customer's name
+replicated customer update --customer cus_abcdef123456 --name "New Company Name"
 
-	  # Change a customer's channel and make it the default
-	  replicated customer update --customer cus_abcdef123456 --channel stable --default-channel stable
+# Change a customer's channel and make it the default
+replicated customer update --customer cus_abcdef123456 --channel stable --default-channel stable
 
-	  # Enable airgap installations for a customer
-	  replicated customer update --customer cus_abcdef123456 --airgap
+# Enable airgap installations for a customer
+replicated customer update --customer cus_abcdef123456 --airgap
 
-	  # Update multiple attributes at once
-	  replicated customer update --customer cus_abcdef123456 --name "Updated Corp" --type paid --channel enterprise --airgap --snapshot
+# Update multiple attributes at once
+replicated customer update --customer cus_abcdef123456 --name "Updated Corp" --type paid --channel enterprise --airgap --snapshot
 
-	  # Set an expiration date for a customer's license
-	  replicated customer update --customer cus_abcdef123456 --expires-in 8760h
+# Set an expiration date for a customer's license
+replicated customer update --customer cus_abcdef123456 --expires-in 8760h
 
-	  # Update a customer and output the result in JSON format
-	  replicated customer update --customer cus_abcdef123456 --name "JSON Corp" --output json`,
+# Update a customer and output the result in JSON format
+replicated customer update --customer cus_abcdef123456 --name "JSON Corp" --output json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return r.updateCustomer(cmd, opts)
 		},

--- a/cli/cmd/default.go
+++ b/cli/cmd/default.go
@@ -7,7 +7,7 @@ func (r *runners) InitDefaultCommand(parent *cobra.Command) *cobra.Command {
 		Use:     "default",
 		Short:   "Manage default values used by other commands",
 		Long:    ``,
-		Example: `  `,
+		Example: ``,
 	}
 
 	parent.AddCommand(cmd)

--- a/cli/cmd/default_clear.go
+++ b/cli/cmd/default_clear.go
@@ -15,8 +15,8 @@ This command removes default values that are used by other commands run by the c
 
 Supported keys:
 - app: the default application to use`,
-		Example: `  # Clear default application
-  replicated default clear app`,
+		Example: `# Clear default application
+replicated default clear app`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return r.clearDefault(cmd, args[0])

--- a/cli/cmd/default_clearall.go
+++ b/cli/cmd/default_clearall.go
@@ -9,8 +9,8 @@ func (r *runners) InitDefaultClearAllCommand(parent *cobra.Command) *cobra.Comma
 		Long: `Clears all default values that are used by other commands.
 
 This command removes all default values that are used by other commands run by the current user.`,
-		Example: `  # Clear all default values
-  replicated default clear-all`,
+		Example: `# Clear all default values
+replicated default clear-all`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return r.clearAllDefaults(cmd)
 		},

--- a/cli/cmd/default_set.go
+++ b/cli/cmd/default_set.go
@@ -22,8 +22,8 @@ Supported keys:
 
 The output can be customized using the --output flag to display results in
 either table or JSON format.`,
-		Example: `  # Set default application
-  replicated default set app my-app-slug`,
+		Example: `# Set default application
+replicated default set app my-app-slug`,
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return r.setDefault(cmd, args[0], args[1], outputFormat)

--- a/cli/cmd/default_show.go
+++ b/cli/cmd/default_show.go
@@ -24,8 +24,8 @@ Supported keys:
 
 The output can be customized using the --output flag to display results in
 either table or JSON format.`,
-		Example: `  # Show default application
-  replicated default show app
+		Example: `# Show default application
+replicated default show app
 `,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/cmd/enterprise_portal_invite.go
+++ b/cli/cmd/enterprise_portal_invite.go
@@ -24,17 +24,17 @@ the customer (by name or ID) and provide one or more email addresses of the user
 you want to invite.
 
 The command will generate and return unique invitation URLs for each email address.`,
-		Example: `  # Invite a single user to the Enterprise Portal for a customer
-  replicated enterprise-portal invite --customer "ACME Inc" user@example.com
+		Example: `# Invite a single user to the Enterprise Portal for a customer
+replicated enterprise-portal invite --customer "ACME Inc" user@example.com
 
-  # Invite multiple users to the Enterprise Portal for a customer
-  replicated enterprise-portal invite --customer "cus_abcdef123456" user1@example.com user2@example.com
+# Invite multiple users to the Enterprise Portal for a customer
+replicated enterprise-portal invite --customer "cus_abcdef123456" user1@example.com user2@example.com
 
-  # Invite a user and specify JSON output format
-  replicated enterprise-portal invite --customer "ACME Inc" --output json user@example.com
+# Invite a user and specify JSON output format
+replicated enterprise-portal invite --customer "ACME Inc" --output json user@example.com
 
-  # Invite users to the Enterprise Portal for a specific app (if you have multiple apps)
-  replicated enterprise-portal invite --app myapp --customer "ACME Inc" user1@example.com user2@example.com`,
+# Invite users to the Enterprise Portal for a specific app (if you have multiple apps)
+replicated enterprise-portal invite --app myapp --customer "ACME Inc" user1@example.com user2@example.com`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return r.enterprisePortalInvite(cmd, r.appID, customer, args, outputFormat)
 		},

--- a/cli/cmd/enterprise_portal_status.go
+++ b/cli/cmd/enterprise_portal_status.go
@@ -15,17 +15,17 @@ and updating it. You can use these subcommands to monitor and control the state 
 Enterprise Portal for your application.
 
 Use 'status get' to retrieve the current status and 'status update' to change the status.`,
-		Example: `  # Get the current status of the Enterprise Portal
-  replicated enterprise-portal status get
+		Example: `# Get the current status of the Enterprise Portal
+replicated enterprise-portal status get
 
-  # Update the status of the Enterprise Portal
-  replicated enterprise-portal status update --status active
+# Update the status of the Enterprise Portal
+replicated enterprise-portal status update --status active
 
-  # Get the status for a specific application
-  replicated enterprise-portal status get --app myapp
+# Get the status for a specific application
+replicated enterprise-portal status get --app myapp
 
-  # Update the status for a specific application
-  replicated enterprise-portal status update --app myapp --status inactive`,
+# Update the status for a specific application
+replicated enterprise-portal status update --app myapp --status inactive`,
 	}
 	parent.AddCommand(cmd)
 

--- a/cli/cmd/enterprise_portal_user.go
+++ b/cli/cmd/enterprise_portal_user.go
@@ -13,11 +13,11 @@ func (r *runners) InitEnterprisePortalUserCmd(parent *cobra.Command) *cobra.Comm
 This command provides subcommands for listing, adding, and removing users
 from the Enterprise Portal. You can use these subcommands to control access
 to the Enterprise Portal for your application.`,
-		Example: `  # List all users with access to the Enterprise Portal
-  replicated enterprise-portal user ls
+		Example: `# List all users with access to the Enterprise Portal
+replicated enterprise-portal user ls
 
-  # List users for a specific application
-  replicated enterprise-portal user ls --app myapp`,
+# List users for a specific application
+replicated enterprise-portal user ls --app myapp`,
 	}
 	parent.AddCommand(cmd)
 

--- a/cli/cmd/enterprise_portal_user_ls.go
+++ b/cli/cmd/enterprise_portal_user_ls.go
@@ -26,20 +26,20 @@ pending invitations as well.
 
 Use the --include-invites flag to also list users who have been invited but
 haven't yet accepted their invitations.`,
-		Example: `  # List all active Enterprise Portal users
-  replicated enterprise-portal user ls
+		Example: `# List all active Enterprise Portal users
+replicated enterprise-portal user ls
 
-  # List all Enterprise Portal users, including pending invitations
-  replicated enterprise-portal user ls --include-invites
+# List all Enterprise Portal users, including pending invitations
+replicated enterprise-portal user ls --include-invites
 
-  # List Enterprise Portal users for a specific application
-  replicated enterprise-portal user ls --app myapp
+# List Enterprise Portal users for a specific application
+replicated enterprise-portal user ls --app myapp
 
-  # List Enterprise Portal users and output in JSON format
-  replicated enterprise-portal user ls --output json
+# List Enterprise Portal users and output in JSON format
+replicated enterprise-portal user ls --output json
 
-  # List all users, including invites, for a specific app in table format
-  replicated enterprise-portal user ls --app myapp --include-invites --output table`,
+# List all users, including invites, for a specific app in table format
+replicated enterprise-portal user ls --app myapp --include-invites --output table`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return r.enterprisePortalUserLs(cmd, r.appID, opts, outputFormat)
 		},

--- a/cli/cmd/enterpriseportal.go
+++ b/cli/cmd/enterpriseportal.go
@@ -9,7 +9,7 @@ func (r *runners) InitEnterprisePortalCommand(parent *cobra.Command) *cobra.Comm
 		Use:     "enterprise-portal",
 		Short:   "Manage enterprise portal",
 		Long:    ``,
-		Example: `  `,
+		Example: ``,
 		Hidden:  true,
 	}
 	parent.AddCommand(cmd)

--- a/cli/cmd/enterpriseportal_status_get.go
+++ b/cli/cmd/enterpriseportal_status_get.go
@@ -21,17 +21,17 @@ whether the Enterprise Portal is active, pending, or in any other state.
 
 If no application is specified, the command will use the default application
 set in your configuration.`,
-		Example: `  # Get the Enterprise Portal status for the default application
-  replicated enterprise-portal status get
+		Example: `# Get the Enterprise Portal status for the default application
+replicated enterprise-portal status get
 
-  # Get the Enterprise Portal status for a specific application
-  replicated enterprise-portal status get --app myapp
+# Get the Enterprise Portal status for a specific application
+replicated enterprise-portal status get --app myapp
 
-  # Get the Enterprise Portal status and output in JSON format
-  replicated enterprise-portal status get --output json
+# Get the Enterprise Portal status and output in JSON format
+replicated enterprise-portal status get --output json
 
-  # Get the Enterprise Portal status and output in table format (default)
-  replicated enterprise-portal status get --output table`,
+# Get the Enterprise Portal status and output in table format (default)
+replicated enterprise-portal status get --output table`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return r.enterprisePortalStatusGet(cmd, r.appID, outputFormat)
 		},

--- a/cli/cmd/enterpriseportal_status_update.go
+++ b/cli/cmd/enterpriseportal_status_update.go
@@ -27,17 +27,17 @@ If no application is specified, the command will use the default application
 set in your configuration.
 
 The new status must be provided using the --status flag.`,
-		Example: `  # Update the Enterprise Portal status for the default application
-  replicated enterprise-portal status update --status active
+		Example: `# Update the Enterprise Portal status for the default application
+replicated enterprise-portal status update --status active
 
-  # Update the Enterprise Portal status for a specific application
-  replicated enterprise-portal status update --app myapp --status inactive
+# Update the Enterprise Portal status for a specific application
+replicated enterprise-portal status update --app myapp --status inactive
 
-  # Update the Enterprise Portal status and output in JSON format
-  replicated enterprise-portal status update --status pending --output json
+# Update the Enterprise Portal status and output in JSON format
+replicated enterprise-portal status update --status pending --output json
 
-  # Update the Enterprise Portal status and output in table format (default)
-  replicated enterprise-portal status update --status active --output table`,
+# Update the Enterprise Portal status and output in table format (default)
+replicated enterprise-portal status update --status active --output table`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return r.enterprisePortalStatusUpdate(cmd, r.appID, opts, outputFormat)
 		},

--- a/cli/cmd/release_download.go
+++ b/cli/cmd/release_download.go
@@ -17,11 +17,9 @@ func (r *runners) InitReleaseDownload(parent *cobra.Command) {
 		Short: "Download application manifests for a release.",
 		Long: `Download application manifests for a release to a specified directory.
 
-For non-KOTS applications, this is equivalent to the 'release inspect' command.
-
-Example:
-replicated release download 1 --dest ./manifests`,
-		Args: cobra.ExactArgs(1),
+For non-KOTS applications, this is equivalent to the 'release inspect' command.`,
+		Example: `replicated release download 1 --dest ./manifests`,
+		Args:    cobra.ExactArgs(1),
 	}
 	parent.AddCommand(cmd)
 	cmd.RunE = r.releaseDownload

--- a/cli/cmd/release_inspect.go
+++ b/cli/cmd/release_inspect.go
@@ -21,11 +21,11 @@ This command displays detailed information about a specific release of an applic
 The output can be customized using the --output flag to display results in
 either table or JSON format.
 		`,
-		Example: `  # Display information about a release
-  replicated release inspect 123
+		Example: `# Display information about a release
+replicated release inspect 123
 
-  # Display information about a release in JSON format
-  replicated release inspect 123 --output json`,
+# Display information about a release in JSON format
+replicated release inspect 123 --output json`,
 		Args: cobra.ExactArgs(1),
 	}
 	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")

--- a/cli/cmd/release_promote.go
+++ b/cli/cmd/release_promote.go
@@ -11,11 +11,10 @@ import (
 
 func (r *runners) InitReleasePromote(parent *cobra.Command) {
 	cmd := &cobra.Command{
-		Use:   "promote SEQUENCE CHANNEL_ID",
-		Short: "Set the release for a channel",
-		Long: `Set the release for a channel
-
-  Example: replicated release promote 15 fe4901690971757689f022f7a460f9b2`,
+		Use:           "promote SEQUENCE CHANNEL_ID",
+		Short:         "Set the release for a channel",
+		Long:          `Set the release for a channel`,
+		Example:       `replicated release promote 15 fe4901690971757689f022f7a460f9b2`,
 		SilenceErrors: true, // this command uses custom error printing
 	}
 

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -8,16 +8,15 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/Masterminds/sprig/v3"
 	"github.com/pkg/errors"
-
-	"github.com/replicatedhq/replicated/pkg/credentials"
-	"github.com/replicatedhq/replicated/pkg/kotsclient"
-	"github.com/replicatedhq/replicated/pkg/types"
-	"github.com/replicatedhq/replicated/pkg/version"
-
 	"github.com/replicatedhq/replicated/client"
 	replicatedcache "github.com/replicatedhq/replicated/pkg/cache"
+	"github.com/replicatedhq/replicated/pkg/credentials"
+	"github.com/replicatedhq/replicated/pkg/kotsclient"
 	"github.com/replicatedhq/replicated/pkg/platformclient"
+	"github.com/replicatedhq/replicated/pkg/types"
+	"github.com/replicatedhq/replicated/pkg/version"
 	"github.com/spf13/cobra"
 )
 
@@ -79,7 +78,7 @@ Aliases:
   {{.NameAndAliases}}{{end}}{{if .HasExample}}
 
 Example:
-{{.Example}}{{end}}{{if .HasAvailableSubCommands}}
+{{.Example |  indent 2}}{{end}}{{if .HasAvailableSubCommands}}
 
 Available Commands:{{range .Commands}}{{if .IsAvailableCommand}}
   {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
@@ -282,6 +281,7 @@ func Execute(rootCmd *cobra.Command, stdin io.Reader, stdout io.Writer, stderr i
 	runCmds.InitAPIPut(apiCmd)
 	runCmds.InitAPIPatch(apiCmd)
 
+	cobra.AddTemplateFunc("indent", sprig.FuncMap()["indent"])
 	runCmds.rootCmd.SetUsageTemplate(rootCmdUsageTmpl)
 
 	preRunSetupAPIs := func(cmd *cobra.Command, args []string) error {

--- a/cli/cmd/vm.go
+++ b/cli/cmd/vm.go
@@ -12,17 +12,17 @@ func (r *runners) InitVMCommand(parent *cobra.Command) *cobra.Command {
 		Use:   "vm",
 		Short: "Manage test virtual machines.",
 		Long:  `The 'vm' command allows you to manage and interact with virtual machines (VMs) used for testing purposes. With this command, you can create, list, remove, update, and manage VMs, as well as retrieve information about available VM versions.`,
-		Example: `  # Create a single Ubuntu VM
-  replicated vm create --distribution ubuntu --version 20.04
+		Example: `# Create a single Ubuntu VM
+replicated vm create --distribution ubuntu --version 20.04
 
-  # List all VMs
-  replicated vm ls
+# List all VMs
+replicated vm ls
 
-  # Remove a specific VM by ID
-  replicated vm rm <vm-id>
+# Remove a specific VM by ID
+replicated vm rm <vm-id>
 
-  # Update TTL for a specific VM
-  replicated vm update ttl <vm-id> --ttl 24h`,
+# Update TTL for a specific VM
+replicated vm update ttl <vm-id> --ttl 24h`,
 	}
 	parent.AddCommand(cmd)
 

--- a/cli/cmd/vm_create.go
+++ b/cli/cmd/vm_create.go
@@ -27,14 +27,14 @@ This command allows you to provision VMs with different distributions (e.g., Ubu
 By default, the command provisions one VM, but you can customize the number of VMs to create by using the "--count" flag. Additionally, you can use the "--dry-run" flag to simulate the creation without actually provisioning the VMs.
 
 The command also supports a "--wait" flag to wait for the VMs to be ready before returning control, with a customizable timeout duration.`,
-		Example: `  # Create a single Ubuntu 20.04 VM
-  replicated vm create --distribution ubuntu --version 20.04
+		Example: `# Create a single Ubuntu 20.04 VM
+replicated vm create --distribution ubuntu --version 20.04
 
-  # Create 3 Ubuntu 22.04 VMs
-  replicated vm create --distribution ubuntu --version 22.04 --count 3
+# Create 3 Ubuntu 22.04 VMs
+replicated vm create --distribution ubuntu --version 22.04 --count 3
 
-  # Create 5 Ubuntu VMs with a custom instance type and disk size
-  replicated vm create --distribution ubuntu --version 20.04 --count 5 --instance-type r1.medium --disk 100`,
+# Create 5 Ubuntu VMs with a custom instance type and disk size
+replicated vm create --distribution ubuntu --version 20.04 --count 5 --instance-type r1.medium --disk 100`,
 		SilenceUsage: true,
 		RunE:         r.createVM,
 		Args:         cobra.NoArgs,

--- a/cli/cmd/vm_ls.go
+++ b/cli/cmd/vm_ls.go
@@ -24,17 +24,17 @@ By default, the command will return a table of all VMs, but you can switch to JS
 You can use the '--watch' flag to monitor VMs continuously. This will refresh the list of VMs every 2 seconds, displaying any updates in real-time, such as new VMs being created or existing VMs being terminated.
 
 The command also allows you to customize the output format, supporting 'json', 'table', and 'wide' views for flexibility based on your needs.`,
-		Example: `  # List all active VMs
-  replicated vm ls
+		Example: `# List all active VMs
+replicated vm ls
 
-  # List all VMs that were created after a specific start time
-  replicated vm ls --start-time 2024-10-01T00:00:00Z
+# List all VMs that were created after a specific start time
+replicated vm ls --start-time 2024-10-01T00:00:00Z
 
-  # Show only terminated VMs
-  replicated vm ls --show-terminated
+# Show only terminated VMs
+replicated vm ls --show-terminated
 
-  # Watch VM status changes in real-time
-  replicated vm ls --watch`,
+# Watch VM status changes in real-time
+replicated vm ls --watch`,
 		RunE: r.listVMs,
 	}
 	parent.AddCommand(cmd)

--- a/cli/cmd/vm_port.go
+++ b/cli/cmd/vm_port.go
@@ -11,14 +11,14 @@ func (r *runners) InitVMPort(parent *cobra.Command) *cobra.Command {
 		Long: `The 'vm port' command is a parent command for managing ports in a vm. It allows users to list, remove, or expose specific ports used by the vm. Use the subcommands (such as 'ls', 'rm', and 'expose') to manage port configurations effectively.
 
 This command provides flexibility for handling ports in various test vms, ensuring efficient management of vm networking settings.`,
-		Example: `  # List all exposed ports in a vm
-  replicated vm port ls [VM_ID]
+		Example: `# List all exposed ports in a vm
+replicated vm port ls [VM_ID]
 
-  # Remove an exposed port from a vm
-  replicated vm port rm [VM_ID] [PORT]
+# Remove an exposed port from a vm
+replicated vm port rm [VM_ID] [PORT]
 
-  # Expose a new port in a vm
-  replicated vm port expose [VM_ID] [PORT]`,
+# Expose a new port in a vm
+replicated vm port expose [VM_ID] [PORT]`,
 		SilenceUsage: true,
 		Hidden:       false,
 	}

--- a/cli/cmd/vm_port_expose.go
+++ b/cli/cmd/vm_port_expose.go
@@ -15,17 +15,17 @@ func (r *runners) InitVMPortExpose(parent *cobra.Command) *cobra.Command {
 You can also create a wildcard DNS entry and TLS certificate by specifying the "--wildcard" flag. Please note that creating a wildcard certificate may take additional time.
 
 This command supports different protocols including "http", "https", "ws", and "wss" for web traffic and web socket communication.`,
-		Example: `  # Expose port 8080 with HTTPS protocol and wildcard DNS
-  replicated vm port expose VM_ID --port 8080 --protocol https --wildcard
+		Example: `# Expose port 8080 with HTTPS protocol and wildcard DNS
+replicated vm port expose VM_ID --port 8080 --protocol https --wildcard
 
-  # Expose port 3000 with HTTP protocol
-  replicated vm port expose VM_ID --port 3000 --protocol http
+# Expose port 3000 with HTTP protocol
+replicated vm port expose VM_ID --port 3000 --protocol http
 
-  # Expose port 8080 with multiple protocols
-  replicated vm port expose VM_ID --port 8080 --protocol http,https
+# Expose port 8080 with multiple protocols
+replicated vm port expose VM_ID --port 8080 --protocol http,https
 
-  # Expose port 8080 and display the result in JSON format
-  replicated vm port expose VM_ID --port 8080 --protocol https --output json`,
+# Expose port 8080 and display the result in JSON format
+replicated vm port expose VM_ID --port 8080 --protocol https --output json`,
 		RunE:              r.vmPortExpose,
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: r.completeVMIDs,

--- a/cli/cmd/vm_port_ls.go
+++ b/cli/cmd/vm_port_ls.go
@@ -12,14 +12,14 @@ func (r *runners) InitVMPortLs(parent *cobra.Command) *cobra.Command {
 		Long: `The 'vm port ls' command lists all the ports configured for a specific vm. You must provide the vm ID to retrieve and display the ports.
 
 This command is useful for viewing the current port configurations, protocols, and other related settings of your test vm. The output format can be customized to suit your needs, and the available formats include table, JSON, and wide views.`,
-		Example: `  # List ports for a vm in the default table format
-  replicated vm port ls VM_ID
+		Example: `# List ports for a vm in the default table format
+replicated vm port ls VM_ID
 
-  # List ports for a vm in JSON format
-  replicated vm port ls VM_ID --output json
+# List ports for a vm in JSON format
+replicated vm port ls VM_ID --output json
 
-  # List ports for a vm in wide format
-  replicated vm port ls VM_ID --output wide`,
+# List ports for a vm in wide format
+replicated vm port ls VM_ID --output wide`,
 		RunE:              r.vmPortList,
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: r.completeVMIDs,

--- a/cli/cmd/vm_port_rm.go
+++ b/cli/cmd/vm_port_rm.go
@@ -12,11 +12,11 @@ func (r *runners) InitVMPortRm(parent *cobra.Command) *cobra.Command {
 		Long: `The 'vm port rm' command removes a specific port from a vm. You must provide the ID of the port to remove.
 
 This command is useful for managing the network settings of your test vms by allowing you to clean up unused or incorrect ports. After removing a port, the updated list of ports will be displayed.`,
-		Example: `  # Remove a port using its ID
-  replicated vm port rm VM_ID --id PORT_ID
+		Example: `# Remove a port using its ID
+replicated vm port rm VM_ID --id PORT_ID
 
-  # Remove a port and display the result in JSON format
-  replicated vm port rm VM_ID --id PORT_ID --output json`,
+# Remove a port and display the result in JSON format
+replicated vm port rm VM_ID --id PORT_ID --output json`,
 		RunE:              r.vmPortRemove,
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: r.completeVMIDs,

--- a/cli/cmd/vm_rm.go
+++ b/cli/cmd/vm_rm.go
@@ -18,23 +18,23 @@ func (r *runners) InitVMRemove(parent *cobra.Command) *cobra.Command {
 This command supports multiple filtering options, including removing VMs by their name, by specific tags, or by specifying the '--all' flag to remove all VMs in your account.
 
 You can also use the '--dry-run' flag to simulate the removal without actually deleting the VMs.`,
-		Example: `  # Remove a VM by ID
-  replicated vm rm aaaaa11
+		Example: `# Remove a VM by ID
+replicated vm rm aaaaa11
 
-  # Remove multiple VMs by ID
-  replicated vm rm aaaaa11 bbbbb22 ccccc33
+# Remove multiple VMs by ID
+replicated vm rm aaaaa11 bbbbb22 ccccc33
 
-  # Remove all VMs with a specific name
-  replicated vm rm --name test-vm
+# Remove all VMs with a specific name
+replicated vm rm --name test-vm
 
-  # Remove all VMs with a specific tag
-  replicated vm rm --tag env=dev
+# Remove all VMs with a specific tag
+replicated vm rm --tag env=dev
 
-  # Remove all VMs
-  replicated vm rm --all
+# Remove all VMs
+replicated vm rm --all
 
-  # Perform a dry run of removing all VMs
-  replicated vm rm --all --dry-run`,
+# Perform a dry run of removing all VMs
+replicated vm rm --all --dry-run`,
 		RunE:              r.removeVMs,
 		ValidArgsFunction: r.completeVMIDs,
 	}

--- a/cli/cmd/vm_update.go
+++ b/cli/cmd/vm_update.go
@@ -16,11 +16,11 @@ func (r *runners) InitVMUpdateCommand(parent *cobra.Command) *cobra.Command {
 - To update the VM by its name, use the '--name' flag.
 
 Subcommands will allow for more specific updates like TTL`,
-		Example: `  # Update a VM by specifying its ID
-  replicated vm update --id aaaaa11 --ttl 12h
+		Example: `# Update a VM by specifying its ID
+replicated vm update --id aaaaa11 --ttl 12h
 
-  # Update a VM by specifying its name
-  replicated vm update --name --ttl 12h`,
+# Update a VM by specifying its name
+replicated vm update --name --ttl 12h`,
 	}
 	parent.AddCommand(cmd)
 

--- a/cli/cmd/vm_update_ttl.go
+++ b/cli/cmd/vm_update_ttl.go
@@ -19,11 +19,11 @@ The TTL specifies how long the VM will run before it is automatically terminated
 The command accepts a VM ID as an argument and requires the '--ttl' flag to specify the new TTL value.
 
 You can also specify the output format (json, table, wide) using the '--output' flag.`,
-		Example: `  # Update the TTL of a VM to 2 hours
-  replicated vm update ttl aaaaa11 --ttl 2h
+		Example: `# Update the TTL of a VM to 2 hours
+replicated vm update ttl aaaaa11 --ttl 2h
 
-  # Update the TTL of a VM to 30 minutes
-  replicated vm update ttl aaaaa11 --ttl 30m`,
+# Update the TTL of a VM to 30 minutes
+replicated vm update ttl aaaaa11 --ttl 30m`,
 		RunE:              r.updateVMTTL,
 		SilenceUsage:      true,
 		ValidArgsFunction: r.completeVMIDs,

--- a/cli/cmd/vm_versions.go
+++ b/cli/cmd/vm_versions.go
@@ -16,14 +16,14 @@ func (r *runners) InitVMVersions(parent *cobra.Command) *cobra.Command {
 
 - You can filter the list by a specific distribution using the '--distribution' flag.
 - The output can be formatted as a table or in JSON format using the '--output' flag.`,
-		Example: `  # List all available VM versions
-  replicated vm versions
+		Example: `# List all available VM versions
+replicated vm versions
 
-  # List VM versions for a specific distribution (e.g., Ubuntu)
-  replicated vm versions --distribution ubuntu
+# List VM versions for a specific distribution (e.g., Ubuntu)
+replicated vm versions --distribution ubuntu
 
-  # Display the output in JSON format
-  replicated vm versions --output json`,
+# Display the output in JSON format
+replicated vm versions --output json`,
 		RunE: r.listVMVersions,
 	}
 	parent.AddCommand(cmd)

--- a/dagger/docs.go
+++ b/dagger/docs.go
@@ -1,0 +1,251 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"dagger/replicated/internal/dagger"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+func (r *Replicated) GenerateDocs(
+	ctx context.Context,
+
+	// +defaultPath="./"
+	source *dagger.Directory,
+
+	githubToken *dagger.Secret,
+) error {
+	err := checkGitTree(ctx, source, githubToken)
+	if err != nil {
+		return errors.Wrap(err, "failed to check git tree")
+	}
+
+	latestVersion, err := getLatestVersion(ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to get latest version")
+	}
+
+	docsContainer := dag.Container().
+		From("alpine/git:latest").
+		WithWorkdir("/").
+		With(CacheBustingExec([]string{"git", "clone", "--depth", "1", "https://github.com/replicatedhq/replicated-docs.git", "/replicated-docs"}))
+
+	rootDocsDirectory := docsContainer.Directory("/replicated-docs")
+	docsDirectory := rootDocsDirectory.Directory("/docs/reference/")
+
+	// Remove existing CLI docs
+	existingDocs, err := docsDirectory.Entries(ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to get existing docs")
+	}
+
+	for _, existingDoc := range existingDocs {
+		// 'replicated-cli-installing.mdx' is a special file that's not a CLI doc
+		if existingDoc == "replicated-cli-installing.mdx" {
+			continue
+		}
+		if !strings.HasPrefix(existingDoc, "replicated-cli") {
+			continue
+		}
+
+		docsDirectory = docsDirectory.WithoutFile(existingDoc)
+	}
+
+	// Generate CLI new docs
+	goModCache := dag.CacheVolume("replicated-go-mod-122")
+	goBuildCache := dag.CacheVolume("replicated-go-build-121")
+
+	// generate the docs from this current commit
+	docs := dag.Container().
+		From("golang:1.22").
+		WithMountedDirectory("/go/src/github.com/replicatedhq/replicated", source).
+		WithWorkdir("/go/src/github.com/replicatedhq/replicated").
+		WithMountedCache("/go/pkg/mod", goModCache).
+		WithEnvVariable("GOMODCACHE", "/go/pkg/mod").
+		WithMountedCache("/go/build-cache", goBuildCache).
+		WithEnvVariable("GOCACHE", "/go/build-cache").
+		WithEnvVariable("CGO_ENABLED", "0").
+		With(CacheBustingExec([]string{"go", "run", "./docs/gen.go"}))
+
+	generatedDocs := docs.Directory("/go/src/github.com/replicatedhq/replicated/gen/docs")
+
+	entries, err := generatedDocs.Entries(ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to get generated docs")
+	}
+
+	// Add new CLI docs to the docs directory while updating file names and fixing up header level
+	newDocFilenames := []string{}
+	for _, entry := range entries {
+		file := generatedDocs.File(entry)
+
+		content, err := file.Contents(ctx)
+		if err != nil {
+			return errors.Wrap(err, "failed to get generated doc contents")
+		}
+
+		// Header must be level 1 in order for white spaces to be rendered correctly ("replicated api get" vs "replicated_api_get")
+		if strings.HasPrefix(content, "## ") {
+			content = content[1:]
+		}
+
+		destFilename := entry
+		destFilename = strings.ReplaceAll(destFilename, "replicated_", "replicated-cli-")
+		destFilename = strings.ReplaceAll(destFilename, "_", "-")
+
+		docsDirectory = docsDirectory.WithNewFile(destFilename, content)
+		newDocFilenames = append(newDocFilenames, destFilename)
+	}
+
+	// Update sidebar config to include new CLI docs
+	sidebarFile := rootDocsDirectory.File("sidebars.js")
+	sidebarContent, err := sidebarFile.Contents(ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to get sidebar contents")
+	}
+
+	sidebarContent, err = replaceFilenamesInSidebar(sidebarContent, newDocFilenames)
+	if err != nil {
+		return errors.Wrap(err, "failed to replace filenames in sidebar")
+	}
+
+	rootDocsDirectory = rootDocsDirectory.WithNewFile("sidebars.js", sidebarContent)
+
+	docsContainer = docsContainer.
+		WithMountedDirectory("/replicated-docs", rootDocsDirectory).
+		WithMountedDirectory("/replicated-docs/docs/reference", docsDirectory).
+		WithWorkdir("/replicated-docs").
+		WithExec([]string{"git", "diff"})
+	diffOut, err := docsContainer.Stdout(ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to get diff")
+	}
+
+	if diffOut == "" {
+		return errors.New("diff is empty")
+	}
+
+	githubTokenPlaintext, err := githubToken.Plaintext(ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to get github token plaintext")
+	}
+
+	branchName := fmt.Sprintf("update-cli-docs-%s-%s", latestVersion, time.Now().Format("202501221200"))
+	docsContainer = docsContainer.
+		WithExec([]string{"git", "config", "user.email", "release@replicated.com"}).
+		WithExec([]string{"git", "config", "user.name", "Replicated Release Pipeline"}).
+		WithExec([]string{"git", "remote", "add", "dagger", fmt.Sprintf("https://%s@github.com/replicatedhq/replicated-docs.git", githubTokenPlaintext)}).
+		WithExec([]string{"git", "checkout", "-b", branchName}).
+		WithExec([]string{"git", "add", "."}).
+		WithExec([]string{"git", "commit", "-m", fmt.Sprintf("Update Replicated CLI docs for %s", latestVersion)}).
+		WithExec([]string{"git", "push", "dagger", branchName})
+
+	_, err = docsContainer.Stdout(ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to get push output")
+	}
+
+	err = createPullRequest(ctx, branchName, fmt.Sprintf("Update Replicated CLI docs for %s", latestVersion), "", githubTokenPlaintext)
+	if err != nil {
+		return errors.Wrap(err, "failed to create pull request")
+	}
+
+	return nil
+}
+
+func replaceFilenamesInSidebar(sidebarContent string, newDocFilenames []string) (string, error) {
+	scanner := bufio.NewScanner(strings.NewReader(sidebarContent))
+
+	newDocLines := []string{}
+	foundCLILabel := false
+	wroteNewList := false
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// 'reference/replicated-cli-installing' is a special file that's not a CLI doc
+		if strings.Contains(line, `reference/replicated-cli-`) && !strings.Contains(line, `'reference/replicated-cli-installing'`) {
+			continue
+		}
+
+		if strings.Contains(line, `label: 'Replicated CLI'`) {
+			newDocLines = append(newDocLines, `    label: 'Replicated CLI', // This label is generated. Do not edit.`)
+			foundCLILabel = true
+			continue
+		}
+
+		if foundCLILabel && !wroteNewList && strings.Contains(line, `items: [`) {
+			newDocLines = append(newDocLines, `    items: [`)
+			newDocLines = append(newDocLines, `      // This list is generated. Do not edit.`)
+			for _, newDocFilename := range newDocFilenames {
+				newDocLines = append(newDocLines, fmt.Sprintf(`      'reference/%s',`, strings.TrimSuffix(newDocFilename, filepath.Ext(newDocFilename))))
+			}
+			wroteNewList = true
+			continue
+		}
+
+		newDocLines = append(newDocLines, line)
+	}
+
+	if !wroteNewList {
+		return "", fmt.Errorf("no CLI list found in sidebar")
+	}
+
+	return strings.Join(newDocLines, "\n"), nil
+}
+
+func createPullRequest(ctx context.Context, branchName string, title string, body string, githubTokenPlaintext string) error {
+	requestData := map[string]string{
+		"title": title,
+		"body":  body,
+		"head":  branchName,
+		"base":  "main",
+	}
+
+	requestBody, err := json.Marshal(requestData)
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal request data")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", "https://api.github.com/repos/replicatedhq/replicated-docs/pulls", bytes.NewReader(requestBody))
+	if err != nil {
+		return errors.Wrap(err, "failed to create pull request")
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", githubTokenPlaintext))
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return errors.Wrap(err, "failed to do pull request")
+	}
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return errors.Wrap(err, "failed to read response body")
+	}
+
+	if resp.StatusCode != http.StatusCreated {
+		return errors.Errorf("failed to create pull request: %s", string(respBody))
+	}
+
+	var pullRequest struct {
+		HTMLURL string `json:"html_url"`
+	}
+	if err := json.Unmarshal(respBody, &pullRequest); err != nil {
+		return errors.Wrap(err, "failed to unmarshal pull request")
+	}
+
+	fmt.Printf("created pull request at: %s\n", pullRequest.HTMLURL)
+
+	return nil
+}


### PR DESCRIPTION
Adds dagger function to generate docs. Running `make docs` will make a PR in the https://github.com/replicatedhq/replicated-docs repo

1. Dagger GenerateDocs function
2. Example indentations removed from Cobra cmd and replaced with `indent` sprig function
3. `Example` text moved from Long to Example fields of Cobra command
4. Clean up error handling in Dagger Release function (make it consistent)

2nd commit:
1. Moves "Installing replicated" topic to the top of the list
2. Replaces Cobra links with docs links in the "SEE ALSO" sections
3. Replaces .md extension with .mdx