### PR TITLE
chore(cmx): accept `-o` for `--output`

### DIFF
--- a/cli/cmd/cluster_create.go
+++ b/cli/cmd/cluster_create.go
@@ -79,7 +79,7 @@ replicated cluster create --distribution eks --version 1.21 --nodes 3 --addon ob
 
 	cmd.Flags().BoolVar(&r.args.createClusterDryRun, "dry-run", false, "Dry run")
 
-	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table|wide (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table|wide (default: table)")
 
 	_ = cmd.MarkFlagRequired("distribution")
 

--- a/cli/cmd/cluster_ls.go
+++ b/cli/cmd/cluster_ls.go
@@ -46,7 +46,7 @@ replicated cluster ls --output wide`,
 	cmd.Flags().BoolVar(&r.args.lsClusterShowTerminated, "show-terminated", false, "when set, only show terminated clusters")
 	cmd.Flags().StringVar(&r.args.lsClusterStartTime, "start-time", "", "start time for the query (Format: 2006-01-02T15:04:05Z)")
 	cmd.Flags().StringVar(&r.args.lsClusterEndTime, "end-time", "", "end time for the query (Format: 2006-01-02T15:04:05Z)")
-	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table|wide (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table|wide (default: table)")
 	cmd.Flags().BoolVarP(&r.args.lsClusterWatch, "watch", "w", false, "watch clusters")
 
 	return cmd
@@ -97,7 +97,6 @@ func (r *runners) listClusters(_ *cobra.Command, args []string) error {
 		// Runs until ctrl C is recognized
 		for range time.Tick(2 * time.Second) {
 			newClusters, err := r.kotsAPI.ListClusters(r.args.lsClusterShowTerminated, startTime, endTime)
-
 			if err != nil {
 				if err == promptui.ErrInterrupt {
 					return errors.New("interrupted")

--- a/cli/cmd/cluster_nodegroup_ls.go
+++ b/cli/cmd/cluster_nodegroup_ls.go
@@ -31,7 +31,7 @@ replicated cluster nodegroup ls CLUSTER_ID --output wide`,
 	}
 	parent.AddCommand(cmd)
 
-	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table|wide (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table|wide (default: table)")
 
 	return cmd
 }

--- a/cli/cmd/cluster_port_expose.go
+++ b/cli/cmd/cluster_port_expose.go
@@ -41,7 +41,7 @@ replicated cluster port expose CLUSTER_ID --port 8080 --protocol https --output 
 	}
 	cmd.Flags().StringSliceVar(&r.args.clusterExposePortProtocols, "protocol", []string{"http", "https"}, `Protocol to expose (valid values are "http", "https", "ws" and "wss")`)
 	cmd.Flags().BoolVar(&r.args.clusterExposePortIsWildcard, "wildcard", false, "Create a wildcard DNS entry and TLS certificate for this port")
-	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table|wide (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table|wide (default: table)")
 
 	return cmd
 }

--- a/cli/cmd/cluster_port_ls.go
+++ b/cli/cmd/cluster_port_ls.go
@@ -27,7 +27,7 @@ replicated cluster port ls CLUSTER_ID --output wide`,
 	}
 	parent.AddCommand(cmd)
 
-	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table|wide (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table|wide (default: table)")
 
 	return cmd
 }

--- a/cli/cmd/cluster_port_rm.go
+++ b/cli/cmd/cluster_port_rm.go
@@ -31,7 +31,7 @@ replicated cluster port rm CLUSTER_ID --id PORT_ID --output json`,
 	parent.AddCommand(cmd)
 
 	cmd.Flags().StringVar(&r.args.clusterPortRemoveAddonID, "id", "", "ID of the port to remove (required)")
-	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table|wide (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table|wide (default: table)")
 
 	// Deprecated flags
 	cmd.Flags().IntVar(&r.args.clusterPortRemovePort, "port", 0, "Port to remove")

--- a/cli/cmd/cluster_update_nodegroup.go
+++ b/cli/cmd/cluster_update_nodegroup.go
@@ -34,7 +34,7 @@ replicated cluster update nodegroup CLUSTER_ID --nodegroup-id NODEGROUP_ID --min
 	cmd.Flags().StringVar(&r.args.updateClusterNodeGroupMinCount, "min-nodes", "", "The minimum number of nodes in the nodegroup")
 	cmd.Flags().StringVar(&r.args.updateClusterNodeGroupMaxCount, "max-nodes", "", "The maximum number of nodes in the nodegroup")
 
-	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table|wide (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table|wide (default: table)")
 
 	return cmd
 }

--- a/cli/cmd/cluster_update_ttl.go
+++ b/cli/cmd/cluster_update_ttl.go
@@ -22,7 +22,7 @@ replicated cluster update ttl CLUSTER_ID --ttl 24h`,
 	parent.AddCommand(cmd)
 
 	cmd.Flags().StringVar(&r.args.updateClusterTTL, "ttl", "", "Update TTL which starts from the moment the cluster is running (duration, max 48h).")
-	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table|wide (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table|wide (default: table)")
 
 	cmd.MarkFlagRequired("ttl")
 

--- a/cli/cmd/cluster_upgrade.go
+++ b/cli/cmd/cluster_upgrade.go
@@ -36,7 +36,7 @@ replicated cluster upgrade [CLUSTER_ID] --version 1.31 --wait 30m`,
 	cmd.Flags().BoolVar(&r.args.upgradeClusterDryRun, "dry-run", false, "Dry run")
 	cmd.Flags().DurationVar(&r.args.upgradeClusterWaitDuration, "wait", 0, "Wait duration for cluster to be ready (leave empty to not wait)")
 
-	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table|wide (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table|wide (default: table)")
 
 	_ = cmd.MarkFlagRequired("version")
 

--- a/cli/cmd/network_create.go
+++ b/cli/cmd/network_create.go
@@ -30,7 +30,7 @@ func (r *runners) InitNetworkCreate(parent *cobra.Command) *cobra.Command {
 
 	cmd.Flags().BoolVar(&r.args.createNetworkDryRun, "dry-run", false, "Dry run")
 
-	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table|wide (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table|wide (default: table)")
 
 	return cmd
 }
@@ -61,7 +61,6 @@ func (r *runners) createNetwork(_ *cobra.Command, args []string) error {
 	}
 
 	return print.Network(r.outputFormat, r.w, network)
-
 }
 
 func (r *runners) createAndWaitForNetwork(opts kotsclient.CreateNetworkOpts) (*types.Network, error) {

--- a/cli/cmd/network_ls.go
+++ b/cli/cmd/network_ls.go
@@ -24,7 +24,7 @@ func (r *runners) InitNetworkList(parent *cobra.Command) *cobra.Command {
 
 	cmd.Flags().StringVar(&r.args.lsNetworkStartTime, "start-time", "", "start time for the query (Format: 2006-01-02T15:04:05Z)")
 	cmd.Flags().StringVar(&r.args.lsNetworkEndTime, "end-time", "", "end time for the query (Format: 2006-01-02T15:04:05Z)")
-	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table|wide (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table|wide (default: table)")
 	cmd.Flags().BoolVarP(&r.args.lsNetworkWatch, "watch", "w", false, "watch networks")
 
 	return cmd
@@ -75,7 +75,6 @@ func (r *runners) listNetworks(_ *cobra.Command, args []string) error {
 		// Runs until ctrl C is recognized
 		for range time.Tick(2 * time.Second) {
 			newNetworks, err := r.kotsAPI.ListNetworks(startTime, endTime)
-
 			if err != nil {
 				if err == promptui.ErrInterrupt {
 					return errors.New("interrupted")

--- a/cli/cmd/vm_create.go
+++ b/cli/cmd/vm_create.go
@@ -58,7 +58,7 @@ replicated vm create --distribution ubuntu --version 20.04 --count 5 --instance-
 
 	cmd.Flags().BoolVar(&r.args.createVMDryRun, "dry-run", false, "Dry run")
 
-	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table|wide (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table|wide (default: table)")
 
 	_ = cmd.MarkFlagRequired("distribution")
 

--- a/cli/cmd/vm_ls.go
+++ b/cli/cmd/vm_ls.go
@@ -42,7 +42,7 @@ replicated vm ls --watch`,
 	cmd.Flags().BoolVar(&r.args.lsVMShowTerminated, "show-terminated", false, "when set, only show terminated vms")
 	cmd.Flags().StringVar(&r.args.lsVMStartTime, "start-time", "", "start time for the query (Format: 2006-01-02T15:04:05Z)")
 	cmd.Flags().StringVar(&r.args.lsVMEndTime, "end-time", "", "end time for the query (Format: 2006-01-02T15:04:05Z)")
-	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table|wide (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table|wide (default: table)")
 	cmd.Flags().BoolVarP(&r.args.lsVMWatch, "watch", "w", false, "watch vms")
 
 	return cmd
@@ -93,7 +93,6 @@ func (r *runners) listVMs(_ *cobra.Command, args []string) error {
 		// Runs until ctrl C is recognized
 		for range time.Tick(2 * time.Second) {
 			newVMs, err := r.kotsAPI.ListVMs(r.args.lsVMShowTerminated, startTime, endTime)
-
 			if err != nil {
 				if err == promptui.ErrInterrupt {
 					return errors.New("interrupted")

--- a/cli/cmd/vm_port_expose.go
+++ b/cli/cmd/vm_port_expose.go
@@ -39,7 +39,7 @@ replicated vm port expose VM_ID --port 8080 --protocol https --output json`,
 	}
 	cmd.Flags().StringSliceVar(&r.args.vmExposePortProtocols, "protocol", []string{"http", "https"}, `Protocol to expose (valid values are "http", "https", "ws" and "wss")`)
 	cmd.Flags().BoolVar(&r.args.vmExposePortIsWildcard, "wildcard", false, "Create a wildcard DNS entry and TLS certificate for this port")
-	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table|wide (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table|wide (default: table)")
 
 	return cmd
 }

--- a/cli/cmd/vm_port_ls.go
+++ b/cli/cmd/vm_port_ls.go
@@ -26,7 +26,7 @@ replicated vm port ls VM_ID --output wide`,
 	}
 	parent.AddCommand(cmd)
 
-	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table|wide (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table|wide (default: table)")
 
 	return cmd
 }

--- a/cli/cmd/vm_port_rm.go
+++ b/cli/cmd/vm_port_rm.go
@@ -28,7 +28,7 @@ replicated vm port rm VM_ID --id PORT_ID --output json`,
 	if err != nil {
 		panic(err)
 	}
-	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table|wide (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table|wide (default: table)")
 
 	return cmd
 }

--- a/cli/cmd/vm_update_ttl.go
+++ b/cli/cmd/vm_update_ttl.go
@@ -31,7 +31,7 @@ replicated vm update ttl aaaaa11 --ttl 30m`,
 	parent.AddCommand(cmd)
 
 	cmd.Flags().StringVar(&r.args.updateVMTTL, "ttl", "", "Update TTL which starts from the moment the vm is running (duration, max 48h).")
-	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table|wide (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table|wide (default: table)")
 
 	cmd.MarkFlagRequired("ttl")
 


### PR DESCRIPTION
Coming from kubectl, `-o` is a common alias for `--output`, update each of our uses of the `--output` command to a StringVarP so that the `-o` alias can be used for output format.