### PR TITLE
bug(cmx): Print to stderr to not break json

### DIFF
--- a/cli/cmd/network_update_outbound.go
+++ b/cli/cmd/network_update_outbound.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/replicated/cli/print"
@@ -37,7 +38,7 @@ replicated network update outbound NETWORK_ID --outbound any`,
 }
 
 func (r *runners) updateNetworkOutbound(cmd *cobra.Command, args []string) error {
-	fmt.Println("Note: 'replicated network update outbound' is deprecated. Use 'replicated network update policy' instead.")
+	fmt.Fprintln(os.Stderr, "Note: 'replicated network update outbound' is deprecated. Use 'replicated network update policy' instead.")
 
 	if err := r.ensureUpdateNetworkIDArg(args); err != nil {
 		return errors.Wrap(err, "ensure network id arg")
@@ -49,13 +50,13 @@ func (r *runners) updateNetworkOutbound(cmd *cobra.Command, args []string) error
 
 	var updateOpts kotsclient.UpdateNetworkPolicyOpts
 	if r.args.updateNetworkOutbound == "none" {
-		fmt.Println("Updating policy to 'airgap' to match 'none' outbound setting")
+		fmt.Fprintln(os.Stderr, "Updating policy to 'airgap' to match 'none' outbound setting")
 		updateOpts = kotsclient.UpdateNetworkPolicyOpts{
 			Policy: noneTranslatedPolicy,
 		}
 	}
 	if r.args.updateNetworkOutbound == "any" {
-		fmt.Println("Updating policy to 'open' to match 'any' outbound setting")
+		fmt.Fprintln(os.Stderr, "Updating policy to 'open' to match 'any' outbound setting")
 		updateOpts = kotsclient.UpdateNetworkPolicyOpts{
 			Policy: anyTranslatedPolicy,
 		}


### PR DESCRIPTION
No json breakage:

```
 ./bin/replicated network update outbound --output json --id aeac7e86 --outbound none | jq
Note: 'replicated network update outbound' is deprecated. Use 'replicated network update policy' instead.
Updating policy to 'airgap' to match 'none' outbound setting
[
  {
    "id": "aeac7e86",
    "name": "relaxed_moser",
    "status": "running",
    "created_at": "2025-03-18T21:17:45Z",
    "expires_at": "2025-03-18T22:18:07Z",
    "ttl": "1h",
    "overlay_endpoint": "http://65.109.157.169:42151",
    "overlay_token": "9c60a6694e9e30dcf461f71ca53a0034c36006bba6aa3741",
    "policy": "airgap"
  }
]
```