### PR TITLE
Add ssh and scp subcommand

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -252,7 +252,6 @@ func Execute(rootCmd *cobra.Command, stdin io.Reader, stdout io.Writer, stderr i
 	runCmds.InitVMVersions(vmCmd)
 	runCmds.InitVMRemove(vmCmd)
 	runCmds.InitVMSSH(vmCmd)
-	runCmds.InitVMSCP(vmCmd)
 	vmUpdateCmd := runCmds.InitVMUpdateCommand(vmCmd)
 	runCmds.InitVMUpdateTTL(vmUpdateCmd)
 

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -252,6 +252,7 @@ func Execute(rootCmd *cobra.Command, stdin io.Reader, stdout io.Writer, stderr i
 	runCmds.InitVMVersions(vmCmd)
 	runCmds.InitVMRemove(vmCmd)
 	runCmds.InitVMSSH(vmCmd)
+	runCmds.InitVMSCP(vmCmd)
 	vmUpdateCmd := runCmds.InitVMUpdateCommand(vmCmd)
 	runCmds.InitVMUpdateTTL(vmUpdateCmd)
 

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -251,7 +251,7 @@ func Execute(rootCmd *cobra.Command, stdin io.Reader, stdout io.Writer, stderr i
 	runCmds.InitVMList(vmCmd)
 	runCmds.InitVMVersions(vmCmd)
 	runCmds.InitVMRemove(vmCmd)
-
+	runCmds.InitVMSSH(vmCmd)
 	vmUpdateCmd := runCmds.InitVMUpdateCommand(vmCmd)
 	runCmds.InitVMUpdateTTL(vmUpdateCmd)
 
@@ -265,7 +265,7 @@ func Execute(rootCmd *cobra.Command, stdin io.Reader, stdout io.Writer, stderr i
 	runCmds.InitNetworkList(networkCmd)
 	runCmds.InitNetworkRemove(networkCmd)
 	runCmds.InitNetworkJoin(networkCmd)
-	
+
 	networkUpdateCmd := runCmds.InitNetworkUpdateCommand(networkCmd)
 	runCmds.InitNetworkUpdateOutbound(networkUpdateCmd)
 

--- a/cli/cmd/vm.go
+++ b/cli/cmd/vm.go
@@ -22,7 +22,13 @@ replicated vm ls
 replicated vm rm <vm-id>
 
 # Update TTL for a specific VM
-replicated vm update ttl <vm-id> --ttl 24h`,
+replicated vm update ttl <vm-id> --ttl 24h
+
+# SSH into a VM
+replicated vm ssh <vm-id>
+
+# Copy files to/from a VM
+replicated vm scp localfile.txt <vm-id>:/path/on/vm/`,
 	}
 	parent.AddCommand(cmd)
 

--- a/cli/cmd/vm.go
+++ b/cli/cmd/vm.go
@@ -22,13 +22,7 @@ replicated vm ls
 replicated vm rm <vm-id>
 
 # Update TTL for a specific VM
-replicated vm update ttl <vm-id> --ttl 24h
-
-# SSH into a VM
-replicated vm ssh <vm-id>
-
-# Copy files to/from a VM
-replicated vm scp localfile.txt <vm-id>:/path/on/vm/`,
+replicated vm update ttl <vm-id> --ttl 24h`,
 	}
 	parent.AddCommand(cmd)
 

--- a/cli/cmd/vm_scp.go
+++ b/cli/cmd/vm_scp.go
@@ -1,0 +1,156 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/replicated/pkg/kotsclient"
+	"github.com/replicatedhq/replicated/pkg/types"
+	"github.com/spf13/cobra"
+)
+
+func (r *runners) InitVMSCP(parent *cobra.Command) *cobra.Command {
+	var sshUser string
+
+	cmd := &cobra.Command{
+		Use:   "scp [VM_ID:]SOURCE [VM_ID:]DESTINATION",
+		Short: "Copy files to/from a VM",
+		Long: `Securely copy files to or from a VM using SCP.
+
+This command allows you to copy files between your local machine and a VM. You can specify the VM ID followed by a colon and the path on the VM, or just a local path.
+
+To copy a file from your local machine to a VM, use:
+replicated vm scp localfile.txt vm-id:/path/on/vm/
+
+To copy a file from a VM to your local machine, use:
+replicated vm scp vm-id:/path/on/vm/file.txt localfile.txt
+
+If no VM ID is provided and multiple VMs are available, you will be prompted to select a VM.
+
+The SSH user can be specified in order of precedence:
+1. By specifying the -u flag
+2. REPLICATED_SSH_USER environment variable
+3. GITHUB_ACTOR environment variable (from GitHub Actions)
+4. GITHUB_USER environment variable
+
+Note: Only running VMs can be connected to via SCP.`,
+		Example: `# Copy a local file to a VM
+replicated vm scp localfile.txt vm-id:/home/user/
+
+# Copy a file from a VM to local machine
+replicated vm scp vm-id:/home/user/file.txt localfile.txt
+
+# Copy with a specific user
+replicated vm scp -u myuser localfile.txt vm-id:/home/myuser/
+
+# Interactive VM selection (if VM ID is not specified)
+replicated vm scp localfile.txt :/home/user/`,
+		RunE: r.scpVM,
+		Args: cobra.ExactArgs(2),
+	}
+	parent.AddCommand(cmd)
+
+	cmd.Flags().StringVarP(&sshUser, "user", "u", "", "SSH user to connect with")
+
+	return cmd
+}
+
+func (r *runners) scpVM(cmd *cobra.Command, args []string) error {
+	if err := r.initVMClient(); err != nil {
+		return err
+	}
+
+	sshUser, _ := cmd.Flags().GetString("user")
+	source := args[0]
+	destination := args[1]
+
+	// Parse source and destination to determine if they contain VM IDs
+	sourceVMID, sourcePath, sourceIsRemote := parseScpPath(source)
+	destVMID, destPath, destIsRemote := parseScpPath(destination)
+
+	// Ensure we're not trying to copy between two VMs
+	if sourceIsRemote && destIsRemote {
+		return errors.New("copying between two VMs is not supported. Please copy to your local machine first")
+	}
+
+	// Ensure we're copying either to or from a VM
+	if !sourceIsRemote && !destIsRemote {
+		return errors.New("at least one of source or destination must be a VM path (prefixed with VM_ID:)")
+	}
+
+	// Handle the case where we need to select a VM
+	if sourceIsRemote && sourceVMID == "" {
+		selectedVM, err := selectRunningVM(r.kotsAPI)
+		if err != nil {
+			return err
+		}
+		sourceVMID = selectedVM.ID
+	}
+
+	if destIsRemote && destVMID == "" {
+		selectedVM, err := selectRunningVM(r.kotsAPI)
+		if err != nil {
+			return err
+		}
+		destVMID = selectedVM.ID
+	}
+
+	// Execute the appropriate SCP command
+	if sourceIsRemote {
+		// Copy from VM to local
+		return r.kotsAPI.SCPFromVM(sourceVMID, sshUser, sourcePath, destPath)
+	} else {
+		// Copy from local to VM
+		return r.kotsAPI.SCPToVM(destVMID, sshUser, sourcePath, destPath)
+	}
+}
+
+// parseScpPath parses a path string to determine if it contains a VM ID
+// Returns vmID, path, and whether the path is remote (on a VM)
+func parseScpPath(path string) (string, string, bool) {
+	for i, c := range path {
+		if c == ':' {
+			if i == 0 {
+				// Path starts with a colon, indicating an empty VM ID (for selection)
+				return "", path[i+1:], true
+			}
+			return path[:i], path[i+1:], true
+		}
+	}
+	return "", path, false
+}
+
+// selectRunningVM prompts the user to select a running VM
+func selectRunningVM(kotsAPI *kotsclient.VendorV3Client) (*types.VM, error) {
+	vms, err := kotsAPI.ListVMs(false, nil, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list VMs")
+	}
+
+	// Filter to only show running VMs
+	runningVMs := filterVMsByStatus(vms, types.VMStatusRunning)
+	if len(runningVMs) == 0 {
+		// Show information about non-running VMs if they exist
+		nonTerminatedVMs := filterVMsByStatus(vms, "")
+		if len(nonTerminatedVMs) == 0 {
+			return nil, errors.New("no active VMs found")
+		}
+
+		// List non-running VMs with their statuses
+		fmt.Println("No running VMs found. The following VMs are available but not running:")
+		for _, vm := range nonTerminatedVMs {
+			if vm.Status != types.VMStatusTerminated {
+				fmt.Printf("  - %s (ID: %s, Status: %s)\n", vm.Name, vm.ID, vm.Status)
+			}
+		}
+		return nil, errors.New("SCP connection requires a running VM. Please start a VM before connecting")
+	}
+
+	// If only one running VM, use it directly
+	if len(runningVMs) == 1 {
+		return runningVMs[0], nil
+	}
+
+	// Create VM selection prompt for running VMs
+	return selectVM(runningVMs)
+}

--- a/cli/cmd/vm_scp.go
+++ b/cli/cmd/vm_scp.go
@@ -146,11 +146,6 @@ func selectRunningVM(kotsAPI *kotsclient.VendorV3Client) (*types.VM, error) {
 		return nil, errors.New("SCP connection requires a running VM. Please start a VM before connecting")
 	}
 
-	// If only one running VM, use it directly
-	if len(runningVMs) == 1 {
-		return runningVMs[0], nil
-	}
-
-	// Create VM selection prompt for running VMs
+	// Always prompt for VM selection, even if there's only one VM
 	return selectVM(runningVMs)
 }

--- a/cli/cmd/vm_ssh.go
+++ b/cli/cmd/vm_ssh.go
@@ -20,7 +20,7 @@ func (r *runners) InitVMSSH(parent *cobra.Command) *cobra.Command {
 If a VM ID is provided, it will directly connect to that VM. Otherwise, if multiple VMs are available, you will be prompted to select the VM you want to connect to. The command will then establish an SSH connection to the selected VM using the appropriate credentials and configuration.
 
 The SSH user can be specified in order of precedence:
-1. -u flag
+1. By specifying the -u flag
 2. REPLICATED_SSH_USER environment variable
 3. GITHUB_ACTOR environment variable (from GitHub Actions)
 4. GITHUB_USER environment variable

--- a/cli/cmd/vm_ssh.go
+++ b/cli/cmd/vm_ssh.go
@@ -90,7 +90,7 @@ func (r *runners) sshVM(cmd *cobra.Command, args []string) error {
 				fmt.Printf("  - %s (ID: %s, Status: %s)\n", vm.Name, vm.ID, vm.Status)
 			}
 		}
-		return fmt.Errorf("SSH connection requires a running VM. Please start a VM before connecting")
+		return errors.New("SSH connection requires a running VM. Please start a VM before connecting")
 	}
 
 	// If only one running VM, use it directly

--- a/cli/cmd/vm_ssh.go
+++ b/cli/cmd/vm_ssh.go
@@ -1,0 +1,110 @@
+package cmd
+
+import (
+	"github.com/manifoldco/promptui"
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/replicated/pkg/types"
+	"github.com/spf13/cobra"
+)
+
+func (r *runners) InitVMSSH(parent *cobra.Command) *cobra.Command {
+	var sshUser string
+
+	cmd := &cobra.Command{
+		Use:   "ssh [VM_ID]",
+		Short: "SSH into a VM",
+		Long: `Connect to a VM using SSH.
+
+If a VM ID is provided, it will directly connect to that VM. Otherwise, if multiple VMs are available, you will be prompted to select the VM you want to connect to. The command will then establish an SSH connection to the selected VM using the appropriate credentials and configuration.
+
+The SSH user can be specified in order of precedence:
+1. -u flag
+2. REPLICATED_SSH_USER environment variable
+3. GITHUB_ACTOR environment variable (from GitHub Actions)
+4. GITHUB_USER environment variable`,
+		Example: `# SSH into a specific VM by ID
+replicated vm ssh <id>
+
+# SSH into a VM with a specific user
+replicated vm ssh <id> -u myuser
+
+# SSH into a VM (interactive selection if multiple VMs exist)
+replicated vm ssh`,
+		RunE:              r.sshVM,
+		Args:              cobra.MaximumNArgs(1),
+		ValidArgsFunction: r.completeVMIDs,
+	}
+	parent.AddCommand(cmd)
+
+	cmd.Flags().StringVarP(&sshUser, "user", "u", "", "SSH user to connect with")
+
+	return cmd
+}
+
+func (r *runners) sshVM(cmd *cobra.Command, args []string) error {
+	if err := r.initVMClient(); err != nil {
+		return err
+	}
+
+	sshUser, _ := cmd.Flags().GetString("user")
+
+	// If VM ID is provided, directly SSH into it
+	if len(args) == 1 {
+		return r.kotsAPI.SSHIntoVM(args[0], sshUser)
+	}
+
+	vms, err := r.kotsAPI.ListVMs(false, nil, nil)
+	if err != nil {
+		return errors.Wrap(err, "failed to list VMs")
+	}
+
+	// Filter out terminated VMs
+	activeVMs := filterActiveVMs(vms)
+	if len(activeVMs) == 0 {
+		return errors.New("no active VMs found")
+	}
+
+	// If only one VM, use it directly
+	if len(activeVMs) == 1 {
+		return r.kotsAPI.SSHIntoVM(activeVMs[0].ID, sshUser)
+	}
+
+	// Create VM selection prompt
+	selectedVM, err := selectVM(activeVMs)
+	if err != nil {
+		return errors.Wrap(err, "failed to select VM")
+	}
+
+	return r.kotsAPI.SSHIntoVM(selectedVM.ID, sshUser)
+}
+
+// filterActiveVMs returns a slice of non-terminated VMs
+func filterActiveVMs(vms []*types.VM) []*types.VM {
+	var activeVMs []*types.VM
+	for _, vm := range vms {
+		if vm.Status != types.VMStatusTerminated {
+			activeVMs = append(activeVMs, vm)
+		}
+	}
+	return activeVMs
+}
+
+// selectVM prompts the user to select a VM from the list
+func selectVM(vms []*types.VM) (*types.VM, error) {
+	var vmOptions []string
+	for _, vm := range vms {
+		vmOptions = append(vmOptions, vm.Name)
+	}
+
+	prompt := promptui.Select{
+		Label: "Select VM to connect to",
+		Items: vmOptions,
+	}
+
+	index, _, err := prompt.Run()
+	if err != nil {
+		return nil, err
+	}
+
+	return vms[index], nil
+}

--- a/cli/cmd/vm_ssh.go
+++ b/cli/cmd/vm_ssh.go
@@ -93,7 +93,7 @@ func (r *runners) sshVM(cmd *cobra.Command, args []string) error {
 		fmt.Println("No running VMs found. The following VMs are available but not running:")
 		for _, vm := range nonTerminatedVMs {
 			if vm.Status != types.VMStatusTerminated {
-				fmt.Printf("  - %s (ID: %s, Status: %s)\n", vm.Name, vm.ID, vm.Status)
+				fmt.Printf("  • %s (ID: %s, Status: %s)\n", vm.Name, vm.ID, vm.Status)
 			}
 		}
 		return errors.New("SSH connection requires a running VM. Please start a VM before connecting")

--- a/cli/cmd/vm_ssh.go
+++ b/cli/cmd/vm_ssh.go
@@ -93,12 +93,7 @@ func (r *runners) sshVM(cmd *cobra.Command, args []string) error {
 		return errors.New("SSH connection requires a running VM. Please start a VM before connecting")
 	}
 
-	// If only one running VM, use it directly
-	if len(runningVMs) == 1 {
-		return r.kotsAPI.SSHIntoVM(runningVMs[0].ID, sshUser)
-	}
-
-	// Create VM selection prompt for running VMs
+	// Always prompt for VM selection, even if there's only one VM
 	selectedVM, err := selectVM(runningVMs)
 	if err != nil {
 		return errors.Wrap(err, "failed to select VM")

--- a/pkg/kotsclient/vm_common.go
+++ b/pkg/kotsclient/vm_common.go
@@ -1,0 +1,52 @@
+package kotsclient
+
+import (
+	"fmt"
+	"os"
+)
+
+// SSHConnectionInfo contains the information needed to connect to a VM via SSH or SCP
+type SSHConnectionInfo struct {
+	Endpoint string
+	Port     int64
+	User     string
+}
+
+// GetSSHConnectionInfo returns the SSH connection information for a VM
+func (c *VendorV3Client) GetSSHConnectionInfo(vmID string, sshUserFlag string) (*SSHConnectionInfo, error) {
+	vm, err := c.GetVM(vmID)
+	if err != nil {
+		return nil, err
+	}
+
+	if vm.DirectSSHEndpoint == "" || vm.DirectSSHPort == 0 {
+		return nil, fmt.Errorf("VM %s does not have SSH access configured", vmID)
+	}
+
+	// Try to get the SSH user in order of precedence
+	sshUser := getSSHUser(sshUserFlag)
+
+	return &SSHConnectionInfo{
+		Endpoint: vm.DirectSSHEndpoint,
+		Port:     vm.DirectSSHPort,
+		User:     sshUser,
+	}, nil
+}
+
+// getSSHUser returns the SSH user based on the provided flag and environment variables
+func getSSHUser(sshUserFlag string) string {
+	// Try to get the SSH user in order of precedence
+	if sshUserFlag != "" {
+		return sshUserFlag
+	}
+	if user := os.Getenv("REPLICATED_SSH_USER"); user != "" {
+		return user
+	}
+	if user := os.Getenv("GITHUB_ACTOR"); user != "" {
+		return user
+	}
+	if user := os.Getenv("GITHUB_USER"); user != "" {
+		return user
+	}
+	return ""
+}

--- a/pkg/kotsclient/vm_scp.go
+++ b/pkg/kotsclient/vm_scp.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-
-	"github.com/replicatedhq/replicated/pkg/types"
 )
 
 // SCPToVM copies a file to a VM using SCP
@@ -17,11 +15,6 @@ func (c *VendorV3Client) SCPToVM(vmID string, sshUserFlag string, localPath stri
 
 	if vm.DirectSSHEndpoint == "" || vm.DirectSSHPort == 0 {
 		return fmt.Errorf("VM %s does not have SSH access configured", vmID)
-	}
-
-	// Check if VM is running
-	if vm.Status != types.VMStatusRunning {
-		return fmt.Errorf("VM %s is not running (current status: %s). SCP connection requires a running VM", vmID, vm.Status)
 	}
 
 	// Try to get the SSH user in order of precedence
@@ -50,19 +43,14 @@ func (c *VendorV3Client) SCPToVM(vmID string, sshUserFlag string, localPath stri
 }
 
 // SCPFromVM copies a file from a VM using SCP
-func (c *VendorV3Client) SCPFromVM(id string, sshUserFlag string, remotePath string, localPath string) error {
-	vm, err := c.GetVM(id)
+func (c *VendorV3Client) SCPFromVM(vmID string, sshUserFlag string, remotePath string, localPath string) error {
+	vm, err := c.GetVM(vmID)
 	if err != nil {
 		return err
 	}
 
 	if vm.DirectSSHEndpoint == "" || vm.DirectSSHPort == 0 {
-		return fmt.Errorf("VM %s does not have SSH access configured", id)
-	}
-
-	// Check if VM is running
-	if vm.Status != types.VMStatusRunning {
-		return fmt.Errorf("VM %s is not running (current status: %s). SCP connection requires a running VM", id, vm.Status)
+		return fmt.Errorf("VM %s does not have SSH access configured", vmID)
 	}
 
 	// Try to get the SSH user in order of precedence

--- a/pkg/kotsclient/vm_scp.go
+++ b/pkg/kotsclient/vm_scp.go
@@ -1,0 +1,91 @@
+package kotsclient
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/replicatedhq/replicated/pkg/types"
+)
+
+// SCPToVM copies a file to a VM using SCP
+func (c *VendorV3Client) SCPToVM(id string, sshUserFlag string, localPath string, remotePath string) error {
+	vm, err := c.GetVM(id)
+	if err != nil {
+		return err
+	}
+
+	if vm.DirectSSHEndpoint == "" || vm.DirectSSHPort == 0 {
+		return fmt.Errorf("VM %s does not have SSH access configured", id)
+	}
+
+	// Check if VM is running
+	if vm.Status != types.VMStatusRunning {
+		return fmt.Errorf("VM %s is not running (current status: %s). SCP connection requires a running VM", id, vm.Status)
+	}
+
+	// Try to get the SSH user in order of precedence
+	sshUser := firstNonEmpty(
+		sshUserFlag,
+		os.Getenv("REPLICATED_SSH_USER"),
+		os.Getenv("GITHUB_ACTOR"),
+		os.Getenv("GITHUB_USER"),
+	)
+
+	// Format the remote destination
+	remoteDestination := remotePath
+	if sshUser != "" {
+		remoteDestination = fmt.Sprintf("%s@%s:%s", sshUser, vm.DirectSSHEndpoint, remotePath)
+	} else {
+		remoteDestination = fmt.Sprintf("%s:%s", vm.DirectSSHEndpoint, remotePath)
+	}
+
+	// Build the scp command
+	cmd := exec.Command("scp", "-P", fmt.Sprintf("%d", vm.DirectSSHPort), localPath, remoteDestination)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return cmd.Run()
+}
+
+// SCPFromVM copies a file from a VM using SCP
+func (c *VendorV3Client) SCPFromVM(id string, sshUserFlag string, remotePath string, localPath string) error {
+	vm, err := c.GetVM(id)
+	if err != nil {
+		return err
+	}
+
+	if vm.DirectSSHEndpoint == "" || vm.DirectSSHPort == 0 {
+		return fmt.Errorf("VM %s does not have SSH access configured", id)
+	}
+
+	// Check if VM is running
+	if vm.Status != types.VMStatusRunning {
+		return fmt.Errorf("VM %s is not running (current status: %s). SCP connection requires a running VM", id, vm.Status)
+	}
+
+	// Try to get the SSH user in order of precedence
+	sshUser := firstNonEmpty(
+		sshUserFlag,
+		os.Getenv("REPLICATED_SSH_USER"),
+		os.Getenv("GITHUB_ACTOR"),
+		os.Getenv("GITHUB_USER"),
+	)
+
+	// Format the remote source
+	remoteSource := remotePath
+	if sshUser != "" {
+		remoteSource = fmt.Sprintf("%s@%s:%s", sshUser, vm.DirectSSHEndpoint, remotePath)
+	} else {
+		remoteSource = fmt.Sprintf("%s:%s", vm.DirectSSHEndpoint, remotePath)
+	}
+
+	// Build the scp command
+	cmd := exec.Command("scp", "-P", fmt.Sprintf("%d", vm.DirectSSHPort), remoteSource, localPath)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return cmd.Run()
+}

--- a/pkg/kotsclient/vm_scp.go
+++ b/pkg/kotsclient/vm_scp.go
@@ -8,33 +8,16 @@ import (
 
 // SCPToVM copies a file to a VM using SCP
 func (c *VendorV3Client) SCPToVM(vmID string, sshUserFlag string, localPath string, remotePath string) error {
-	vm, err := c.GetVM(vmID)
+	connInfo, err := c.GetSSHConnectionInfo(vmID, sshUserFlag)
 	if err != nil {
 		return err
 	}
 
-	if vm.DirectSSHEndpoint == "" || vm.DirectSSHPort == 0 {
-		return fmt.Errorf("VM %s does not have SSH access configured", vmID)
-	}
-
-	// Try to get the SSH user in order of precedence
-	sshUser := firstNonEmpty(
-		sshUserFlag,
-		os.Getenv("REPLICATED_SSH_USER"),
-		os.Getenv("GITHUB_ACTOR"),
-		os.Getenv("GITHUB_USER"),
-	)
-
 	// Format the remote destination
-	remoteDestination := remotePath
-	if sshUser != "" {
-		remoteDestination = fmt.Sprintf("%s@%s:%s", sshUser, vm.DirectSSHEndpoint, remotePath)
-	} else {
-		remoteDestination = fmt.Sprintf("%s:%s", vm.DirectSSHEndpoint, remotePath)
-	}
+	remoteDestination := formatRemotePath(connInfo, remotePath)
 
 	// Build the scp command
-	cmd := exec.Command("scp", "-P", fmt.Sprintf("%d", vm.DirectSSHPort), localPath, remoteDestination)
+	cmd := exec.Command("scp", "-P", fmt.Sprintf("%d", connInfo.Port), localPath, remoteDestination)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -44,36 +27,27 @@ func (c *VendorV3Client) SCPToVM(vmID string, sshUserFlag string, localPath stri
 
 // SCPFromVM copies a file from a VM using SCP
 func (c *VendorV3Client) SCPFromVM(vmID string, sshUserFlag string, remotePath string, localPath string) error {
-	vm, err := c.GetVM(vmID)
+	connInfo, err := c.GetSSHConnectionInfo(vmID, sshUserFlag)
 	if err != nil {
 		return err
 	}
 
-	if vm.DirectSSHEndpoint == "" || vm.DirectSSHPort == 0 {
-		return fmt.Errorf("VM %s does not have SSH access configured", vmID)
-	}
-
-	// Try to get the SSH user in order of precedence
-	sshUser := firstNonEmpty(
-		sshUserFlag,
-		os.Getenv("REPLICATED_SSH_USER"),
-		os.Getenv("GITHUB_ACTOR"),
-		os.Getenv("GITHUB_USER"),
-	)
-
 	// Format the remote source
-	remoteSource := remotePath
-	if sshUser != "" {
-		remoteSource = fmt.Sprintf("%s@%s:%s", sshUser, vm.DirectSSHEndpoint, remotePath)
-	} else {
-		remoteSource = fmt.Sprintf("%s:%s", vm.DirectSSHEndpoint, remotePath)
-	}
+	remoteSource := formatRemotePath(connInfo, remotePath)
 
 	// Build the scp command
-	cmd := exec.Command("scp", "-P", fmt.Sprintf("%d", vm.DirectSSHPort), remoteSource, localPath)
+	cmd := exec.Command("scp", "-P", fmt.Sprintf("%d", connInfo.Port), remoteSource, localPath)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
 	return cmd.Run()
+}
+
+// formatRemotePath formats a remote path for SCP using the connection info
+func formatRemotePath(connInfo *SSHConnectionInfo, path string) string {
+	if connInfo.User != "" {
+		return fmt.Sprintf("%s@%s:%s", connInfo.User, connInfo.Endpoint, path)
+	}
+	return fmt.Sprintf("%s:%s", connInfo.Endpoint, path)
 }

--- a/pkg/kotsclient/vm_scp.go
+++ b/pkg/kotsclient/vm_scp.go
@@ -9,19 +9,19 @@ import (
 )
 
 // SCPToVM copies a file to a VM using SCP
-func (c *VendorV3Client) SCPToVM(id string, sshUserFlag string, localPath string, remotePath string) error {
-	vm, err := c.GetVM(id)
+func (c *VendorV3Client) SCPToVM(vmID string, sshUserFlag string, localPath string, remotePath string) error {
+	vm, err := c.GetVM(vmID)
 	if err != nil {
 		return err
 	}
 
 	if vm.DirectSSHEndpoint == "" || vm.DirectSSHPort == 0 {
-		return fmt.Errorf("VM %s does not have SSH access configured", id)
+		return fmt.Errorf("VM %s does not have SSH access configured", vmID)
 	}
 
 	// Check if VM is running
 	if vm.Status != types.VMStatusRunning {
-		return fmt.Errorf("VM %s is not running (current status: %s). SCP connection requires a running VM", id, vm.Status)
+		return fmt.Errorf("VM %s is not running (current status: %s). SCP connection requires a running VM", vmID, vm.Status)
 	}
 
 	// Try to get the SSH user in order of precedence

--- a/pkg/kotsclient/vm_ssh.go
+++ b/pkg/kotsclient/vm_ssh.go
@@ -9,14 +9,14 @@ import (
 )
 
 // SSHIntoVM connects to a VM via SSH using the provided ID and optional user flag
-func (c *VendorV3Client) SSHIntoVM(id string, sshUserFlag string) error {
-	vm, err := c.GetVM(id)
+func (c *VendorV3Client) SSHIntoVM(vmID string, sshUserFlag string) error {
+	vm, err := c.GetVM(vmID)
 	if err != nil {
 		return err
 	}
 
 	if vm.DirectSSHEndpoint == "" || vm.DirectSSHPort == 0 {
-		return fmt.Errorf("VM %s does not have SSH access configured", id)
+		return fmt.Errorf("VM %s does not have SSH access configured", vmID)
 	}
 
 	// Check if VM is running

--- a/pkg/kotsclient/vm_ssh.go
+++ b/pkg/kotsclient/vm_ssh.go
@@ -21,7 +21,7 @@ func (c *VendorV3Client) SSHIntoVM(id string, sshUserFlag string) error {
 
 	// Check if VM is running
 	if vm.Status != types.VMStatusRunning {
-		return fmt.Errorf("VM %s is not running (current status: %s). SSH connection requires a running VM", id, vm.Status)
+		return fmt.Errorf("VM: %s is not running (current status: %q): SSH connection requires a running VM", vmID, vm.Status)
 	}
 
 	// Try to get the SSH user in order of precedence

--- a/pkg/kotsclient/vm_ssh.go
+++ b/pkg/kotsclient/vm_ssh.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+
+	"github.com/replicatedhq/replicated/pkg/types"
 )
 
 // SSHIntoVM connects to a VM via SSH using the provided ID and optional user flag
@@ -15,6 +17,11 @@ func (c *VendorV3Client) SSHIntoVM(id string, sshUserFlag string) error {
 
 	if vm.DirectSSHEndpoint == "" || vm.DirectSSHPort == 0 {
 		return fmt.Errorf("VM %s does not have SSH access configured", id)
+	}
+
+	// Check if VM is running
+	if vm.Status != types.VMStatusRunning {
+		return fmt.Errorf("VM %s is not running (current status: %s). SSH connection requires a running VM", id, vm.Status)
 	}
 
 	// Try to get the SSH user in order of precedence

--- a/pkg/kotsclient/vm_ssh.go
+++ b/pkg/kotsclient/vm_ssh.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-
-	"github.com/replicatedhq/replicated/pkg/types"
 )
 
 // SSHIntoVM connects to a VM via SSH using the provided ID and optional user flag
@@ -17,11 +15,6 @@ func (c *VendorV3Client) SSHIntoVM(vmID string, sshUserFlag string) error {
 
 	if vm.DirectSSHEndpoint == "" || vm.DirectSSHPort == 0 {
 		return fmt.Errorf("VM %s does not have SSH access configured", vmID)
-	}
-
-	// Check if VM is running
-	if vm.Status != types.VMStatusRunning {
-		return fmt.Errorf("VM: %s is not running (current status: %q): SSH connection requires a running VM", vmID, vm.Status)
 	}
 
 	// Try to get the SSH user in order of precedence

--- a/pkg/kotsclient/vm_ssh.go
+++ b/pkg/kotsclient/vm_ssh.go
@@ -1,0 +1,49 @@
+package kotsclient
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+// SSHIntoVM connects to a VM via SSH using the provided ID and optional user flag
+func (c *VendorV3Client) SSHIntoVM(id string, sshUserFlag string) error {
+	vm, err := c.GetVM(id)
+	if err != nil {
+		return err
+	}
+
+	if vm.DirectSSHEndpoint == "" || vm.DirectSSHPort == 0 {
+		return fmt.Errorf("VM %s does not have SSH access configured", id)
+	}
+
+	// Try to get the SSH user in order of precedence
+	sshUser := firstNonEmpty(
+		sshUserFlag,
+		os.Getenv("REPLICATED_SSH_USER"),
+		os.Getenv("GITHUB_ACTOR"),
+		os.Getenv("GITHUB_USER"),
+	)
+
+	sshEndpoint := vm.DirectSSHEndpoint
+	if sshUser != "" {
+		sshEndpoint = fmt.Sprintf("%s@%s", sshUser, vm.DirectSSHEndpoint)
+	}
+
+	cmd := exec.Command("ssh", sshEndpoint, "-p", fmt.Sprintf("%d", vm.DirectSSHPort))
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return cmd.Run()
+}
+
+// firstNonEmpty returns the first non-empty string from the provided values
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/pkg/kotsclient/vm_ssh.go
+++ b/pkg/kotsclient/vm_ssh.go
@@ -8,42 +8,20 @@ import (
 
 // SSHIntoVM connects to a VM via SSH using the provided ID and optional user flag
 func (c *VendorV3Client) SSHIntoVM(vmID string, sshUserFlag string) error {
-	vm, err := c.GetVM(vmID)
+	connInfo, err := c.GetSSHConnectionInfo(vmID, sshUserFlag)
 	if err != nil {
 		return err
 	}
 
-	if vm.DirectSSHEndpoint == "" || vm.DirectSSHPort == 0 {
-		return fmt.Errorf("VM %s does not have SSH access configured", vmID)
+	sshEndpoint := connInfo.Endpoint
+	if connInfo.User != "" {
+		sshEndpoint = fmt.Sprintf("%s@%s", connInfo.User, connInfo.Endpoint)
 	}
 
-	// Try to get the SSH user in order of precedence
-	sshUser := firstNonEmpty(
-		sshUserFlag,
-		os.Getenv("REPLICATED_SSH_USER"),
-		os.Getenv("GITHUB_ACTOR"),
-		os.Getenv("GITHUB_USER"),
-	)
-
-	sshEndpoint := vm.DirectSSHEndpoint
-	if sshUser != "" {
-		sshEndpoint = fmt.Sprintf("%s@%s", sshUser, vm.DirectSSHEndpoint)
-	}
-
-	cmd := exec.Command("ssh", sshEndpoint, "-p", fmt.Sprintf("%d", vm.DirectSSHPort))
+	cmd := exec.Command("ssh", sshEndpoint, "-p", fmt.Sprintf("%d", connInfo.Port))
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
 	return cmd.Run()
-}
-
-// firstNonEmpty returns the first non-empty string from the provided values
-func firstNonEmpty(values ...string) string {
-	for _, v := range values {
-		if v != "" {
-			return v
-		}
-	}
-	return ""
 }


### PR DESCRIPTION
Currently SSH access to CMX VMs happens one of two ways:
- via the proxy
  - In some scenarios this can cause high latency at the terminal
- directly
  - but the user must fish out the ip and port number manually

This `replicated vm ssh` command handles connecting directly to a CMX vm via it's exposed port. 
it's behavior is such that: 
- specifying a VM by it's ID with `replicated vm ssh <id>` will connect you to that VM
- if no VMs are specified but multiple active VMs exist, prompt the user for which to connect to. 

TODO: 
- [ ] filter out airgapped VMs
- [x] add `scp` subcommand
- [ ] tests?