### PR TITLE
Update all tools to use Go 1.23

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '^1.22'
+          go-version: '^1.23'
       - run: make test-unit
 
   make-pact-tests:
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '^1.22'
+          go-version: '^1.23'
       - uses: replicatedhq/action-install-pact@v1
       - name: setup pact environment
         run: |
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '^1.22'
+          go-version: '^1.23'
       - run: make test-integration
 
   make-build:
@@ -54,6 +54,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '^1.22'
+          go-version: '^1.23'
       - name: make build
         run: make build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22
+FROM golang:1.23
 
 ENV PROJECTPATH=/go/src/github.com/replicatedhq/replicated
 

--- a/dagger/docs.go
+++ b/dagger/docs.go
@@ -66,7 +66,7 @@ func (r *Replicated) GenerateDocs(
 
 	// generate the docs from this current commit
 	docs := dag.Container().
-		From("golang:1.22").
+		From("golang:1.23").
 		WithMountedDirectory("/go/src/github.com/replicatedhq/replicated", source).
 		WithWorkdir("/go/src/github.com/replicatedhq/replicated").
 		WithMountedCache("/go/pkg/mod", goModCache).

--- a/dagger/functionality.go
+++ b/dagger/functionality.go
@@ -16,7 +16,7 @@ func validateFunctionality(
 
 	// unit tests
 	unitTest := dag.Container().
-		From("golang:1.22").
+		From("golang:1.23").
 		WithMountedDirectory("/go/src/github.com/replicatedhq/replicated", source).
 		WithWorkdir("/go/src/github.com/replicatedhq/replicated").
 		WithMountedCache("/go/pkg/mod", goModCache).

--- a/dagger/release.go
+++ b/dagger/release.go
@@ -111,7 +111,7 @@ func (r *Replicated) Release(
 	replicatedBinary := dag.Container(dagger.ContainerOpts{
 		Platform: "linux/amd64",
 	}).
-		From("golang:1.22").
+		From("golang:1.23").
 		WithMountedDirectory("/go/src/github.com/replicatedhq/replicated", updatedSource).
 		WithoutFile("/go/src/github.com/replicatedhq/replicated/bin/replicated").
 		WithWorkdir("/go/src/github.com/replicatedhq/replicated").


### PR DESCRIPTION
go.mod is now at 1.23, so we need to use 1.23

```
102 : [13.3s] | go build \
102 : [13.3s] |          \
102 : [13.3s] |         -tags "containers_image_ostree_stub exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_openpgp" \
102 : [13.3s] |         -o bin/replicated \
102 : [13.3s] |         cli/main.go
102 : [13.4s] | go: go.mod requires go >= 1.23.0 (running go 1.22.12; GOTOOLCHAIN=local)
102 : [13.4s] | make: *** [Makefile:95: build] Error 1
```