### PR TITLE
Performance Improvements for CLI Version Checking

### DIFF
--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -17,10 +17,40 @@ func Version() *cobra.Command {
 		Short: "Print the current version and exit",
 		Long:  `Print the current version and exit`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			currentVersion := version.Version()
+				
+			// For version command, do a synchronous update check
+			updateChecker, err := version.NewUpdateChecker(currentVersion, "replicatedhq/replicated/cli") 
+			if err == nil {
+				// If we're in a development build or unknown version, still try to get latest
+				// version info but don't compare versions
+				updateInfo, err := updateChecker.GetUpdateInfo()
+				if err == nil && updateInfo != nil {
+					// Update the build info with latest version
+					version.SetUpdateInfo(updateInfo)
+					// Also save to cache for future commands
+					version.SaveUpdateCache(currentVersion, updateInfo)
+				}
+			}
+			
+			// Now get the (potentially updated) build info
 			build := version.GetBuild()
 
 			if !versionJson {
-				version.Print()
+				// Special handling for development/unknown version when printing
+				if currentVersion == "unknown" || currentVersion == "development" {
+					fmt.Printf("replicated version %s (development build)\n", currentVersion)
+					if build.UpdateInfo != nil {
+						fmt.Printf("Latest release: %s\n", build.UpdateInfo.LatestVersion)
+						if build.UpdateInfo.CanUpgradeInPlace {
+							fmt.Printf("To automatically upgrade, run \"replicated version upgrade\"\n")
+						} else if build.UpdateInfo.ExternalUpgradeCommand != "" {
+							fmt.Printf("To upgrade, run \"%s\"\n", build.UpdateInfo.ExternalUpgradeCommand)
+						}
+					}
+				} else {
+					version.Print()
+				}
 			} else {
 				versionInfo, err := json.MarshalIndent(build, "", "    ")
 				if err != nil {

--- a/pkg/version/updatecache.go
+++ b/pkg/version/updatecache.go
@@ -1,0 +1,212 @@
+package version
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// debugMode controls whether debug messages are printed
+var debugMode bool
+
+// SetDebugMode enables or disables debug mode
+func SetDebugMode(debug bool) {
+	debugMode = debug
+}
+
+// debugLog logs messages when debug mode is enabled
+func debugLog(format string, args ...interface{}) {
+	if debugMode {
+		fmt.Fprintf(os.Stderr, "[DEBUG] Version: "+format+"\n", args...)
+	}
+}
+
+// UpdateCache represents the cached update information
+type UpdateCache struct {
+	Version        string     `json:"cachedVersion"`
+	UpdateInfo     UpdateInfo `json:"updateCheckerInfo"`
+	LastCheckedAt  time.Time  `json:"lastCheckedAt"`
+}
+
+// getCacheDir returns the directory where the cache file is stored
+func getCacheDir() (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", errors.Wrap(err, "failed to get user home directory")
+	}
+
+	return filepath.Join(homeDir, ".replicated"), nil
+}
+
+// getCachePath returns the path to the update cache file
+func getCachePath() (string, error) {
+	cacheDir, err := getCacheDir()
+	if err != nil {
+		return "", errors.Wrap(err, "failed to get cache directory")
+	}
+
+	return filepath.Join(cacheDir, "cache.json"), nil
+}
+
+// LoadUpdateCache loads the update information from the cache file
+// Returns nil without error if the cache doesn't exist or is invalid
+func LoadUpdateCache() (*UpdateCache, error) {
+	cachePath, err := getCachePath()
+	if err != nil {
+		debugLog("Failed to get cache path: %v", err)
+		return nil, nil // Silently return nil
+	}
+
+	debugLog("Loading update cache from %s", cachePath)
+	data, err := os.ReadFile(cachePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			debugLog("Cache file doesn't exist")
+			return nil, nil // Cache doesn't exist yet, not an error
+		}
+		debugLog("Error reading cache file: %v", err)
+		return nil, nil // Silently return nil on any error
+	}
+
+	var cache UpdateCache
+	err = json.Unmarshal(data, &cache)
+	if err != nil {
+		debugLog("Invalid cache format: %v", err)
+		return nil, nil // Invalid cache, silently return nil
+	}
+
+	debugLog("Successfully loaded cache: version=%s, latest=%s, checked=%s", 
+		cache.Version, cache.UpdateInfo.LatestVersion, cache.LastCheckedAt.Format(time.RFC3339))
+	return &cache, nil
+}
+
+// ClearUpdateCache removes the update cache file
+// Silently fails - no errors are returned
+func ClearUpdateCache() {
+	cachePath, err := getCachePath()
+	if err != nil {
+		debugLog("Failed to get cache path: %v", err)
+		return
+	}
+	
+	// Check if file exists first
+	_, err = os.Stat(cachePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			debugLog("Cache file doesn't exist, nothing to clear")
+			return
+		}
+		debugLog("Error checking cache file: %v", err)
+		return
+	}
+	
+	debugLog("Clearing update cache at %s", cachePath)
+	err = os.Remove(cachePath)
+	if err != nil {
+		debugLog("Failed to remove cache file: %v", err)
+	} else {
+		debugLog("Successfully cleared update cache")
+	}
+}
+
+// SaveUpdateCache saves the update information to the cache file
+// Silently fails - no errors are returned
+func SaveUpdateCache(currentVersion string, updateInfo *UpdateInfo) {
+	if updateInfo == nil {
+		debugLog("Not saving cache: updateInfo is nil")
+		return
+	}
+
+	debugLog("Saving update cache for version %s, latest version %s", 
+		currentVersion, updateInfo.LatestVersion)
+
+	cacheDir, err := getCacheDir()
+	if err != nil {
+		debugLog("Failed to get cache directory: %v", err)
+		return // Silently fail
+	}
+
+	// Ensure directory exists
+	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+		debugLog("Failed to create cache directory: %v", err)
+		return // Silently fail
+	}
+
+	cachePath, err := getCachePath()
+	if err != nil {
+		debugLog("Failed to get cache path: %v", err)
+		return // Silently fail
+	}
+
+	cache := UpdateCache{
+		Version:       currentVersion,
+		UpdateInfo:    *updateInfo,
+		LastCheckedAt: time.Now(),
+	}
+
+	data, err := json.Marshal(cache)
+	if err != nil {
+		debugLog("Failed to marshal cache data: %v", err)
+		return // Silently fail
+	}
+
+	// Write to temp file first to avoid corruption
+	tmpFile := cachePath + ".tmp"
+	debugLog("Writing to temporary file %s", tmpFile)
+	if err := os.WriteFile(tmpFile, data, 0644); err != nil {
+		debugLog("Failed to write temporary file: %v", err)
+		return // Silently fail
+	}
+
+	// Rename to the actual file (atomic on POSIX systems)
+	debugLog("Renaming %s to %s", tmpFile, cachePath)
+	if err := os.Rename(tmpFile, cachePath); err != nil {
+		debugLog("Failed to rename temporary file: %v", err)
+		os.Remove(tmpFile) // Clean up temp file if rename fails
+		return // Silently fail
+	}
+	
+	debugLog("Successfully saved update cache")
+}
+
+// CheckForUpdatesInBackground starts a goroutine to check for updates
+// and save the results to the cache file. It never blocks and silently
+// handles all errors.
+func CheckForUpdatesInBackground(currentVersion string, homebrewFormula string) {
+	debugLog("Starting background update check for version %s", currentVersion)
+	
+	go func() {
+		// Create update checker with shorter timeout for background checks
+		debugLog("Creating update checker with formula %s", homebrewFormula)
+		updateChecker, err := NewUpdateChecker(currentVersion, homebrewFormula)
+		if err != nil {
+			debugLog("Failed to create update checker: %v", err)
+			return // Silently fail
+		}
+		
+		// Use a shorter timeout for background checks
+		updateChecker.httpTimeout = 1 * time.Second
+
+		// Get update info with a longer timeout for background check
+		debugLog("Checking for updates in background")
+		updateInfo, err := updateChecker.GetUpdateInfo()
+		if err != nil {
+			debugLog("Failed to get update info: %v", err)
+			return // Silently fail
+		}
+
+		if updateInfo == nil {
+			debugLog("No update info returned (nil)")
+			return
+		}
+
+		debugLog("Update check complete, latest version: %s", updateInfo.LatestVersion)
+		
+		// Save to cache
+		SaveUpdateCache(currentVersion, updateInfo)
+	}()
+}

--- a/pkg/version/updatechecker.go
+++ b/pkg/version/updatechecker.go
@@ -21,7 +21,7 @@ type Option func(*UpdateChecker) error
 func NewUpdateChecker(version string, homebrewFormula string) (*UpdateChecker, error) {
 	updateChecker := UpdateChecker{
 		version:     version,
-		httpTimeout: 3 * time.Second,
+		httpTimeout: 3 * time.Second, // Default timeout
 	}
 
 	if homebrewFormula != "" {

--- a/pkg/version/updateinfo.go
+++ b/pkg/version/updateinfo.go
@@ -15,25 +15,33 @@ const (
 
 // GetUpdateInfo will return the latest version
 func (s UpdateChecker) GetUpdateInfo() (*UpdateInfo, error) {
+	debugLog("Getting update info for version %s", s.version)
 	checkedAt := time.Now()
 
+	debugLog("Fetching latest version with timeout %v", s.httpTimeout)
 	latestVersion, err := getLatestVersion(s.httpTimeout)
 	if err != nil {
+		debugLog("Error getting latest version: %v", err)
 		return nil, errors.Wrap(err, "get latest version")
 	}
 
 	if latestVersion == nil {
+		debugLog("No latest version info returned (nil)")
 		return nil, nil
 	}
 
+	debugLog("Got latest version: %s", latestVersion.Version)
 	updateInfo, err := UpdateInfoFromVersions(s.version, latestVersion)
 	if err != nil {
+		debugLog("Error creating update info: %v", err)
 		return nil, nil
 	}
 	if updateInfo == nil {
+		debugLog("No update needed, current version is latest or newer")
 		return nil, nil
 	}
 
+	debugLog("Update available: %s", updateInfo.LatestVersion)
 	updateInfo.ExternalUpgradeCommand = s.ExternalUpgradeCommand()
 	updateInfo.CanUpgradeInPlace = updateInfo.ExternalUpgradeCommand == ""
 	updateInfo.CheckedAt = &checkedAt
@@ -53,30 +61,41 @@ type ClientVersions struct {
 }
 
 func getLatestVersion(timeout time.Duration) (*VersionInfo, error) {
+	startTime := time.Now()
+	debugLog("Making HTTP request to %s with timeout %v", latestVersionURI, timeout)
+	
 	client := &http.Client{
 		Timeout: timeout,
 	}
 
 	resp, err := client.Get(latestVersionURI)
 	if err != nil {
+		debugLog("HTTP request failed: %v", err)
 		return nil, errors.Wrap(err, "get latest version")
 	}
 	defer resp.Body.Close()
 
+	elapsed := time.Since(startTime)
+	debugLog("HTTP request completed in %v with status %d", elapsed, resp.StatusCode)
+
 	if resp.StatusCode != http.StatusOK {
+		debugLog("Unexpected status code: %d", resp.StatusCode)
 		return nil, errors.Errorf("unexpected status code: %d", resp.StatusCode)
 	}
 
 	pingResponse := PingResponse{}
 	err = json.NewDecoder(resp.Body).Decode(&pingResponse)
 	if err != nil {
+		debugLog("Failed to decode response: %v", err)
 		return nil, errors.Wrap(err, "decode response")
 	}
 
 	if pingResponse.ClientVersions.ReplicatedCLI == "" {
+		debugLog("No CLI version found in response")
 		return nil, nil
 	}
 
+	debugLog("Latest CLI version from server: %s", pingResponse.ClientVersions.ReplicatedCLI)
 	return &VersionInfo{
 		Version: pingResponse.ClientVersions.ReplicatedCLI,
 	}, nil
@@ -101,20 +120,41 @@ func UpdateInfoFromVersions(currentVersion string, latestVersion *VersionInfo) (
 		return nil, errors.New("latest version is nil")
 	}
 
+	// Try to parse the latest version
 	latestSemver, err := semver.NewVersion(latestVersion.Version)
 	if err != nil {
+		debugLog("Failed to parse latest version as semver: %v", err)
 		return nil, errors.Wrap(err, "latest semver")
 	}
 
-	currentSemver, err := semver.NewVersion(currentVersion)
-	if err != nil {
-		return nil, errors.Wrap(err, "current semver")
+	// Special handling for "unknown" or otherwise invalid current versions
+	// In this case, we'll always return update info since we can't compare versions
+	if currentVersion == "" || currentVersion == "unknown" || currentVersion == "development" {
+		debugLog("Current version is '%s', assuming update is available", currentVersion)
+		return &UpdateInfo{
+			LatestVersion: latestVersion.Version,
+		}, nil
 	}
 
+	// Parse the current version, but handle errors gracefully
+	currentSemver, err := semver.NewVersion(currentVersion)
+	if err != nil {
+		debugLog("Failed to parse current version '%s' as semver: %v", currentVersion, err)
+		// Since we can't parse the current version, we'll assume an update is available
+		// This is safer than failing silently
+		return &UpdateInfo{
+			LatestVersion: latestVersion.Version,
+		}, nil
+	}
+
+	// Compare versions and only return update info if a newer version is available
 	if latestSemver.LessThan(currentSemver) || latestSemver.Equal(currentSemver) {
+		debugLog("Current version %s is equal to or newer than latest %s, no update needed", 
+			currentVersion, latestVersion.Version)
 		return nil, nil
 	}
 
+	debugLog("Update available: current=%s, latest=%s", currentVersion, latestVersion.Version)
 	updateInfo := UpdateInfo{
 		LatestVersion: latestVersion.Version,
 	}


### PR DESCRIPTION
  - Converted the blocking version update check to a non-blocking background operation
  - Eliminated the 3+ second delay on every CLI command
  - Added version cache invalidation to properly handle CLI upgrades
  - Improved handling for development and "unknown" versions
  - Added debug logging for version check diagnostics

  Background Version Checking

  - Moved the version check API call to a background goroutine that never blocks command execution
  - Used existing cache (at ~/.replicated/cache.json) to store and retrieve update information
  - Reduced the timeout for background checks from 3s to 1s
  - Added proper cache management with version-specific invalidation

  Development Version Handling

  - Added special handling for "unknown" and development versions
  - More gracefully handles semver parsing errors
  - Provides better update information for non-versioned builds

  Debug Mode

  - Added --debug flag and REPLICATED_DEBUG environment variable
  - Comprehensive debug logging throughout the version check process
  - Shows detailed timing for HTTP requests
  - Logs all cache reads/writes and version comparisons

  Performance Impact

  - Eliminated the ~3 second delay on every CLI command execution
  - Maintains the update notification functionality without affecting performance
  - Version command still performs a synchronous check to ensure accurate information

  Testing

  - Tested with production builds and development builds
  - Verified cached update detection works correctly
  - Confirmed cache is properly invalidated when CLI is upgraded
  - Validated debug mode provides appropriate diagnostics
