### PR TITLE
feature(cmx): add network column to 'vm ls' and 'cluster ls'

### DIFF
--- a/cli/print/clusters.go
+++ b/cli/print/clusters.go
@@ -15,18 +15,18 @@ var clusterFuncs = template.FuncMap{
 }
 
 // Table formatting
-var clustersTmplTableHeaderSrc = `ID	NAME	DISTRIBUTION	VERSION	STATUS     NETWORK	CREATED	EXPIRES	COST`
+var clustersTmplTableHeaderSrc = `ID	NAME	DISTRIBUTION	VERSION	STATUS       NETWORK	CREATED	EXPIRES	COST`
 var clustersTmplTableRowSrc = `{{ range . -}}
-{{ .ID }}	{{ padding .Name 27	}}	{{ padding .KubernetesDistribution 12 }}	{{ padding .KubernetesVersion 10 }}	{{ padding (printf "%s" .Status) 10 }} {{ padding (printf "%.8s" .Network) 10 }}	{{ padding (printf "%s" (localeTime .CreatedAt)) 30 }}	{{if .ExpiresAt.IsZero}}{{ padding "-" 30 }}{{else}}{{ padding (printf "%s" (localeTime .ExpiresAt)) 30 }}{{end}}	{{ padding (CreditsToDollarsDisplay .EstimatedCost) 11 }}
+{{ .ID }}	{{ padding .Name 27	}}	{{ padding .KubernetesDistribution 12 }}	{{ padding .KubernetesVersion 10 }}	{{ padding (printf "%s" .Status) 12 }} {{ if .Network }}{{ padding (printf "%.8s" .Network) 8 }}{{else}}{{ padding "-" 8 }}{{end}}	{{ padding (printf "%s" (localeTime .CreatedAt)) 30 }}	{{if .ExpiresAt.IsZero}}{{ padding "-" 30 }}{{else}}{{ padding (printf "%s" (localeTime .ExpiresAt)) 30 }}{{end}}	{{ padding (CreditsToDollarsDisplay .EstimatedCost) 11 }}
 {{ end }}`
 var clustersTmplTableSrc = fmt.Sprintln(clustersTmplTableHeaderSrc) + clustersTmplTableRowSrc
 var clustersTmplTable = template.Must(template.New("clusters").Funcs(clusterFuncs).Funcs(funcs).Parse(clustersTmplTableSrc))
 var clustersTmplTableNoHeader = template.Must(template.New("clusters").Funcs(clusterFuncs).Funcs(funcs).Parse(clustersTmplTableRowSrc))
 
 // Wide table formatting
-var clustersTmplWideHeaderSrc = `ID	NAME	DISTRIBUTION	VERSION	STATUS     NETWORK	CREATED	EXPIRES	COST	TOTAL NODES	NODEGROUPS	TAGS`
+var clustersTmplWideHeaderSrc = `ID	NAME	DISTRIBUTION	VERSION	STATUS       NETWORK	CREATED	EXPIRES	COST	TOTAL NODES	NODEGROUPS	TAGS`
 var clustersTmplWideRowSrc = `{{ range . -}}
-{{ .ID }}	{{ padding .Name 27	}}	{{ padding .KubernetesDistribution 12 }}	{{ padding .KubernetesVersion 10 }}	{{ padding (printf "%s" .Status) 10 }} {{ padding (printf "%.8s" .Network) 10 }}	{{ padding (printf "%s" (localeTime .CreatedAt)) 30 }}	{{if .ExpiresAt.IsZero}}{{ padding "-" 30 }}{{else}}{{ padding (printf "%s" (localeTime .ExpiresAt)) 30 }}{{end}}	{{ padding (CreditsToDollarsDisplay .EstimatedCost) 11 }}	{{$nodecount:=0}}{{ range $index, $ng := .NodeGroups}}{{$nodecount = add $nodecount $ng.NodeCount}}{{ end }}{{ padding (printf "%d" $nodecount) 11 }}	{{ len .NodeGroups}}	{{ range $index, $tag := .Tags }}{{if $index}}, {{end}}{{ $tag.Key }}={{ $tag.Value }}{{ end }}
+{{ .ID }}	{{ padding .Name 27	}}	{{ padding .KubernetesDistribution 12 }}	{{ padding .KubernetesVersion 10 }}	{{ padding (printf "%s" .Status) 12 }} {{ if .Network }}{{ padding (printf "%.8s" .Network) 8 }}{{else}}{{ padding "-" 8 }}{{end}}	{{ padding (printf "%s" (localeTime .CreatedAt)) 30 }}	{{if .ExpiresAt.IsZero}}{{ padding "-" 30 }}{{else}}{{ padding (printf "%s" (localeTime .ExpiresAt)) 30 }}{{end}}	{{ padding (CreditsToDollarsDisplay .EstimatedCost) 11 }}	{{$nodecount:=0}}{{ range $index, $ng := .NodeGroups}}{{$nodecount = add $nodecount $ng.NodeCount}}{{ end }}{{ padding (printf "%d" $nodecount) 11 }}	{{ len .NodeGroups}}	{{ if eq (len .Tags) 0 }}{{ padding "-" 11 }}{{ else }}{{ range $index, $tag := .Tags }}{{if $index}}, {{end}}{{ $tag.Key }}={{ $tag.Value }}{{ end }}{{ end }}
 {{ end }}`
 var clustersTmplWideSrc = fmt.Sprintln(clustersTmplWideHeaderSrc) + clustersTmplWideRowSrc
 var clustersTmplWide = template.Must(template.New("clusters").Funcs(clusterFuncs).Funcs(funcs).Parse(clustersTmplWideSrc))

--- a/cli/print/clusters.go
+++ b/cli/print/clusters.go
@@ -15,18 +15,18 @@ var clusterFuncs = template.FuncMap{
 }
 
 // Table formatting
-var clustersTmplTableHeaderSrc = `ID	NAME	DISTRIBUTION	VERSION	STATUS	CREATED	EXPIRES	COST`
+var clustersTmplTableHeaderSrc = `ID	NAME	DISTRIBUTION	VERSION	STATUS     NETWORK	CREATED	EXPIRES	COST`
 var clustersTmplTableRowSrc = `{{ range . -}}
-{{ .ID }}	{{ padding .Name 27	}}	{{ padding .KubernetesDistribution 12 }}	{{ padding .KubernetesVersion 10 }}	{{ padding (printf "%s" .Status) 12 }}	{{ padding (printf "%s" (localeTime .CreatedAt)) 30 }}	{{if .ExpiresAt.IsZero}}{{ padding "-" 30 }}{{else}}{{ padding (printf "%s" (localeTime .ExpiresAt)) 30 }}{{end}}	{{ padding (CreditsToDollarsDisplay .EstimatedCost) 11 }}
+{{ .ID }}	{{ padding .Name 27	}}	{{ padding .KubernetesDistribution 12 }}	{{ padding .KubernetesVersion 10 }}	{{ padding (printf "%s" .Status) 10 }} {{ padding (printf "%.8s" .Network) 10 }}	{{ padding (printf "%s" (localeTime .CreatedAt)) 30 }}	{{if .ExpiresAt.IsZero}}{{ padding "-" 30 }}{{else}}{{ padding (printf "%s" (localeTime .ExpiresAt)) 30 }}{{end}}	{{ padding (CreditsToDollarsDisplay .EstimatedCost) 11 }}
 {{ end }}`
 var clustersTmplTableSrc = fmt.Sprintln(clustersTmplTableHeaderSrc) + clustersTmplTableRowSrc
 var clustersTmplTable = template.Must(template.New("clusters").Funcs(clusterFuncs).Funcs(funcs).Parse(clustersTmplTableSrc))
 var clustersTmplTableNoHeader = template.Must(template.New("clusters").Funcs(clusterFuncs).Funcs(funcs).Parse(clustersTmplTableRowSrc))
 
 // Wide table formatting
-var clustersTmplWideHeaderSrc = `ID	NAME	DISTRIBUTION	VERSION	STATUS	CREATED	EXPIRES	COST	TOTAL NODES	NODEGROUPS	TAGS`
+var clustersTmplWideHeaderSrc = `ID	NAME	DISTRIBUTION	VERSION	STATUS     NETWORK	CREATED	EXPIRES	COST	TOTAL NODES	NODEGROUPS	TAGS`
 var clustersTmplWideRowSrc = `{{ range . -}}
-{{ .ID }}	{{ padding .Name 27	}}	{{ padding .KubernetesDistribution 12 }}	{{ padding .KubernetesVersion 10 }}	{{ padding (printf "%s" .Status) 12 }}	{{ padding (printf "%s" (localeTime .CreatedAt)) 30 }}	{{if .ExpiresAt.IsZero}}{{ padding "-" 30 }}{{else}}{{ padding (printf "%s" (localeTime .ExpiresAt)) 30 }}{{end}}	{{ padding (CreditsToDollarsDisplay .EstimatedCost) 11 }}	{{$nodecount:=0}}{{ range $index, $ng := .NodeGroups}}{{$nodecount = add $nodecount $ng.NodeCount}}{{ end }}{{ padding (printf "%d" $nodecount) 11 }}	{{ len .NodeGroups}}	{{ range $index, $tag := .Tags }}{{if $index}}, {{end}}{{ $tag.Key }}={{ $tag.Value }}{{ end }}
+{{ .ID }}	{{ padding .Name 27	}}	{{ padding .KubernetesDistribution 12 }}	{{ padding .KubernetesVersion 10 }}	{{ padding (printf "%s" .Status) 10 }} {{ padding (printf "%.8s" .Network) 10 }}	{{ padding (printf "%s" (localeTime .CreatedAt)) 30 }}	{{if .ExpiresAt.IsZero}}{{ padding "-" 30 }}{{else}}{{ padding (printf "%s" (localeTime .ExpiresAt)) 30 }}{{end}}	{{ padding (CreditsToDollarsDisplay .EstimatedCost) 11 }}	{{$nodecount:=0}}{{ range $index, $ng := .NodeGroups}}{{$nodecount = add $nodecount $ng.NodeCount}}{{ end }}{{ padding (printf "%d" $nodecount) 11 }}	{{ len .NodeGroups}}	{{ range $index, $tag := .Tags }}{{if $index}}, {{end}}{{ $tag.Key }}={{ $tag.Value }}{{ end }}
 {{ end }}`
 var clustersTmplWideSrc = fmt.Sprintln(clustersTmplWideHeaderSrc) + clustersTmplWideRowSrc
 var clustersTmplWide = template.Must(template.New("clusters").Funcs(clusterFuncs).Funcs(funcs).Parse(clustersTmplWideSrc))

--- a/cli/print/vms.go
+++ b/cli/print/vms.go
@@ -15,18 +15,18 @@ var vmFuncs = template.FuncMap{
 }
 
 // Table formatting
-var vmsTmplTableHeaderSrc = `ID	NAME	DISTRIBUTION	VERSION	STATUS     NETWORK	CREATED	EXPIRES	COST`
+var vmsTmplTableHeaderSrc = `ID	NAME	DISTRIBUTION	VERSION	STATUS        NETWORK	CREATED	EXPIRES	COST`
 var vmsTmplTableRowSrc = `{{ range . -}}
-{{ .ID }}	{{ padding .Name 27	}}	{{ padding .Distribution 12 }}	{{ padding .Version 10 }}	{{ padding (printf "%s" .Status) 9 }}  {{ padding (printf "%.8s" .Network) 8 }} 	{{ padding (printf "%s" (localeTime .CreatedAt)) 30 }}	{{if .ExpiresAt.IsZero}}{{ padding "-" 30 }}{{else}}{{ padding (printf "%s" (localeTime .ExpiresAt)) 30 }}{{end}}	{{ padding (CreditsToDollarsDisplay .EstimatedCost) 11 }}
+{{ .ID }}	{{ padding .Name 27	}}	{{ padding .Distribution 12 }}	{{ padding .Version 10 }}	{{ padding (printf "%s" .Status) 12 }}  {{ if .Network }}{{ padding (printf "%.8s" .Network) 8 }}{{else}}{{ padding "-" 8 }}{{end}} 	{{ padding (printf "%s" (localeTime .CreatedAt)) 30 }}	{{if .ExpiresAt.IsZero}}{{ padding "-" 30 }}{{else}}{{ padding (printf "%s" (localeTime .ExpiresAt)) 30 }}{{end}}	{{ padding (CreditsToDollarsDisplay .EstimatedCost) 11 }}
 {{ end }}`
 var vmsTmplTableSrc = fmt.Sprintln(vmsTmplTableHeaderSrc) + vmsTmplTableRowSrc
 var vmsTmplTable = template.Must(template.New("vms").Funcs(vmFuncs).Funcs(funcs).Parse(vmsTmplTableSrc))
 var vmsTmplTableNoHeader = template.Must(template.New("vms").Funcs(vmFuncs).Funcs(funcs).Parse(vmsTmplTableRowSrc))
 
 // Wide table formatting
-var vmsTmplWideHeaderSrc = `ID	NAME	DISTRIBUTION	VERSION	STATUS     NETWORK	CREATED	EXPIRES	COST	TAGS`
+var vmsTmplWideHeaderSrc = `ID	NAME	DISTRIBUTION	VERSION	STATUS        NETWORK	CREATED	EXPIRES	COST	TAGS`
 var vmsTmplWideRowSrc = `{{ range . -}}
-{{ .ID }}	{{ padding .Name 27	}}	{{ padding .Distribution 12 }}	{{ padding .Version 10 }}	{{ padding (printf "%s" .Status) 9 }}  {{ padding (printf "%.8s" .Network) 8 }} 	{{ padding (printf "%s" (localeTime .CreatedAt)) 30 }}	{{if .ExpiresAt.IsZero}}{{ padding "-" 30 }}{{else}}{{ padding (printf "%s" (localeTime .ExpiresAt)) 30 }}{{end}}	{{ padding (CreditsToDollarsDisplay .EstimatedCost) 11 }}	{{ range $index, $tag := .Tags }}{{if $index}}, {{end}}{{ $tag.Key }}={{ $tag.Value }}{{ end }}
+{{ .ID }}	{{ padding .Name 27	}}	{{ padding .Distribution 12 }}	{{ padding .Version 10 }}	{{ padding (printf "%s" .Status) 12 }}  {{ if .Network }}{{ padding (printf "%.8s" .Network) 8 }}{{else}}{{ padding "-" 8 }}{{end}} 	{{ padding (printf "%s" (localeTime .CreatedAt)) 30 }}	{{if .ExpiresAt.IsZero}}{{ padding "-" 30 }}{{else}}{{ padding (printf "%s" (localeTime .ExpiresAt)) 30 }}{{end}}	{{ padding (CreditsToDollarsDisplay .EstimatedCost) 11 }}	{{ if eq (len .Tags) 0 }}{{ padding "-" 11 }}{{ else }}{{ range $index, $tag := .Tags }}{{if $index}}, {{end}}{{ $tag.Key }}={{ $tag.Value }}{{ end }}{{ end }}
 {{ end }}`
 var vmsTmplWideSrc = fmt.Sprintln(vmsTmplWideHeaderSrc) + vmsTmplWideRowSrc
 var vmsTmplWide = template.Must(template.New("vms").Funcs(vmFuncs).Funcs(funcs).Parse(vmsTmplWideSrc))

--- a/cli/print/vms.go
+++ b/cli/print/vms.go
@@ -15,18 +15,18 @@ var vmFuncs = template.FuncMap{
 }
 
 // Table formatting
-var vmsTmplTableHeaderSrc = `ID	NAME	DISTRIBUTION	VERSION	STATUS	CREATED	EXPIRES	COST`
+var vmsTmplTableHeaderSrc = `ID	NAME	DISTRIBUTION	VERSION	STATUS     NETWORK	CREATED	EXPIRES	COST`
 var vmsTmplTableRowSrc = `{{ range . -}}
-{{ .ID }}	{{ padding .Name 27	}}	{{ padding .Distribution 12 }}	{{ padding .Version 10 }}	{{ padding (printf "%s" .Status) 12 }}	{{ padding (printf "%s" (localeTime .CreatedAt)) 30 }}	{{if .ExpiresAt.IsZero}}{{ padding "-" 30 }}{{else}}{{ padding (printf "%s" (localeTime .ExpiresAt)) 30 }}{{end}}	{{ padding (CreditsToDollarsDisplay .EstimatedCost) 11 }}
+{{ .ID }}	{{ padding .Name 27	}}	{{ padding .Distribution 12 }}	{{ padding .Version 10 }}	{{ padding (printf "%s" .Status) 9 }}  {{ padding (printf "%.8s" .Network) 8 }} 	{{ padding (printf "%s" (localeTime .CreatedAt)) 30 }}	{{if .ExpiresAt.IsZero}}{{ padding "-" 30 }}{{else}}{{ padding (printf "%s" (localeTime .ExpiresAt)) 30 }}{{end}}	{{ padding (CreditsToDollarsDisplay .EstimatedCost) 11 }}
 {{ end }}`
 var vmsTmplTableSrc = fmt.Sprintln(vmsTmplTableHeaderSrc) + vmsTmplTableRowSrc
 var vmsTmplTable = template.Must(template.New("vms").Funcs(vmFuncs).Funcs(funcs).Parse(vmsTmplTableSrc))
 var vmsTmplTableNoHeader = template.Must(template.New("vms").Funcs(vmFuncs).Funcs(funcs).Parse(vmsTmplTableRowSrc))
 
 // Wide table formatting
-var vmsTmplWideHeaderSrc = `ID	NAME	DISTRIBUTION	VERSION	STATUS	CREATED	EXPIRES	COST	TAGS`
+var vmsTmplWideHeaderSrc = `ID	NAME	DISTRIBUTION	VERSION	STATUS     NETWORK	CREATED	EXPIRES	COST	TAGS`
 var vmsTmplWideRowSrc = `{{ range . -}}
-{{ .ID }}	{{ padding .Name 27	}}	{{ padding .Distribution 12 }}	{{ padding .Version 10 }}	{{ padding (printf "%s" .Status) 12 }}	{{ padding (printf "%s" (localeTime .CreatedAt)) 30 }}	{{if .ExpiresAt.IsZero}}{{ padding "-" 30 }}{{else}}{{ padding (printf "%s" (localeTime .ExpiresAt)) 30 }}{{end}}	{{ padding (CreditsToDollarsDisplay .EstimatedCost) 11 }}	{{ range $index, $tag := .Tags }}{{if $index}}, {{end}}{{ $tag.Key }}={{ $tag.Value }}{{ end }}
+{{ .ID }}	{{ padding .Name 27	}}	{{ padding .Distribution 12 }}	{{ padding .Version 10 }}	{{ padding (printf "%s" .Status) 9 }}  {{ padding (printf "%.8s" .Network) 8 }} 	{{ padding (printf "%s" (localeTime .CreatedAt)) 30 }}	{{if .ExpiresAt.IsZero}}{{ padding "-" 30 }}{{else}}{{ padding (printf "%s" (localeTime .ExpiresAt)) 30 }}{{end}}	{{ padding (CreditsToDollarsDisplay .EstimatedCost) 11 }}	{{ range $index, $tag := .Tags }}{{if $index}}, {{end}}{{ $tag.Key }}={{ $tag.Value }}{{ end }}
 {{ end }}`
 var vmsTmplWideSrc = fmt.Sprintln(vmsTmplWideHeaderSrc) + vmsTmplWideRowSrc
 var vmsTmplWide = template.Must(template.New("vms").Funcs(vmFuncs).Funcs(funcs).Parse(vmsTmplWideSrc))

--- a/pkg/types/cluster.go
+++ b/pkg/types/cluster.go
@@ -25,6 +25,7 @@ type Cluster struct {
 	NodeGroups             []*NodeGroup `json:"node_groups"`
 
 	Status    ClusterStatus `json:"status"`
+	Network   string        `json:"network_id"`
 	CreatedAt time.Time     `json:"created_at"`
 	ExpiresAt time.Time     `json:"expires_at"`
 

--- a/pkg/types/vm.go
+++ b/pkg/types/vm.go
@@ -7,6 +7,7 @@ type VM struct {
 	Name         string `json:"name"`
 	Distribution string `json:"distribution"`
 	Version      string `json:"version"`
+	Network      string `json:"network_id"`
 
 	Status    VMStatus  `json:"status"`
 	CreatedAt time.Time `json:"created_at"`


### PR DESCRIPTION
The network column prints the short "network_id" affiliated with the VM or cluster.

## Before
```
$  replicated vm ls
ID          NAME                           DISTRIBUTION    VERSION       STATUS          CREATED                           EXPIRES                           COST
cef438fe    affectionate_wescoff           ubuntu          24.04         running         2025-02-19 11:40 PST              2025-02-19 15:40 PST              $0.88

$  replicated vm ls --output wide
ID          NAME                           DISTRIBUTION    VERSION       STATUS          CREATED                           EXPIRES                           COST           TAGS
cef438fe    affectionate_wescoff           ubuntu          24.04         running         2025-02-19 11:40 PST              2025-02-19 15:40 PST              $0.88

$ replicated cluster ls
ID          NAME                           DISTRIBUTION    VERSION       STATUS          CREATED                           EXPIRES                           COST
79578f57    kind-test                      kind            1.32.1        running         2025-02-19 11:17 PST              2025-02-19 12:20 PST              $0.60

$ replicated cluster ls --output wide
ID          NAME                           DISTRIBUTION    VERSION       STATUS          CREATED                           EXPIRES                           COST           TOTAL NODES    NODEGROUPS    TAGS
79578f57    kind-test                      kind            1.32.1        running         2025-02-19 11:17 PST              2025-02-19 12:20 PST              $0.60          1              1
```

## After

```
$ ./bin/replicated vm ls
ID          NAME                           DISTRIBUTION    VERSION       STATUS     NETWORK      CREATED                           EXPIRES                           COST
cef438fe    affectionate_wescoff           ubuntu          24.04         running    89c8e80b     2025-02-19 11:40 PST              2025-02-19 15:40 PST              $0.88

$ ./bin/replicated vm ls --output wide
ID          NAME                           DISTRIBUTION    VERSION       STATUS     NETWORK      CREATED                           EXPIRES                           COST           TAGS
cef438fe    affectionate_wescoff           ubuntu          24.04         running    89c8e80b     2025-02-19 11:40 PST              2025-02-19 15:40 PST              $0.88

$  ./bin/replicated cluster ls
ID          NAME                           DISTRIBUTION    VERSION       STATUS     NETWORK       CREATED                           EXPIRES                           COST
79578f57    kind-test                      kind            1.32.1        running    bf4e5dcc      2025-02-19 11:17 PST              2025-02-19 12:20 PST              $0.60

$ ./bin/replicated cluster ls --output wide
ID          NAME                           DISTRIBUTION    VERSION       STATUS     NETWORK       CREATED                           EXPIRES                           COST           TOTAL NODES    NODEGROUPS    TAGS
79578f57    kind-test                      kind            1.32.1        running    bf4e5dcc      2025-02-19 11:17 PST              2025-02-19 12:20 PST              $0.60          1              1
```