### PR TITLE
feat(vm_ssh): support custom identity-file in 'vm ssh' command

### DIFF
--- a/pkg/kotsclient/vm_ssh.go
+++ b/pkg/kotsclient/vm_ssh.go
@@ -7,7 +7,7 @@ import (
 )
 
 // SSHIntoVM connects to a VM via SSH using the provided ID and optional user flag
-func (c *VendorV3Client) SSHIntoVM(vmID string, sshUserFlag string) error {
+func (c *VendorV3Client) SSHIntoVM(vmID string, sshUserFlag string, identityFile string) error {
 	connInfo, err := c.GetSSHConnectionInfo(vmID, sshUserFlag)
 	if err != nil {
 		return err
@@ -18,7 +18,13 @@ func (c *VendorV3Client) SSHIntoVM(vmID string, sshUserFlag string) error {
 		sshEndpoint = fmt.Sprintf("%s@%s", connInfo.User, connInfo.Endpoint)
 	}
 
-	cmd := exec.Command("ssh", sshEndpoint, "-p", fmt.Sprintf("%d", connInfo.Port))
+	var cmd *exec.Cmd
+	if identityFile != "" {
+		cmd = exec.Command("ssh", sshEndpoint, "-p", fmt.Sprintf("%d", connInfo.Port), "-i", identityFile)
+	} else {
+		cmd = exec.Command("ssh", sshEndpoint, "-p", fmt.Sprintf("%d", connInfo.Port))
+	}
+
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
Add `-i, --identity-file` support to the `vm ssh` command to allow a user to specify a custom identity file when using `replicated vm ssh`.

# Testing
```
# I get a password because it's not the right key
./bin/replicated vm ssh -i ~/.ssh/a-key-i-know-wont-work
✔ friendly_kalam (running)
The authenticity of host '[111.222.333.444]:42187 ([111.222.333.444]:42187)' can't be established.
ED25519 key fingerprint is SHA256:cyQAAVxafABejTt5GGt94nTChXLPiC23kFEzLQBIl6s.
This key is not known by any other names.
Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
Warning: Permanently added '[111.222.333.444]:42187' (ED25519) to the list of known hosts.
squizzi@111.222.333.444's password:


# My actual key lets me in
/bin/replicated vm ssh -i ~/.ssh/id_ed25519
✔ friendly_kalam (running)
$ 

./bin/replicated vm ssh -i ~/not-real
Error: identity file does not exist or is not accessible: stat /Users/squizzi/not-real: no such file or directory
```