### PR TITLE
Consistent -o and remove duplicate default

### DIFF
--- a/cli/cmd/app_create.go
+++ b/cli/cmd/app_create.go
@@ -49,7 +49,7 @@ replicated app create "Custom App" --output table`,
 		SilenceUsage: true,
 	}
 	parent.AddCommand(cmd)
-	cmd.Flags().StringVar(&outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
+	cmd.Flags().StringVarP(&outputFormat, "output", "o", "table", "The output format to use. One of: json|table")
 
 	return cmd
 }

--- a/cli/cmd/app_ls.go
+++ b/cli/cmd/app_ls.go
@@ -44,7 +44,7 @@ replicated app ls "App Name" --output table`,
 		SilenceUsage: true,
 	}
 	parent.AddCommand(cmd)
-	cmd.Flags().StringVar(&outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
+	cmd.Flags().StringVarP(&outputFormat, "output", "o", "table", "The output format to use. One of: json|table")
 
 	return cmd
 }

--- a/cli/cmd/app_rm.go
+++ b/cli/cmd/app_rm.go
@@ -48,7 +48,7 @@ replicated app delete "Custom App" --output json`,
 	}
 	parent.AddCommand(cmd)
 	cmd.Flags().BoolVarP(&opts.force, "force", "f", false, "Skip confirmation prompt. There is no undo for this action.")
-	cmd.Flags().StringVar(&outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
+	cmd.Flags().StringVarP(&outputFormat, "output", "o", "table", "The output format to use. One of: json|table")
 
 	return cmd
 }

--- a/cli/cmd/channel_create.go
+++ b/cli/cmd/channel_create.go
@@ -17,7 +17,7 @@ func (r *runners) InitChannelCreate(parent *cobra.Command) {
 
 	cmd.Flags().StringVar(&r.args.channelCreateName, "name", "", "The name of this channel")
 	cmd.Flags().StringVar(&r.args.channelCreateDescription, "description", "", "A longer description of this channel")
-	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table")
 
 	cmd.RunE = r.channelCreate
 }

--- a/cli/cmd/channel_inspect.go
+++ b/cli/cmd/channel_inspect.go
@@ -15,7 +15,7 @@ func (r *runners) InitChannelInspect(parent *cobra.Command) {
 		Long:  "Show full details for a channel",
 	}
 	parent.AddCommand(cmd)
-	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table")
 
 	cmd.RunE = r.channelInspect
 }

--- a/cli/cmd/channel_ls.go
+++ b/cli/cmd/channel_ls.go
@@ -15,7 +15,7 @@ func (r *runners) InitChannelList(parent *cobra.Command) {
 	}
 
 	parent.AddCommand(cmd)
-	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table")
 
 	cmd.RunE = r.channelList
 }

--- a/cli/cmd/cluster_addon_create_objectstore.go
+++ b/cli/cmd/cluster_addon_create_objectstore.go
@@ -56,7 +56,7 @@ func (r *runners) clusterAddonCreateObjectStoreFlags(cmd *cobra.Command) error {
 	}
 	cmd.Flags().DurationVar(&r.args.clusterAddonCreateObjectStoreDuration, "wait", 0, "Wait duration for add-on to be ready before exiting (leave empty to not wait)")
 	cmd.Flags().BoolVar(&r.args.clusterAddonCreateObjectStoreDryRun, "dry-run", false, "Simulate creation to verify that your inputs are valid without actually creating an add-on")
-	cmd.Flags().StringVar(&r.args.clusterAddonCreateObjectStoreOutput, "output", "table", "The output format to use. One of: json|table|wide (default: table)")
+	cmd.Flags().StringVarP(&r.args.clusterAddonCreateObjectStoreOutput, "output", "o", "table", "The output format to use. One of: json|table|wide")
 	return nil
 }
 

--- a/cli/cmd/cluster_addon_ls.go
+++ b/cli/cmd/cluster_addon_ls.go
@@ -46,7 +46,7 @@ replicated cluster addon ls CLUSTER_ID --output wide`,
 }
 
 func clusterAddonLsFlags(cmd *cobra.Command, args *clusterAddonLsArgs) error {
-	cmd.Flags().StringVar(&args.outputFormat, "output", "table", "The output format to use. One of: json|table|wide (default: table)")
+	cmd.Flags().StringVarP(&args.outputFormat, "output", "o", "table", "The output format to use. One of: json|table|wide")
 	return nil
 }
 

--- a/cli/cmd/cluster_create.go
+++ b/cli/cmd/cluster_create.go
@@ -79,7 +79,7 @@ replicated cluster create --distribution eks --version 1.21 --nodes 3 --addon ob
 
 	cmd.Flags().BoolVar(&r.args.createClusterDryRun, "dry-run", false, "Dry run")
 
-	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table|wide (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table|wide")
 
 	_ = cmd.MarkFlagRequired("distribution")
 

--- a/cli/cmd/cluster_ls.go
+++ b/cli/cmd/cluster_ls.go
@@ -46,7 +46,7 @@ replicated cluster ls --output wide`,
 	cmd.Flags().BoolVar(&r.args.lsClusterShowTerminated, "show-terminated", false, "when set, only show terminated clusters")
 	cmd.Flags().StringVar(&r.args.lsClusterStartTime, "start-time", "", "start time for the query (Format: 2006-01-02T15:04:05Z)")
 	cmd.Flags().StringVar(&r.args.lsClusterEndTime, "end-time", "", "end time for the query (Format: 2006-01-02T15:04:05Z)")
-	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table|wide (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table|wide")
 	cmd.Flags().BoolVarP(&r.args.lsClusterWatch, "watch", "w", false, "watch clusters")
 
 	return cmd

--- a/cli/cmd/cluster_nodegroup_ls.go
+++ b/cli/cmd/cluster_nodegroup_ls.go
@@ -31,7 +31,7 @@ replicated cluster nodegroup ls CLUSTER_ID --output wide`,
 	}
 	parent.AddCommand(cmd)
 
-	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table|wide (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table|wide")
 
 	return cmd
 }

--- a/cli/cmd/cluster_port_expose.go
+++ b/cli/cmd/cluster_port_expose.go
@@ -41,7 +41,7 @@ replicated cluster port expose CLUSTER_ID --port 8080 --protocol https --output 
 	}
 	cmd.Flags().StringSliceVar(&r.args.clusterExposePortProtocols, "protocol", []string{"http", "https"}, `Protocol to expose (valid values are "http", "https", "ws" and "wss")`)
 	cmd.Flags().BoolVar(&r.args.clusterExposePortIsWildcard, "wildcard", false, "Create a wildcard DNS entry and TLS certificate for this port")
-	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table|wide (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table|wide")
 
 	return cmd
 }

--- a/cli/cmd/cluster_port_ls.go
+++ b/cli/cmd/cluster_port_ls.go
@@ -27,7 +27,7 @@ replicated cluster port ls CLUSTER_ID --output wide`,
 	}
 	parent.AddCommand(cmd)
 
-	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table|wide (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table|wide")
 
 	return cmd
 }

--- a/cli/cmd/cluster_port_rm.go
+++ b/cli/cmd/cluster_port_rm.go
@@ -31,7 +31,7 @@ replicated cluster port rm CLUSTER_ID --id PORT_ID --output json`,
 	parent.AddCommand(cmd)
 
 	cmd.Flags().StringVar(&r.args.clusterPortRemoveAddonID, "id", "", "ID of the port to remove (required)")
-	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table|wide (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table|wide")
 
 	// Deprecated flags
 	cmd.Flags().IntVar(&r.args.clusterPortRemovePort, "port", 0, "Port to remove")

--- a/cli/cmd/cluster_update_nodegroup.go
+++ b/cli/cmd/cluster_update_nodegroup.go
@@ -34,7 +34,7 @@ replicated cluster update nodegroup CLUSTER_ID --nodegroup-id NODEGROUP_ID --min
 	cmd.Flags().StringVar(&r.args.updateClusterNodeGroupMinCount, "min-nodes", "", "The minimum number of nodes in the nodegroup")
 	cmd.Flags().StringVar(&r.args.updateClusterNodeGroupMaxCount, "max-nodes", "", "The maximum number of nodes in the nodegroup")
 
-	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table|wide (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table|wide")
 
 	return cmd
 }

--- a/cli/cmd/cluster_update_ttl.go
+++ b/cli/cmd/cluster_update_ttl.go
@@ -22,7 +22,7 @@ replicated cluster update ttl CLUSTER_ID --ttl 24h`,
 	parent.AddCommand(cmd)
 
 	cmd.Flags().StringVar(&r.args.updateClusterTTL, "ttl", "", "Update TTL which starts from the moment the cluster is running (duration, max 48h).")
-	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table|wide (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table")
 
 	cmd.MarkFlagRequired("ttl")
 

--- a/cli/cmd/cluster_upgrade.go
+++ b/cli/cmd/cluster_upgrade.go
@@ -36,7 +36,7 @@ replicated cluster upgrade [CLUSTER_ID] --version 1.31 --wait 30m`,
 	cmd.Flags().BoolVar(&r.args.upgradeClusterDryRun, "dry-run", false, "Dry run")
 	cmd.Flags().DurationVar(&r.args.upgradeClusterWaitDuration, "wait", 0, "Wait duration for cluster to be ready (leave empty to not wait)")
 
-	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table|wide (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table|wide")
 
 	_ = cmd.MarkFlagRequired("version")
 

--- a/cli/cmd/cluster_versions.go
+++ b/cli/cmd/cluster_versions.go
@@ -26,7 +26,7 @@ replicated cluster versions --output json`,
 	parent.AddCommand(cmd)
 
 	cmd.Flags().StringVar(&r.args.lsVersionsDistribution, "distribution", "", "Kubernetes distribution to filter by.")
-	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table")
 
 	return cmd
 }

--- a/cli/cmd/collection_addmodel.go
+++ b/cli/cmd/collection_addmodel.go
@@ -22,7 +22,7 @@ func (r *runners) InitCollectionAddModel(parent *cobra.Command) *cobra.Command {
 	cmd.Flags().StringVar(&r.args.modelCollectionAddModelCollectionID, "collection-id", "", "The ID of the collection")
 	cmd.MarkFlagRequired("collection-id")
 
-	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table")
 
 	return cmd
 }

--- a/cli/cmd/collection_create.go
+++ b/cli/cmd/collection_create.go
@@ -21,7 +21,7 @@ func (r *runners) InitCollectionCreate(parent *cobra.Command) *cobra.Command {
 	cmd.Flags().StringVar(&r.args.modelCollectionCreateName, "name", "", "The name of the collection")
 	cmd.MarkFlagRequired("name")
 
-	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table")
 
 	return cmd
 }

--- a/cli/cmd/collection_ls.go
+++ b/cli/cmd/collection_ls.go
@@ -16,7 +16,7 @@ func (r *runners) InitCollectionList(parent *cobra.Command) *cobra.Command {
 		SilenceUsage: true,
 	}
 	parent.AddCommand(cmd)
-	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table")
 
 	return cmd
 }

--- a/cli/cmd/collection_removemodel.go
+++ b/cli/cmd/collection_removemodel.go
@@ -22,7 +22,7 @@ func (r *runners) InitCollectionRemoveModel(parent *cobra.Command) *cobra.Comman
 	cmd.Flags().StringVar(&r.args.modelCollectionRmModelCollectionID, "collection-id", "", "The ID of the collection")
 	cmd.MarkFlagRequired("collection-id")
 
-	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table")
 
 	return cmd
 }

--- a/cli/cmd/collection_rm.go
+++ b/cli/cmd/collection_rm.go
@@ -18,7 +18,7 @@ func (r *runners) InitCollectionRemove(parent *cobra.Command) *cobra.Command {
 	}
 	parent.AddCommand(cmd)
 
-	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table")
 
 	return cmd
 }

--- a/cli/cmd/customer_create.go
+++ b/cli/cmd/customer_create.go
@@ -97,7 +97,7 @@ replicated customer create --app myapp --name "Full Options Inc" --custom-id "FU
 	cmd.Flags().BoolVar(&opts.IsDeveloperModeEnabled, "developer-mode", false, "If set, Replicated SDK installed in dev mode will use mock data.")
 	cmd.Flags().StringVar(&opts.Email, "email", "", "Email address of the customer that is to be created.")
 	cmd.Flags().StringVar(&opts.CustomerType, "type", "dev", "The license type to create. One of: dev|trial|paid|community|test (default: dev)")
-	cmd.Flags().StringVar(&outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
+	cmd.Flags().StringVarP(&outputFormat, "output", "o", "table", "The output format to use. One of: json|table")
 
 	cmd.MarkFlagRequired("channel")
 

--- a/cli/cmd/customer_inspect.go
+++ b/cli/cmd/customer_inspect.go
@@ -44,7 +44,7 @@ replicated customer inspect --app myapp --customer "Acme Inc"`,
 	}
 	parent.AddCommand(cmd)
 	cmd.Flags().StringVar(&customer, "customer", "", "The Customer Name or ID")
-	cmd.Flags().StringVar(&outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
+	cmd.Flags().StringVarP(&outputFormat, "output", "o", "table", "The output format to use. One of: json|table")
 
 	cmd.MarkFlagRequired("customer")
 

--- a/cli/cmd/customer_ls.go
+++ b/cli/cmd/customer_ls.go
@@ -41,7 +41,7 @@ replicated customer ls --app myapp --output json`,
 	parent.AddCommand(customersLsCmd)
 	customersLsCmd.Flags().StringVar(&appVersion, "app-version", "", "Filter customers by a specific app version")
 	customersLsCmd.Flags().BoolVar(&includeTest, "include-test", false, "Include test customers in the results")
-	customersLsCmd.Flags().StringVar(&outputFormat, "output", "table", "Output format: json|table (default: table)")
+	customersLsCmd.Flags().StringVarP(&outputFormat, "output", "o", "table", "The output format to use. One of: json|table")
 
 	return customersLsCmd
 }

--- a/cli/cmd/customer_update.go
+++ b/cli/cmd/customer_update.go
@@ -96,7 +96,7 @@ replicated customer update --customer cus_abcdef123456 --name "JSON Corp" --outp
 	cmd.Flags().BoolVar(&opts.IsDeveloperModeEnabled, "developer-mode", false, "If set, Replicated SDK installed in dev mode will use mock data.")
 	cmd.Flags().StringVar(&opts.Email, "email", "", "Email address of the customer that is to be updated.")
 	cmd.Flags().StringVar(&opts.Type, "type", "dev", "The license type to update. One of: dev|trial|paid|community|test (default: dev)")
-	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table")
 
 	cmd.MarkFlagRequired("customer")
 	cmd.MarkFlagRequired("channel")

--- a/cli/cmd/default_set.go
+++ b/cli/cmd/default_set.go
@@ -30,7 +30,7 @@ replicated default set app my-app-slug`,
 		},
 	}
 
-	cmd.Flags().StringVar(&outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
+	cmd.Flags().StringVarP(&outputFormat, "output", "o", "table", "The output format to use. One of: json|table")
 	parent.AddCommand(cmd)
 
 	return cmd

--- a/cli/cmd/default_show.go
+++ b/cli/cmd/default_show.go
@@ -33,7 +33,7 @@ replicated default show app
 		},
 	}
 
-	cmd.Flags().StringVar(&outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
+	cmd.Flags().StringVarP(&outputFormat, "output", "o", "table", "The output format to use. One of: json|table")
 	parent.AddCommand(cmd)
 
 	return cmd

--- a/cli/cmd/enterprise_portal_invite.go
+++ b/cli/cmd/enterprise_portal_invite.go
@@ -43,7 +43,7 @@ replicated enterprise-portal invite --app myapp --customer "ACME Inc" user1@exam
 	parent.AddCommand(cmd)
 
 	cmd.Flags().StringVar(&customer, "customer", "", "The customer name or ID to invite")
-	cmd.Flags().StringVar(&outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
+	cmd.Flags().StringVarP(&outputFormat, "output", "o", "table", "The output format to use. One of: json|table")
 
 	cmd.MarkFlagRequired("customer")
 

--- a/cli/cmd/enterprise_portal_user_ls.go
+++ b/cli/cmd/enterprise_portal_user_ls.go
@@ -48,7 +48,7 @@ replicated enterprise-portal user ls --app myapp --include-invites --output tabl
 	parent.AddCommand(cmd)
 
 	cmd.Flags().BoolVar(&opts.includeInvites, "include-invites", false, "Include pending invitations in the list")
-	cmd.Flags().StringVar(&outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
+	cmd.Flags().StringVarP(&outputFormat, "output", "o", "table", "The output format to use. One of: json|table")
 
 	return cmd
 }

--- a/cli/cmd/enterpriseportal_status_get.go
+++ b/cli/cmd/enterpriseportal_status_get.go
@@ -38,7 +38,7 @@ replicated enterprise-portal status get --output table`,
 		SilenceUsage: true,
 	}
 	parent.AddCommand(cmd)
-	cmd.Flags().StringVar(&outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
+	cmd.Flags().StringVarP(&outputFormat, "output", "o", "table", "The output format to use. One of: json|table")
 
 	return cmd
 }

--- a/cli/cmd/enterpriseportal_status_update.go
+++ b/cli/cmd/enterpriseportal_status_update.go
@@ -45,7 +45,7 @@ replicated enterprise-portal status update --status active --output table`,
 	}
 	parent.AddCommand(cmd)
 	cmd.Flags().StringVar(&opts.status, "status", "", "The status to set for the enterprise portal")
-	cmd.Flags().StringVar(&outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
+	cmd.Flags().StringVarP(&outputFormat, "output", "o", "table", "The output format to use. One of: json|table")
 
 	cmd.MarkFlagRequired("status")
 

--- a/cli/cmd/installer_ls.go
+++ b/cli/cmd/installer_ls.go
@@ -15,7 +15,7 @@ func (r *runners) InitInstallerList(parent *cobra.Command) {
 	}
 
 	parent.AddCommand(cmd)
-	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table")
 
 	cmd.RunE = r.installerList
 }

--- a/cli/cmd/instance_inspect.go
+++ b/cli/cmd/instance_inspect.go
@@ -19,7 +19,7 @@ func (r *runners) InitInstanceInspectCommand(parent *cobra.Command) *cobra.Comma
 	parent.AddCommand(cmd)
 	cmd.Flags().StringVar(&r.args.instanceInspectCustomer, "customer", "", "Customer Name or ID")
 	cmd.Flags().StringVar(&r.args.instanceInspectInstance, "instance", "", "Instance Name or ID")
-	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table")
 
 	return cmd
 }

--- a/cli/cmd/instance_ls.go
+++ b/cli/cmd/instance_ls.go
@@ -20,7 +20,7 @@ func (r *runners) InitInstanceLSCommand(parent *cobra.Command) *cobra.Command {
 	parent.AddCommand(cmd)
 	cmd.Flags().StringVar(&r.args.instanceListCustomer, "customer", "", "Customer Name or ID")
 	cmd.Flags().StringArrayVar(&r.args.instanceListTags, "tag", []string{}, "Tags to use to filter instances (key=value format, can be specified multiple times). Only one tag needs to match (an OR operation)")
-	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table")
 
 	return cmd
 }

--- a/cli/cmd/instance_tag.go
+++ b/cli/cmd/instance_tag.go
@@ -19,7 +19,7 @@ func (r *runners) InitInstanceTagCommand(parent *cobra.Command) *cobra.Command {
 	cmd.Flags().StringVar(&r.args.instanceTagCustomer, "customer", "", "Customer Name or ID")
 	cmd.Flags().StringVar(&r.args.instanceTagInstacne, "instance", "", "Instance Name or ID")
 	cmd.Flags().StringArrayVar(&r.args.instanceTagTags, "tag", []string{}, "Tags to apply to instance. Leave value empty to remove tag. Tags not specified will not be removed.")
-	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table")
 
 	return cmd
 }

--- a/cli/cmd/model_ls.go
+++ b/cli/cmd/model_ls.go
@@ -15,7 +15,7 @@ func (r *runners) InitModelList(parent *cobra.Command) *cobra.Command {
 		SilenceUsage: true,
 	}
 	parent.AddCommand(cmd)
-	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table")
 
 	return cmd
 }

--- a/cli/cmd/model_rm.go
+++ b/cli/cmd/model_rm.go
@@ -16,7 +16,7 @@ func (r *runners) InitModelRemove(parent *cobra.Command) *cobra.Command {
 		Args:         cobra.ExactArgs(1),
 	}
 	parent.AddCommand(cmd)
-	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table")
 
 	return cmd
 }

--- a/cli/cmd/network_create.go
+++ b/cli/cmd/network_create.go
@@ -30,7 +30,7 @@ func (r *runners) InitNetworkCreate(parent *cobra.Command) *cobra.Command {
 
 	cmd.Flags().BoolVar(&r.args.createNetworkDryRun, "dry-run", false, "Dry run")
 
-	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table|wide (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table|wide")
 
 	return cmd
 }

--- a/cli/cmd/network_ls.go
+++ b/cli/cmd/network_ls.go
@@ -24,7 +24,7 @@ func (r *runners) InitNetworkList(parent *cobra.Command) *cobra.Command {
 
 	cmd.Flags().StringVar(&r.args.lsNetworkStartTime, "start-time", "", "start time for the query (Format: 2006-01-02T15:04:05Z)")
 	cmd.Flags().StringVar(&r.args.lsNetworkEndTime, "end-time", "", "end time for the query (Format: 2006-01-02T15:04:05Z)")
-	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table|wide (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table|wide")
 	cmd.Flags().BoolVarP(&r.args.lsNetworkWatch, "watch", "w", false, "watch networks")
 
 	return cmd

--- a/cli/cmd/network_update_outbound.go
+++ b/cli/cmd/network_update_outbound.go
@@ -22,7 +22,7 @@ replicated network update outbound NETWORK_ID --outbound any`,
 	parent.AddCommand(cmd)
 
 	cmd.Flags().StringVar(&r.args.updateNetworkOutbound, "outbound", "", "Update outbound setting (must be 'none' or 'any')")
-	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table|wide")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table|wide")
 
 	cmd.MarkFlagRequired("outbound")
 

--- a/cli/cmd/registry_add_dockerhub.go
+++ b/cli/cmd/registry_add_dockerhub.go
@@ -25,7 +25,7 @@ func (r *runners) InitRegistryAddDockerHub(parent *cobra.Command) *cobra.Command
 	cmd.Flags().BoolVar(&r.args.addRegistryPasswordFromStdIn, "password-stdin", false, "Take the password from stdin")
 	cmd.Flags().StringVar(&r.args.addRegistryToken, "token", "", "The token to authenticate to the registry with")
 	cmd.Flags().BoolVar(&r.args.addRegistryTokenFromStdIn, "token-stdin", false, "Take the token from stdin")
-	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table")
 
 	cmd.RunE = r.registryAddDockerHub
 

--- a/cli/cmd/registry_add_ecr.go
+++ b/cli/cmd/registry_add_ecr.go
@@ -23,7 +23,7 @@ func (r *runners) InitRegistryAddECR(parent *cobra.Command) {
 	cmd.Flags().StringVar(&r.args.addRegistryAccessKeyID, "accesskeyid", "", "The access key id to authenticate to the registry with")
 	cmd.Flags().StringVar(&r.args.addRegistrySecretAccessKey, "secretaccesskey", "", "The secret access key to authenticate to the registry with")
 	cmd.Flags().BoolVar(&r.args.addRegistrySecretAccessKeyFromStdIn, "secretaccesskey-stdin", false, "Take the secret access key from stdin")
-	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table")
 
 	cmd.RunE = r.registryAddECR
 }

--- a/cli/cmd/registry_add_gar.go
+++ b/cli/cmd/registry_add_gar.go
@@ -26,7 +26,7 @@ func (r *runners) InitRegistryAddGAR(parent *cobra.Command) {
 	cmd.Flags().BoolVar(&r.args.addRegistryServiceAccountKeyFromStdIn, "serviceaccountkey-stdin", false, "Take the service account key from stdin")
 	cmd.Flags().StringVar(&r.args.addRegistryToken, "token", "", "The token to use to auth to the registry with")
 	cmd.Flags().BoolVar(&r.args.addRegistryTokenFromStdIn, "token-stdin", false, "Take the token from stdin")
-	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table")
 
 	cmd.RunE = r.registryAddGAR
 }

--- a/cli/cmd/registry_add_gcr.go
+++ b/cli/cmd/registry_add_gcr.go
@@ -22,7 +22,7 @@ func (r *runners) InitRegistryAddGCR(parent *cobra.Command) {
 	cmd.Flags().StringVar(&r.args.addRegistryEndpoint, "endpoint", "", "The GCR endpoint")
 	cmd.Flags().StringVar(&r.args.addRegistryServiceAccountKey, "serviceaccountkey", "", "The service account key to authenticate to the registry with")
 	cmd.Flags().BoolVar(&r.args.addRegistryServiceAccountKeyFromStdIn, "serviceaccountkey-stdin", false, "Take the service account key from stdin")
-	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table")
 
 	cmd.RunE = r.registryAddGCR
 }

--- a/cli/cmd/registry_add_ghcr.go
+++ b/cli/cmd/registry_add_ghcr.go
@@ -21,7 +21,7 @@ func (r *runners) InitRegistryAddGHCR(parent *cobra.Command) {
 
 	cmd.Flags().StringVar(&r.args.addRegistryToken, "token", "", "The token to use to auth to the registry with")
 	cmd.Flags().BoolVar(&r.args.addRegistryTokenFromStdIn, "token-stdin", false, "Take the token from stdin")
-	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table")
 
 	cmd.RunE = r.registryAddGHCR
 }

--- a/cli/cmd/registry_add_other.go
+++ b/cli/cmd/registry_add_other.go
@@ -23,7 +23,7 @@ func (r *runners) InitRegistryAddOther(parent *cobra.Command) *cobra.Command {
 	cmd.Flags().StringVar(&r.args.addRegistryUsername, "username", "", "The userame to authenticate to the registry with")
 	cmd.Flags().StringVar(&r.args.addRegistryPassword, "password", "", "The password to authenticate to the registry with")
 	cmd.Flags().BoolVar(&r.args.addRegistryPasswordFromStdIn, "password-stdin", false, "Take the password from stdin")
-	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table")
 
 	cmd.RunE = r.registryAddOther
 

--- a/cli/cmd/registry_add_quay.go
+++ b/cli/cmd/registry_add_quay.go
@@ -22,7 +22,7 @@ func (r *runners) InitRegistryAddQuay(parent *cobra.Command) *cobra.Command {
 	cmd.Flags().StringVar(&r.args.addRegistryUsername, "username", "", "The userame to authenticate to the registry with")
 	cmd.Flags().StringVar(&r.args.addRegistryPassword, "password", "", "The password to authenticate to the registry with")
 	cmd.Flags().BoolVar(&r.args.addRegistryPasswordFromStdIn, "password-stdin", false, "Take the password from stdin")
-	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table")
 
 	cmd.RunE = r.registryAddQuay
 

--- a/cli/cmd/registry_ls.go
+++ b/cli/cmd/registry_ls.go
@@ -19,7 +19,7 @@ func (r *runners) InitRegistryList(parent *cobra.Command) *cobra.Command {
 		SilenceUsage: true,
 	}
 	parent.AddCommand(cmd)
-	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table")
 
 	return cmd
 }

--- a/cli/cmd/release_inspect.go
+++ b/cli/cmd/release_inspect.go
@@ -28,7 +28,7 @@ replicated release inspect 123
 replicated release inspect 123 --output json`,
 		Args: cobra.ExactArgs(1),
 	}
-	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table")
 	parent.AddCommand(cmd)
 
 	cmd.RunE = r.releaseInspect

--- a/cli/cmd/release_lint.go
+++ b/cli/cmd/release_lint.go
@@ -35,7 +35,7 @@ func (r *runners) InitReleaseLint(parent *cobra.Command) {
 	cmd.Flags().StringVar(&r.args.lintReleaseYamlDir, "yaml-dir", "", "The directory containing multiple yamls for a Kots release.  Cannot be used with the `yaml` flag.")
 	cmd.Flags().StringVar(&r.args.lintReleaseChart, "chart", "", "Helm chart to lint from. Cannot be used with the --yaml, --yaml-file, or --yaml-dir flags.")
 	cmd.Flags().StringVar(&r.args.lintReleaseFailOn, "fail-on", "error", "The minimum severity to cause the command to exit with a non-zero exit code. Supported values are [info, warn, error, none].")
-	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table")
 
 	cmd.Flags().MarkHidden("chart")
 

--- a/cli/cmd/release_ls.go
+++ b/cli/cmd/release_ls.go
@@ -15,7 +15,7 @@ func (r *runners) IniReleaseList(parent *cobra.Command) {
 	}
 
 	parent.AddCommand(cmd)
-	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table")
 
 	cmd.RunE = r.releaseList
 }

--- a/cli/cmd/vm_create.go
+++ b/cli/cmd/vm_create.go
@@ -42,9 +42,9 @@ replicated vm create --distribution ubuntu --version 20.04 --count 5 --instance-
 	parent.AddCommand(cmd)
 
 	cmd.Flags().StringVar(&r.args.createVMName, "name", "", "VM name (defaults to random name)")
-	cmd.Flags().StringVar(&r.args.createVMDistribution, "distribution", "", "Distribution of the vm to provision")
+	cmd.Flags().StringVar(&r.args.createVMDistribution, "distribution", "", "Distribution of the VM to provision")
 	cmd.RegisterFlagCompletionFunc("distribution", r.completeVMDistributions)
-	cmd.Flags().StringVar(&r.args.createVMVersion, "version", "", "Vversion to provision (format is distribution dependent)")
+	cmd.Flags().StringVar(&r.args.createVMVersion, "version", "", "Version to provision (format is distribution dependent)")
 	cmd.RegisterFlagCompletionFunc("version", r.completeVMVersions)
 	cmd.Flags().IntVar(&r.args.createVMCount, "count", int(1), "Number of matching VMs to create")
 	cmd.Flags().Int64Var(&r.args.createVMDiskGiB, "disk", int64(50), "Disk Size (GiB) to request per node")
@@ -58,7 +58,7 @@ replicated vm create --distribution ubuntu --version 20.04 --count 5 --instance-
 
 	cmd.Flags().BoolVar(&r.args.createVMDryRun, "dry-run", false, "Dry run")
 
-	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table|wide (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table|wide")
 
 	_ = cmd.MarkFlagRequired("distribution")
 

--- a/cli/cmd/vm_ls.go
+++ b/cli/cmd/vm_ls.go
@@ -42,7 +42,7 @@ replicated vm ls --watch`,
 	cmd.Flags().BoolVar(&r.args.lsVMShowTerminated, "show-terminated", false, "when set, only show terminated vms")
 	cmd.Flags().StringVar(&r.args.lsVMStartTime, "start-time", "", "start time for the query (Format: 2006-01-02T15:04:05Z)")
 	cmd.Flags().StringVar(&r.args.lsVMEndTime, "end-time", "", "end time for the query (Format: 2006-01-02T15:04:05Z)")
-	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table|wide (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table|wide")
 	cmd.Flags().BoolVarP(&r.args.lsVMWatch, "watch", "w", false, "watch vms")
 
 	return cmd

--- a/cli/cmd/vm_port_expose.go
+++ b/cli/cmd/vm_port_expose.go
@@ -39,7 +39,7 @@ replicated vm port expose VM_ID --port 8080 --protocol https --output json`,
 	}
 	cmd.Flags().StringSliceVar(&r.args.vmExposePortProtocols, "protocol", []string{"http", "https"}, `Protocol to expose (valid values are "http", "https", "ws" and "wss")`)
 	cmd.Flags().BoolVar(&r.args.vmExposePortIsWildcard, "wildcard", false, "Create a wildcard DNS entry and TLS certificate for this port")
-	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table|wide (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table|wide")
 
 	return cmd
 }

--- a/cli/cmd/vm_port_ls.go
+++ b/cli/cmd/vm_port_ls.go
@@ -26,7 +26,7 @@ replicated vm port ls VM_ID --output wide`,
 	}
 	parent.AddCommand(cmd)
 
-	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table|wide (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table|wide")
 
 	return cmd
 }

--- a/cli/cmd/vm_port_rm.go
+++ b/cli/cmd/vm_port_rm.go
@@ -28,7 +28,7 @@ replicated vm port rm VM_ID --id PORT_ID --output json`,
 	if err != nil {
 		panic(err)
 	}
-	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table|wide (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table|wide")
 
 	return cmd
 }

--- a/cli/cmd/vm_update_ttl.go
+++ b/cli/cmd/vm_update_ttl.go
@@ -31,7 +31,7 @@ replicated vm update ttl aaaaa11 --ttl 30m`,
 	parent.AddCommand(cmd)
 
 	cmd.Flags().StringVar(&r.args.updateVMTTL, "ttl", "", "Update TTL which starts from the moment the vm is running (duration, max 48h).")
-	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table|wide (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table|wide")
 
 	cmd.MarkFlagRequired("ttl")
 

--- a/cli/cmd/vm_versions.go
+++ b/cli/cmd/vm_versions.go
@@ -29,7 +29,7 @@ replicated vm versions --output json`,
 	parent.AddCommand(cmd)
 
 	cmd.Flags().StringVar(&r.args.lsVersionsDistribution, "distribution", "", "Kubernetes distribution to filter by.")
-	cmd.Flags().StringVar(&r.outputFormat, "output", "table", "The output format to use. One of: json|table (default: table)")
+	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "table", "The output format to use. One of: json|table")
 
 	return cmd
 }


### PR DESCRIPTION
Consistently support `-o` as an alias for `--output`. Also remove duplicate mention of default.

Previously:
<img width="1179" alt="Screenshot 2025-03-20 at 1 31 06 PM" src="https://github.com/user-attachments/assets/6ec36747-5450-4a5e-b0d3-a74c89886a33" />

Now:
<img width="1033" alt="Screenshot 2025-03-20 at 1 31 42 PM" src="https://github.com/user-attachments/assets/c0b06ee9-8fde-4a7a-829c-e8209407b82f" />