### PR TITLE
Add CMX Update Network outbound behind feature flag

### DIFF
--- a/cli/cmd/network_update_outbound.go
+++ b/cli/cmd/network_update_outbound.go
@@ -46,7 +46,7 @@ func (r *runners) updateNetworkOutbound(cmd *cobra.Command, args []string) error
 		return ErrCompatibilityMatrixTermsNotAccepted
 	}
 	if err != nil {
-		return err
+		return errors.Wrap(err, "update network outbound")
 	}
 
 	return print.Network(r.outputFormat, r.w, network)

--- a/cli/cmd/network_update_outbound.go
+++ b/cli/cmd/network_update_outbound.go
@@ -44,8 +44,9 @@ func (r *runners) updateNetworkOutbound(cmd *cobra.Command, args []string) error
 	network, err := r.kotsAPI.UpdateNetworkOutbound(r.args.updateNetworkID, opts)
 	if errors.Cause(err) == platformclient.ErrForbidden {
 		return ErrCompatibilityMatrixTermsNotAccepted
-	} else if err != nil {
-		return errors.Wrap(err, "update network outbound")
+	}
+	if err != nil {
+		return err
 	}
 
 	return print.Network(r.outputFormat, r.w, network)

--- a/pkg/kotsclient/network_update_outbound.go
+++ b/pkg/kotsclient/network_update_outbound.go
@@ -2,9 +2,12 @@ package kotsclient
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/replicated/pkg/platformclient"
 	"github.com/replicatedhq/replicated/pkg/types"
 )
 
@@ -21,6 +24,12 @@ type UpdateNetworkOutboundOpts struct {
 	Outbound string
 }
 
+type UpdateNetworkOutboundErrorResponse struct {
+	Error struct {
+		Message string `json:"message"`
+	}
+}
+
 func (c *VendorV3Client) UpdateNetworkOutbound(networkID string, opts UpdateNetworkOutboundOpts) (*types.Network, error) {
 	req := UpdateNetworkOutboundRequest{
 		Outbound: opts.Outbound,
@@ -34,6 +43,17 @@ func (c *VendorV3Client) doUpdateNetworkOutboundRequest(networkID string, req Up
 	endpoint := fmt.Sprintf("/v3/network/%s/outbound", networkID)
 	err := c.DoJSON(context.TODO(), "PUT", endpoint, http.StatusOK, req, &resp)
 	if err != nil {
+		// if err is APIError and the status code is 400, then we have a validation error
+		// and we can return the validation error
+		if apiErr, ok := errors.Cause(err).(platformclient.APIError); ok {
+			if apiErr.StatusCode == http.StatusBadRequest {
+				errResp := &UpdateNetworkOutboundErrorResponse{}
+				if jsonErr := json.Unmarshal(apiErr.Body, errResp); jsonErr != nil {
+					return nil, fmt.Errorf("unmarshal error response: %w", err)
+				}
+				return nil, errors.New(errResp.Error.Message)
+			}
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
When the Air Gap feature is not enabled:
```
❯ replicated network update outbound --id b649e7a6 --outbound none
Error: Air Gap is not enabled. Contact Replicated to get more information.
```

When the Air Gap feature is enabled:
```
❯ replicated network update outbound --id b649e7a6 --outbound none
ID          NAME                           STATUS          CREATED                           EXPIRES                           OUTBOUND
b649e7a6    lucid_cannon                   running         2025-01-31 09:43 PST              2025-01-31 10:43 PST              none
```