### PR TITLE
Add network create cli support

### DIFF
--- a/cli/cmd/cluster_addon.go
+++ b/cli/cmd/cluster_addon.go
@@ -43,13 +43,13 @@ func waitForAddon(kotsRestClient *kotsclient.VendorV3Client, clusterID, id strin
 
 		if addon.Status == types.ClusterAddonStatusRunning {
 			return addon, nil
-		} else if addon.Status == types.ClusterAddonStatusError {
+		}
+		if addon.Status == types.ClusterAddonStatusError {
 			return nil, errors.New("cluster addon failed to provision")
-		} else {
-			if time.Now().After(start.Add(duration)) {
-				// In case of timeout, return the cluster and a WaitDurationExceeded error
-				return addon, ErrWaitDurationExceeded
-			}
+		}
+		if time.Now().After(start.Add(duration)) {
+			// In case of timeout, return the cluster and a WaitDurationExceeded error
+			return addon, ErrWaitDurationExceeded
 		}
 
 		time.Sleep(time.Second * 5)

--- a/cli/cmd/cluster_addon_create_objectstore.go
+++ b/cli/cmd/cluster_addon_create_objectstore.go
@@ -74,9 +74,7 @@ func (r *runners) clusterAddonCreateObjectStoreCreateRun() error {
 	addon, err := r.createAndWaitForClusterAddonCreateObjectStore(opts, r.args.clusterAddonCreateObjectStoreDuration)
 	if err != nil {
 		if errors.Cause(err) == ErrWaitDurationExceeded {
-			defer func() {
-				os.Exit(124)
-			}()
+			defer os.Exit(124)
 		} else {
 			return err
 		}

--- a/cli/cmd/cluster_create.go
+++ b/cli/cmd/cluster_create.go
@@ -156,9 +156,7 @@ func (r *runners) createCluster(cmd *cobra.Command, args []string) error {
 	cl, err := r.createAndWaitForCluster(opts)
 	if err != nil {
 		if errors.Cause(err) == ErrWaitDurationExceeded {
-			defer func() {
-				os.Exit(124)
-			}()
+			defer os.Exit(124)
 		} else {
 			return err
 		}
@@ -247,13 +245,13 @@ func waitForCluster(kotsRestClient *kotsclient.VendorV3Client, id string, durati
 
 		if cluster.Status == types.ClusterStatusRunning {
 			return cluster, nil
-		} else if cluster.Status == types.ClusterStatusError || cluster.Status == types.ClusterStatusUpgradeError {
+		}
+		if cluster.Status == types.ClusterStatusError || cluster.Status == types.ClusterStatusUpgradeError {
 			return nil, errors.New("cluster failed to provision")
-		} else {
-			if time.Now().After(start.Add(duration)) {
-				// In case of timeout, return the cluster and a WaitDurationExceeded error
-				return cluster, ErrWaitDurationExceeded
-			}
+		}
+		if time.Now().After(start.Add(duration)) {
+			// In case of timeout, return the cluster and a WaitDurationExceeded error
+			return cluster, ErrWaitDurationExceeded
 		}
 
 		time.Sleep(time.Second * 5)

--- a/cli/cmd/network_create.go
+++ b/cli/cmd/network_create.go
@@ -49,9 +49,7 @@ func (r *runners) createNetwork(_ *cobra.Command, args []string) error {
 	network, err := r.createAndWaitForNetwork(opts)
 	if err != nil {
 		if errors.Cause(err) == ErrVMWaitDurationExceeded {
-			defer func() {
-				os.Exit(124)
-			}()
+			defer os.Exit(124)
 		} else {
 			return err
 		}
@@ -100,13 +98,13 @@ func waitForNetwork(kotsRestClient *kotsclient.VendorV3Client, network *types.Ne
 
 		if network.Status == types.NetworkStatusRunning {
 			return network, nil
-		} else if network.Status == types.NetworkStatusError {
+		}
+		if network.Status == types.NetworkStatusError {
 			return nil, errors.New("network failed to provision")
-		} else {
-			if time.Now().After(start.Add(duration)) {
-				// In case of timeout, return the network and a WaitDurationExceeded error
-				return network, ErrWaitDurationExceeded
-			}
+		}
+		if time.Now().After(start.Add(duration)) {
+			// In case of timeout, return the network and a WaitDurationExceeded error
+			return network, ErrWaitDurationExceeded
 		}
 
 		time.Sleep(time.Second * 5)

--- a/cli/cmd/network_create.go
+++ b/cli/cmd/network_create.go
@@ -1,6 +1,16 @@
 package cmd
 
 import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/moby/moby/pkg/namesgenerator"
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/replicated/cli/print"
+	"github.com/replicatedhq/replicated/pkg/kotsclient"
+	"github.com/replicatedhq/replicated/pkg/platformclient"
+	"github.com/replicatedhq/replicated/pkg/types"
 	"github.com/spf13/cobra"
 )
 
@@ -14,9 +24,91 @@ func (r *runners) InitNetworkCreate(parent *cobra.Command) *cobra.Command {
 	}
 	parent.AddCommand(cmd)
 
+	cmd.Flags().StringVar(&r.args.createNetworkName, "name", "", "Network name (defaults to random name)")
+	cmd.Flags().StringVar(&r.args.createNetworkTTL, "ttl", "", "Network TTL (duration, max 48h)")
+	cmd.Flags().DurationVar(&r.args.createNetworkWaitDuration, "wait", time.Second*0, "Wait duration for Network to be ready (leave empty to not wait)")
+
+	cmd.Flags().BoolVar(&r.args.createNetworkDryRun, "dry-run", false, "Dry run")
+
+	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table|wide (default: table)")
+
 	return cmd
 }
 
 func (r *runners) createNetwork(_ *cobra.Command, args []string) error {
-	return nil
+	if r.args.createNetworkName == "" {
+		r.args.createNetworkName = namesgenerator.GetRandomName(0)
+	}
+
+	opts := kotsclient.CreateNetworkOpts{
+		Name:   r.args.createNetworkName,
+		TTL:    r.args.createNetworkTTL,
+		DryRun: r.args.createNetworkDryRun,
+	}
+
+	network, err := r.createAndWaitForNetwork(opts)
+	if err != nil {
+		if errors.Cause(err) == ErrVMWaitDurationExceeded {
+			defer func() {
+				os.Exit(124)
+			}()
+		} else {
+			return err
+		}
+	}
+
+	if opts.DryRun {
+		_, err = fmt.Fprintln(r.w, "Dry run succeeded.")
+		return err
+	}
+
+	return print.Network(r.outputFormat, r.w, network)
+
+}
+
+func (r *runners) createAndWaitForNetwork(opts kotsclient.CreateNetworkOpts) (*types.Network, error) {
+	network, ve, err := r.kotsAPI.CreateNetwork(opts)
+	if errors.Cause(err) == platformclient.ErrForbidden {
+		return nil, ErrCompatibilityMatrixTermsNotAccepted
+	} else if err != nil {
+		return nil, errors.Wrap(err, "create network")
+	}
+
+	if ve != nil && ve.Message != "" {
+		return nil, errors.New(ve.Message)
+	}
+
+	if opts.DryRun {
+		return network, nil
+	}
+
+	// if the wait flag was provided, we poll the api until the network is ready, or a timeout
+	if r.args.createNetworkWaitDuration > 0 {
+		return waitForNetwork(r.kotsAPI, network, r.args.createNetworkWaitDuration)
+	}
+
+	return network, nil
+}
+
+func waitForNetwork(kotsRestClient *kotsclient.VendorV3Client, network *types.Network, duration time.Duration) (*types.Network, error) {
+	start := time.Now()
+	for {
+		network, err := kotsRestClient.GetNetwork(network.ID)
+		if err != nil {
+			return nil, errors.Wrap(err, "get network")
+		}
+
+		if network.Status == types.NetworkStatusRunning {
+			return network, nil
+		} else if network.Status == types.NetworkStatusError {
+			return nil, errors.New("network failed to provision")
+		} else {
+			if time.Now().After(start.Add(duration)) {
+				// In case of timeout, return the network and a WaitDurationExceeded error
+				return network, ErrWaitDurationExceeded
+			}
+		}
+
+		time.Sleep(time.Second * 5)
+	}
 }

--- a/cli/cmd/network_ls.go
+++ b/cli/cmd/network_ls.go
@@ -111,7 +111,7 @@ func (r *runners) listNetworks(_ *cobra.Command, args []string) error {
 			// Check for removed networks and print them, changing their status to be "deleted"
 			for id, network := range oldNetworkMap {
 				if _, found := newNetworkMap[id]; !found {
-					network.Status = types.StatusDeleted
+					network.Status = types.NetworkStatusDeleted
 					networksToPrint = append(networksToPrint, network)
 				}
 			}

--- a/cli/cmd/runner.go
+++ b/cli/cmd/runner.go
@@ -236,6 +236,11 @@ type runnerArgs struct {
 	vmExposePortIsWildcard bool
 	vmPortRemoveAddonID    string
 
+	createNetworkName         string
+	createNetworkTTL          string
+	createNetworkWaitDuration time.Duration
+	createNetworkDryRun       bool
+
 	lsNetworkStartTime string
 	lsNetworkEndTime   string
 	lsNetworkWatch     bool

--- a/cli/cmd/vm_create.go
+++ b/cli/cmd/vm_create.go
@@ -78,6 +78,7 @@ func (r *runners) createVM(_ *cobra.Command, args []string) error {
 		Version:      r.args.createVMVersion,
 		Count:        r.args.createVMCount,
 		DiskGiB:      r.args.createVMDiskGiB,
+		Network:      r.args.createVMNetwork,
 		TTL:          r.args.createVMTTL,
 		InstanceType: r.args.createVMInstanceType,
 		Tags:         tags,

--- a/cli/cmd/vm_create.go
+++ b/cli/cmd/vm_create.go
@@ -88,9 +88,7 @@ func (r *runners) createVM(_ *cobra.Command, args []string) error {
 	vms, err := r.createAndWaitForVM(opts)
 	if err != nil {
 		if errors.Cause(err) == ErrVMWaitDurationExceeded {
-			defer func() {
-				os.Exit(124)
-			}()
+			defer os.Exit(124)
 		} else {
 			return err
 		}

--- a/cli/print/networks.go
+++ b/cli/print/networks.go
@@ -63,6 +63,30 @@ func Networks(outputFormat string, w *tabwriter.Writer, networks []*types.Networ
 	return w.Flush()
 }
 
+func Network(outputFormat string, w *tabwriter.Writer, network *types.Network) error {
+	switch outputFormat {
+	case "table":
+		if err := networksTmplTable.Execute(w, []*types.Network{network}); err != nil {
+			return err
+		}
+	case "wide":
+		if err := networksTmplWide.Execute(w, []*types.Network{network}); err != nil {
+			return err
+		}
+	case "json":
+		cAsByte, err := json.MarshalIndent([]*types.Network{network}, "", "  ")
+		if err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintln(w, string(cAsByte)); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("invalid output format: %s", outputFormat)
+	}
+	return w.Flush()
+}
+
 func NoNetworks(outputFormat string, w *tabwriter.Writer) error {
 	switch outputFormat {
 	case "table", "wide":

--- a/pkg/kotsclient/network_create.go
+++ b/pkg/kotsclient/network_create.go
@@ -1,0 +1,92 @@
+package kotsclient
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/replicated/pkg/platformclient"
+	"github.com/replicatedhq/replicated/pkg/types"
+)
+
+type CreateNetworkRequest struct {
+	Name string `json:"name"`
+	TTL  string `json:"ttl"`
+}
+
+type CreateNetworkResponse struct {
+	Network *types.Network `json:"network"`
+	Errors  []string       `json:"errors"`
+}
+
+type CreateNetworkDryRunResponse struct {
+	TTL   *string                 `json:"ttl"`
+	Error CreateNetworkErrorError `json:"error"`
+}
+
+type CreateNetworkOpts struct {
+	Name   string
+	TTL    string
+	DryRun bool
+}
+
+type CreateNetworkErrorResponse struct {
+	Error CreateNetworkErrorError `json:"error"`
+}
+
+type CreateNetworkErrorError struct {
+	Message string `json:"message"`
+}
+
+func (c *VendorV3Client) CreateNetwork(opts CreateNetworkOpts) (*types.Network, *CreateNetworkErrorError, error) {
+	req := CreateNetworkRequest{
+		Name: opts.Name,
+		TTL:  opts.TTL,
+	}
+
+	if opts.DryRun {
+		return c.doCreateNetworkDryRunRequest(req)
+	}
+	return c.doCreateNetworkRequest(req)
+}
+
+func (c *VendorV3Client) doCreateNetworkRequest(req CreateNetworkRequest) (*types.Network, *CreateNetworkErrorError, error) {
+	resp := CreateNetworkResponse{}
+	endpoint := "/v3/network"
+	err := c.DoJSON(context.TODO(), "POST", endpoint, http.StatusCreated, req, &resp)
+	if err != nil {
+		// if err is APIError and the status code is 400, then we have a validation error
+		// and we can return the validation error
+		if apiErr, ok := errors.Cause(err).(platformclient.APIError); ok {
+			if apiErr.StatusCode == http.StatusBadRequest {
+				veResp := &CreateNetworkErrorResponse{}
+				if jsonErr := json.Unmarshal(apiErr.Body, veResp); jsonErr != nil {
+					return nil, nil, fmt.Errorf("unmarshal validation error response: %w", err)
+				}
+				return nil, &veResp.Error, nil
+			}
+		}
+
+		return nil, nil, err
+	}
+
+	return resp.Network, nil, nil
+}
+
+func (c *VendorV3Client) doCreateNetworkDryRunRequest(req CreateNetworkRequest) (*types.Network, *CreateNetworkErrorError, error) {
+	resp := CreateNetworkDryRunResponse{}
+	endpoint := "/v3/network?dry-run=true"
+	err := c.DoJSON(context.TODO(), "POST", endpoint, http.StatusOK, req, &resp)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if resp.Error.Message != "" {
+		return nil, &resp.Error, nil
+	}
+	return &types.Network{
+		TTL: *resp.TTL,
+	}, nil, nil
+}

--- a/pkg/kotsclient/network_get.go
+++ b/pkg/kotsclient/network_get.go
@@ -1,0 +1,25 @@
+package kotsclient
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/replicatedhq/replicated/pkg/types"
+)
+
+type GetNetworkResponse struct {
+	Network *types.Network `json:"network"`
+	Error   string         `json:"error"`
+}
+
+func (c *VendorV3Client) GetNetwork(id string) (*types.Network, error) {
+	network := GetNetworkResponse{}
+
+	err := c.DoJSON(context.TODO(), "GET", fmt.Sprintf("/v3/network/%s", id), http.StatusOK, nil, &network)
+	if err != nil {
+		return nil, err
+	}
+
+	return network.Network, nil
+}

--- a/pkg/kotsclient/vm_create.go
+++ b/pkg/kotsclient/vm_create.go
@@ -17,6 +17,7 @@ type CreateVMRequest struct {
 	Version      string      `json:"version"`
 	Count        int         `json:"count"`
 	DiskGiB      int64       `json:"disk_gib"`
+	NetworkID    string      `json:"network_id"`
 	TTL          string      `json:"ttl"`
 	InstanceType string      `json:"instance_type"`
 	Tags         []types.Tag `json:"tags"`
@@ -40,6 +41,7 @@ type CreateVMOpts struct {
 	Version      string
 	Count        int
 	DiskGiB      int64
+	Network      string
 	TTL          string
 	InstanceType string
 	Tags         []types.Tag
@@ -68,6 +70,7 @@ func (c *VendorV3Client) CreateVM(opts CreateVMOpts) ([]*types.VM, *CreateVMErro
 		Version:      opts.Version,
 		Count:        opts.Count,
 		DiskGiB:      opts.DiskGiB,
+		NetworkID:    opts.Network,
 		TTL:          opts.TTL,
 		InstanceType: opts.InstanceType,
 		Tags:         opts.Tags,

--- a/pkg/types/network.go
+++ b/pkg/types/network.go
@@ -19,14 +19,14 @@ type Network struct {
 type NetworkStatus string
 
 const (
-	StatusQueued       NetworkStatus = "queued"       // Not assigned to a runner yet
-	StatusAssigned     NetworkStatus = "assigned"     // Assigned to a runner, but have not heard back from the runner
-	StatusPreparing    NetworkStatus = "preparing"    // The runner sets this when is receives the request
-	StatusProvisioning NetworkStatus = "provisioning" // The runner sets this when it starts provisioning
-	StatusVerifying    NetworkStatus = "verifying"    // The runner sets this when it is done provisioning and available
-	StatusRunning      NetworkStatus = "running"      // The runner sets this when it is done verifying and available
-	StatusDeleting     NetworkStatus = "deleting"     // The runner sets this when it is deleting the network
-	StatusDeleted      NetworkStatus = "deleted"      // The runner sets this when it has deleted the network
-	StatusTerminated   NetworkStatus = "terminated"   // This is set when the vm is moved to the history table
-	StatusError        NetworkStatus = "error"        // Something unexpected
+	NetworkStatusQueued       NetworkStatus = "queued"       // Not assigned to a runner yet
+	NetworkStatusAssigned     NetworkStatus = "assigned"     // Assigned to a runner, but have not heard back from the runner
+	NetworkStatusPreparing    NetworkStatus = "preparing"    // The runner sets this when is receives the request
+	NetworkStatusProvisioning NetworkStatus = "provisioning" // The runner sets this when it starts provisioning
+	NetworkStatusVerifying    NetworkStatus = "verifying"    // The runner sets this when it is done provisioning and available
+	NetworkStatusRunning      NetworkStatus = "running"      // The runner sets this when it is done verifying and available
+	NetworkStatusDeleting     NetworkStatus = "deleting"     // The runner sets this when it is deleting the network
+	NetworkStatusDeleted      NetworkStatus = "deleted"      // The runner sets this when it has deleted the network
+	NetworkStatusTerminated   NetworkStatus = "terminated"   // This is set when the vm is moved to the history table
+	NetworkStatusError        NetworkStatus = "error"        // Something unexpected
 )


### PR DESCRIPTION
Create a new network:
```
❯ replicated network create --ttl 1h
ID          NAME                           STATUS          CREATED                           EXPIRES
dbb9101a    unruffled_johnson              queued          2025-01-22 10:07 PST              -
```

List all networks:
```
❯ replicated network ls
ID          NAME                           STATUS          CREATED                           EXPIRES
dbb9101a    unruffled_johnson              running         2025-01-22 10:07 PST              2025-01-22 11:08 PST
8c9792ac    optimistic_shockley            running         2025-01-22 09:57 PST              2025-01-22 11:04 PST
```

Create a new vm, reusing an existing network:
```
❯ replicated vm create --distribution ubuntu --network dbb9101a
ID          NAME                           DISTRIBUTION    VERSION       STATUS          CREATED                           EXPIRES                           COST
f7cfc0ba    crazy_cray                     ubuntu          24.04         queued          2025-01-22 10:09 PST              -                                 $0.60
```

Associated Shortcut: [sc-116975](https://app.shortcut.com/replicated/story/116975/tailscale-set-each-tailnet-with-an-exit-node-and-make-tailscale0-be-the-default-route-interface)