### PR TITLE
Optionally send optional values

### DIFF
--- a/cli/cmd/customer_create.go
+++ b/cli/cmd/customer_create.go
@@ -173,25 +173,23 @@ func (r *runners) createCustomer(cmd *cobra.Command, opts createCustomerOpts, ou
 	}
 
 	createOpts := kotsclient.CreateCustomerOpts{
-		Name:                               opts.Name,
-		CustomID:                           opts.CustomID,
-		Channels:                           channels,
-		AppID:                              r.appID,
-		ExpiresAtDuration:                  opts.ExpiryDuration,
-		IsAirgapEnabled:                    opts.IsAirgapEnabled,
-		IsGitopsSupported:                  opts.IsGitopsSupported,
-		IsSnapshotSupported:                opts.IsSnapshotSupported,
-		IsKotsInstallEnabled:               opts.IsKotsInstallEnabled,
-		IsEmbeddedClusterDownloadEnabled:   opts.IsEmbeddedClusterDownloadEnabled,
-		IsEmbeddedClusterMultinodeEnabled:  opts.IsEmbeddedClusterMultinodeEnabled,
-		IsGeoaxisSupported:                 opts.IsGeoaxisSupported,
-		IsHelmVMDownloadEnabled:            opts.IsHelmVMDownloadEnabled,
-		IsIdentityServiceSupported:         opts.IsIdentityServiceSupported,
-		IsInstallerSupportEnabled:          opts.IsInstallerSupportEnabled,
-		IsSupportBundleUploadEnabled:       opts.IsSupportBundleUploadEnabled,
-		IsDeveloperModeEnabled:             opts.IsDeveloperModeEnabled,
-		LicenseType:                        opts.CustomerType,
-		Email:                              opts.Email,
+		Name:                         opts.Name,
+		CustomID:                     opts.CustomID,
+		Channels:                     channels,
+		AppID:                        r.appID,
+		ExpiresAtDuration:            opts.ExpiryDuration,
+		IsAirgapEnabled:              opts.IsAirgapEnabled,
+		IsGitopsSupported:            opts.IsGitopsSupported,
+		IsSnapshotSupported:          opts.IsSnapshotSupported,
+		IsKotsInstallEnabled:         opts.IsKotsInstallEnabled,
+		IsGeoaxisSupported:           opts.IsGeoaxisSupported,
+		IsHelmVMDownloadEnabled:      opts.IsHelmVMDownloadEnabled,
+		IsIdentityServiceSupported:   opts.IsIdentityServiceSupported,
+		IsInstallerSupportEnabled:    opts.IsInstallerSupportEnabled,
+		IsSupportBundleUploadEnabled: opts.IsSupportBundleUploadEnabled,
+		IsDeveloperModeEnabled:       opts.IsDeveloperModeEnabled,
+		LicenseType:                  opts.CustomerType,
+		Email:                        opts.Email,
 	}
 
 	if cmd.Flags().Changed("helm-install") {
@@ -199,6 +197,12 @@ func (r *runners) createCustomer(cmd *cobra.Command, opts createCustomerOpts, ou
 	}
 	if cmd.Flags().Changed("kurl-install") {
 		createOpts.IsKurlInstallEnabled = &opts.IsKurlInstallEnabled
+	}
+	if cmd.Flags().Changed("embedded-cluster-download") {
+		createOpts.IsEmbeddedClusterDownloadEnabled = &opts.IsEmbeddedClusterDownloadEnabled
+	}
+	if cmd.Flags().Changed("embedded-cluster-multinode") {
+		createOpts.IsEmbeddedClusterMultinodeEnabled = &opts.IsEmbeddedClusterMultinodeEnabled
 	}
 
 	customer, err := r.api.CreateCustomer(r.appType, createOpts)

--- a/cli/cmd/customer_update.go
+++ b/cli/cmd/customer_update.go
@@ -179,24 +179,22 @@ func (r *runners) updateCustomer(cmd *cobra.Command, opts updateCustomerOpts) (e
 	}
 
 	updateOpts := kotsclient.UpdateCustomerOpts{
-		Name:                               opts.Name,
-		CustomID:                           opts.CustomID,
-		Channels:                           channels,
-		AppID:                              r.appID,
-		ExpiresAtDuration:                  opts.ExpiryDuration,
-		IsAirgapEnabled:                    opts.IsAirgapEnabled,
-		IsGitopsSupported:                  opts.IsGitopsSupported,
-		IsSnapshotSupported:                opts.IsSnapshotSupported,
-		IsKotsInstallEnabled:               opts.IsKotsInstallEnabled,
-		IsEmbeddedClusterDownloadEnabled:   opts.IsEmbeddedClusterDownloadEnabled,
-		IsEmbeddedClusterMultinodeEnabled:  opts.IsEmbeddedClusterMultinodeEnabled,
-		IsGeoaxisSupported:                 opts.IsGeoaxisSupported,
-		IsHelmVMDownloadEnabled:            opts.IsHelmVMDownloadEnabled,
-		IsIdentityServiceSupported:         opts.IsIdentityServiceSupported,
-		IsSupportBundleUploadEnabled:       opts.IsSupportBundleUploadEnabled,
-		IsDeveloperModeEnabled:             opts.IsDeveloperModeEnabled,
-		LicenseType:                        opts.Type,
-		Email:                              opts.Email,
+		Name:                         opts.Name,
+		CustomID:                     opts.CustomID,
+		Channels:                     channels,
+		AppID:                        r.appID,
+		ExpiresAtDuration:            opts.ExpiryDuration,
+		IsAirgapEnabled:              opts.IsAirgapEnabled,
+		IsGitopsSupported:            opts.IsGitopsSupported,
+		IsSnapshotSupported:          opts.IsSnapshotSupported,
+		IsKotsInstallEnabled:         opts.IsKotsInstallEnabled,
+		IsGeoaxisSupported:           opts.IsGeoaxisSupported,
+		IsHelmVMDownloadEnabled:      opts.IsHelmVMDownloadEnabled,
+		IsIdentityServiceSupported:   opts.IsIdentityServiceSupported,
+		IsSupportBundleUploadEnabled: opts.IsSupportBundleUploadEnabled,
+		IsDeveloperModeEnabled:       opts.IsDeveloperModeEnabled,
+		LicenseType:                  opts.Type,
+		Email:                        opts.Email,
 	}
 
 	if cmd.Flags().Changed("helm-install") {
@@ -204,6 +202,12 @@ func (r *runners) updateCustomer(cmd *cobra.Command, opts updateCustomerOpts) (e
 	}
 	if cmd.Flags().Changed("kurl-install") {
 		updateOpts.IsKurlInstallEnabled = &opts.IsKurlInstallEnabled
+	}
+	if cmd.Flags().Changed("embedded-cluster-download") {
+		updateOpts.IsEmbeddedClusterDownloadEnabled = &opts.IsEmbeddedClusterDownloadEnabled
+	}
+	if cmd.Flags().Changed("embedded-cluster-multinode") {
+		updateOpts.IsEmbeddedClusterMultinodeEnabled = &opts.IsEmbeddedClusterMultinodeEnabled
 	}
 
 	customer, err := r.api.UpdateCustomer(r.appType, opts.CustomerID, updateOpts)

--- a/pkg/kotsclient/customer_create.go
+++ b/pkg/kotsclient/customer_create.go
@@ -21,31 +21,31 @@ type CustomerChannel struct {
 }
 
 type CreateCustomerRequest struct {
-	Name                               string             `json:"name"`
-	Channels                           []CustomerChannel  `json:"channels"`
-	CustomID                           string             `json:"custom_id"`
-	AppID                              string             `json:"app_id"`
-	Type                               string             `json:"type"`
-	ExpiresAt                          string             `json:"expires_at"`
-	IsAirgapEnabled                    bool               `json:"is_airgap_enabled"`
-	IsGitopsSupported                  bool               `json:"is_gitops_supported"`
-	IsSnapshotSupported                bool               `json:"is_snapshot_supported"`
-	IsKotsInstallEnabled               bool               `json:"is_kots_install_enabled"`
-	IsEmbeddedClusterDownloadEnabled   bool               `json:"is_embedded_cluster_download_enabled"`
-	IsEmbeddedClusterMultinodeEnabled  bool               `json:"is_embedded_cluster_multinode_enabled"`
-	IsGeoaxisSupported                 bool               `json:"is_geoaxis_supported"`
-	IsHelmVMDownloadEnabled            bool               `json:"is_helm_vm_download_enabled"`
-	IsIdentityServiceSupported         bool               `json:"is_identity_service_supported"`
-	IsInstallerSupportEnabled          bool               `json:"is_installer_support_enabled"`
-	IsSupportBundleUploadEnabled       bool               `json:"is_support_bundle_upload_enabled"`
-	IsDeveloperModeEnabled             bool               `json:"is_dev_mode_enabled"`
-	Email                              string             `json:"email,omitempty"`
-	EntitlementValues                  []EntitlementValue `json:"entitlementValues"`
+	Name                         string             `json:"name"`
+	Channels                     []CustomerChannel  `json:"channels"`
+	CustomID                     string             `json:"custom_id"`
+	AppID                        string             `json:"app_id"`
+	Type                         string             `json:"type"`
+	ExpiresAt                    string             `json:"expires_at"`
+	IsAirgapEnabled              bool               `json:"is_airgap_enabled"`
+	IsGitopsSupported            bool               `json:"is_gitops_supported"`
+	IsSnapshotSupported          bool               `json:"is_snapshot_supported"`
+	IsKotsInstallEnabled         bool               `json:"is_kots_install_enabled"`
+	IsGeoaxisSupported           bool               `json:"is_geoaxis_supported"`
+	IsHelmVMDownloadEnabled      bool               `json:"is_helm_vm_download_enabled"`
+	IsIdentityServiceSupported   bool               `json:"is_identity_service_supported"`
+	IsInstallerSupportEnabled    bool               `json:"is_installer_support_enabled"`
+	IsSupportBundleUploadEnabled bool               `json:"is_support_bundle_upload_enabled"`
+	IsDeveloperModeEnabled       bool               `json:"is_dev_mode_enabled"`
+	Email                        string             `json:"email,omitempty"`
+	EntitlementValues            []EntitlementValue `json:"entitlementValues"`
 
 	// These fields were added after the "built in" fields feature was released.
 	// If they are not pointer types, they will override the defaults.
-	IsHelmInstallEnabled *bool `json:"is_helm_install_enabled,omitempty"`
-	IsKurlInstallEnabled *bool `json:"is_kurl_install_enabled,omitempty"`
+	IsHelmInstallEnabled              *bool `json:"is_helm_install_enabled,omitempty"`
+	IsKurlInstallEnabled              *bool `json:"is_kurl_install_enabled,omitempty"`
+	IsEmbeddedClusterDownloadEnabled  *bool `json:"is_embedded_cluster_download_enabled,omitempty"`
+	IsEmbeddedClusterMultinodeEnabled *bool `json:"is_embedded_cluster_multinode_enabled,omitempty"`
 }
 
 type CreateCustomerResponse struct {
@@ -53,54 +53,54 @@ type CreateCustomerResponse struct {
 }
 
 type CreateCustomerOpts struct {
-	Name                               string
-	CustomID                           string
-	Channels                           []CustomerChannel
-	AppID                              string
-	ExpiresAt                          string
-	ExpiresAtDuration                  time.Duration
-	IsAirgapEnabled                    bool
-	IsGitopsSupported                  bool
-	IsSnapshotSupported                bool
-	IsKotsInstallEnabled               bool
-	IsHelmInstallEnabled               *bool
-	IsKurlInstallEnabled               *bool
-	IsEmbeddedClusterDownloadEnabled   bool
-	IsEmbeddedClusterMultinodeEnabled  bool
-	IsGeoaxisSupported                 bool
-	IsHelmVMDownloadEnabled            bool
-	IsIdentityServiceSupported         bool
-	IsInstallerSupportEnabled          bool
-	IsSupportBundleUploadEnabled       bool
-	IsDeveloperModeEnabled             bool
-	LicenseType                        string
-	Email                              string
-	EntitlementValues                  []EntitlementValue
+	Name                              string
+	CustomID                          string
+	Channels                          []CustomerChannel
+	AppID                             string
+	ExpiresAt                         string
+	ExpiresAtDuration                 time.Duration
+	IsAirgapEnabled                   bool
+	IsGitopsSupported                 bool
+	IsSnapshotSupported               bool
+	IsKotsInstallEnabled              bool
+	IsHelmInstallEnabled              *bool
+	IsKurlInstallEnabled              *bool
+	IsEmbeddedClusterDownloadEnabled  *bool
+	IsEmbeddedClusterMultinodeEnabled *bool
+	IsGeoaxisSupported                bool
+	IsHelmVMDownloadEnabled           bool
+	IsIdentityServiceSupported        bool
+	IsInstallerSupportEnabled         bool
+	IsSupportBundleUploadEnabled      bool
+	IsDeveloperModeEnabled            bool
+	LicenseType                       string
+	Email                             string
+	EntitlementValues                 []EntitlementValue
 }
 
 func (c *VendorV3Client) CreateCustomer(opts CreateCustomerOpts) (*types.Customer, error) {
 	request := &CreateCustomerRequest{
-		Name:                               opts.Name,
-		CustomID:                           opts.CustomID,
-		Channels:                           opts.Channels,
-		AppID:                              opts.AppID,
-		Type:                               opts.LicenseType,
-		IsAirgapEnabled:                    opts.IsAirgapEnabled,
-		IsGitopsSupported:                  opts.IsGitopsSupported,
-		IsSnapshotSupported:                opts.IsSnapshotSupported,
-		IsKotsInstallEnabled:               opts.IsKotsInstallEnabled,
-		IsHelmInstallEnabled:               opts.IsHelmInstallEnabled,
-		IsKurlInstallEnabled:               opts.IsKurlInstallEnabled,
-		IsEmbeddedClusterDownloadEnabled:   opts.IsEmbeddedClusterDownloadEnabled,
-		IsEmbeddedClusterMultinodeEnabled:  opts.IsEmbeddedClusterMultinodeEnabled,
-		IsGeoaxisSupported:                 opts.IsGeoaxisSupported,
-		IsHelmVMDownloadEnabled:            opts.IsHelmVMDownloadEnabled,
-		IsIdentityServiceSupported:         opts.IsIdentityServiceSupported,
-		IsInstallerSupportEnabled:          opts.IsInstallerSupportEnabled,
-		IsSupportBundleUploadEnabled:       opts.IsSupportBundleUploadEnabled,
-		IsDeveloperModeEnabled:             opts.IsDeveloperModeEnabled,
-		Email:                              opts.Email,
-		EntitlementValues:                  opts.EntitlementValues,
+		Name:                              opts.Name,
+		CustomID:                          opts.CustomID,
+		Channels:                          opts.Channels,
+		AppID:                             opts.AppID,
+		Type:                              opts.LicenseType,
+		IsAirgapEnabled:                   opts.IsAirgapEnabled,
+		IsGitopsSupported:                 opts.IsGitopsSupported,
+		IsSnapshotSupported:               opts.IsSnapshotSupported,
+		IsKotsInstallEnabled:              opts.IsKotsInstallEnabled,
+		IsHelmInstallEnabled:              opts.IsHelmInstallEnabled,
+		IsKurlInstallEnabled:              opts.IsKurlInstallEnabled,
+		IsEmbeddedClusterDownloadEnabled:  opts.IsEmbeddedClusterDownloadEnabled,
+		IsEmbeddedClusterMultinodeEnabled: opts.IsEmbeddedClusterMultinodeEnabled,
+		IsGeoaxisSupported:                opts.IsGeoaxisSupported,
+		IsHelmVMDownloadEnabled:           opts.IsHelmVMDownloadEnabled,
+		IsIdentityServiceSupported:        opts.IsIdentityServiceSupported,
+		IsInstallerSupportEnabled:         opts.IsInstallerSupportEnabled,
+		IsSupportBundleUploadEnabled:      opts.IsSupportBundleUploadEnabled,
+		IsDeveloperModeEnabled:            opts.IsDeveloperModeEnabled,
+		Email:                             opts.Email,
+		EntitlementValues:                 opts.EntitlementValues,
 	}
 
 	// if expiresAtDuration is set, calculate the expiresAt time

--- a/pkg/kotsclient/customer_update.go
+++ b/pkg/kotsclient/customer_update.go
@@ -11,30 +11,30 @@ import (
 )
 
 type UpdateCustomerRequest struct {
-	Name                               string             `json:"name"`
-	Channels                           []CustomerChannel  `json:"channels"`
-	CustomID                           string             `json:"custom_id"`
-	AppID                              string             `json:"app_id"`
-	Type                               string             `json:"type"`
-	ExpiresAt                          string             `json:"expires_at"`
-	IsAirgapEnabled                    bool               `json:"is_airgap_enabled"`
-	IsGitopsSupported                  bool               `json:"is_gitops_supported"`
-	IsSnapshotSupported                bool               `json:"is_snapshot_supported"`
-	IsKotsInstallEnabled               bool               `json:"is_kots_install_enabled"`
-	IsEmbeddedClusterDownloadEnabled   bool               `json:"is_embedded_cluster_download_enabled"`
-	IsEmbeddedClusterMultinodeEnabled  bool               `json:"is_embedded_cluster_multinode_enabled"`
-	IsGeoaxisSupported                 bool               `json:"is_geoaxis_supported"`
-	IsHelmVMDownloadEnabled            bool               `json:"is_helm_vm_download_enabled"`
-	IsIdentityServiceSupported         bool               `json:"is_identity_service_supported"`
-	IsSupportBundleUploadEnabled       bool               `json:"is_support_bundle_upload_enabled"`
-	IsDeveloperModeEnabled             bool               `json:"is_dev_mode_enabled"`
-	Email                              string             `json:"email,omitempty"`
-	EntitlementValues                  []EntitlementValue `json:"entitlementValues"`
+	Name                         string             `json:"name"`
+	Channels                     []CustomerChannel  `json:"channels"`
+	CustomID                     string             `json:"custom_id"`
+	AppID                        string             `json:"app_id"`
+	Type                         string             `json:"type"`
+	ExpiresAt                    string             `json:"expires_at"`
+	IsAirgapEnabled              bool               `json:"is_airgap_enabled"`
+	IsGitopsSupported            bool               `json:"is_gitops_supported"`
+	IsSnapshotSupported          bool               `json:"is_snapshot_supported"`
+	IsKotsInstallEnabled         bool               `json:"is_kots_install_enabled"`
+	IsGeoaxisSupported           bool               `json:"is_geoaxis_supported"`
+	IsHelmVMDownloadEnabled      bool               `json:"is_helm_vm_download_enabled"`
+	IsIdentityServiceSupported   bool               `json:"is_identity_service_supported"`
+	IsSupportBundleUploadEnabled bool               `json:"is_support_bundle_upload_enabled"`
+	IsDeveloperModeEnabled       bool               `json:"is_dev_mode_enabled"`
+	Email                        string             `json:"email,omitempty"`
+	EntitlementValues            []EntitlementValue `json:"entitlementValues"`
 
 	// These fields were added after the "built in" fields feature was released.
 	// If they are not pointer types, they will override the defaults.
-	IsHelmInstallEnabled *bool `json:"is_helm_install_enabled,omitempty"`
-	IsKurlInstallEnabled *bool `json:"is_kurl_install_enabled,omitempty"`
+	IsHelmInstallEnabled              *bool `json:"is_helm_install_enabled,omitempty"`
+	IsKurlInstallEnabled              *bool `json:"is_kurl_install_enabled,omitempty"`
+	IsEmbeddedClusterDownloadEnabled  *bool `json:"is_embedded_cluster_download_enabled,omitempty"`
+	IsEmbeddedClusterMultinodeEnabled *bool `json:"is_embedded_cluster_multinode_enabled,omitempty"`
 }
 
 type UpdateCustomerResponse struct {
@@ -42,52 +42,52 @@ type UpdateCustomerResponse struct {
 }
 
 type UpdateCustomerOpts struct {
-	Name                               string
-	CustomID                           string
-	Channels                           []CustomerChannel
-	AppID                              string
-	ExpiresAt                          string
-	ExpiresAtDuration                  time.Duration
-	IsAirgapEnabled                    bool
-	IsGitopsSupported                  bool
-	IsSnapshotSupported                bool
-	IsKotsInstallEnabled               bool
-	IsHelmInstallEnabled               *bool
-	IsKurlInstallEnabled               *bool
-	IsEmbeddedClusterDownloadEnabled   bool
-	IsEmbeddedClusterMultinodeEnabled  bool
-	IsGeoaxisSupported                 bool
-	IsHelmVMDownloadEnabled            bool
-	IsIdentityServiceSupported         bool
-	IsSupportBundleUploadEnabled       bool
-	IsDeveloperModeEnabled             bool
-	LicenseType                        string
-	Email                              string
-	EntitlementValues                  []EntitlementValue
+	Name                              string
+	CustomID                          string
+	Channels                          []CustomerChannel
+	AppID                             string
+	ExpiresAt                         string
+	ExpiresAtDuration                 time.Duration
+	IsAirgapEnabled                   bool
+	IsGitopsSupported                 bool
+	IsSnapshotSupported               bool
+	IsKotsInstallEnabled              bool
+	IsHelmInstallEnabled              *bool
+	IsKurlInstallEnabled              *bool
+	IsEmbeddedClusterDownloadEnabled  *bool
+	IsEmbeddedClusterMultinodeEnabled *bool
+	IsGeoaxisSupported                bool
+	IsHelmVMDownloadEnabled           bool
+	IsIdentityServiceSupported        bool
+	IsSupportBundleUploadEnabled      bool
+	IsDeveloperModeEnabled            bool
+	LicenseType                       string
+	Email                             string
+	EntitlementValues                 []EntitlementValue
 }
 
 func (c *VendorV3Client) UpdateCustomer(customerID string, opts UpdateCustomerOpts) (*types.Customer, error) {
 	request := &UpdateCustomerRequest{
-		Name:                               opts.Name,
-		CustomID:                           opts.CustomID,
-		Channels:                           opts.Channels,
-		AppID:                              opts.AppID,
-		Type:                               opts.LicenseType,
-		IsAirgapEnabled:                    opts.IsAirgapEnabled,
-		IsGitopsSupported:                  opts.IsGitopsSupported,
-		IsSnapshotSupported:                opts.IsSnapshotSupported,
-		IsKotsInstallEnabled:               opts.IsKotsInstallEnabled,
-		IsHelmInstallEnabled:               opts.IsHelmInstallEnabled,
-		IsKurlInstallEnabled:               opts.IsKurlInstallEnabled,
-		IsEmbeddedClusterDownloadEnabled:   opts.IsEmbeddedClusterDownloadEnabled,
-		IsEmbeddedClusterMultinodeEnabled:  opts.IsEmbeddedClusterMultinodeEnabled,
-		IsGeoaxisSupported:                 opts.IsGeoaxisSupported,
-		IsHelmVMDownloadEnabled:            opts.IsHelmVMDownloadEnabled,
-		IsIdentityServiceSupported:         opts.IsIdentityServiceSupported,
-		IsSupportBundleUploadEnabled:       opts.IsSupportBundleUploadEnabled,
-		IsDeveloperModeEnabled:             opts.IsDeveloperModeEnabled,
-		Email:                              opts.Email,
-		EntitlementValues:                  opts.EntitlementValues,
+		Name:                              opts.Name,
+		CustomID:                          opts.CustomID,
+		Channels:                          opts.Channels,
+		AppID:                             opts.AppID,
+		Type:                              opts.LicenseType,
+		IsAirgapEnabled:                   opts.IsAirgapEnabled,
+		IsGitopsSupported:                 opts.IsGitopsSupported,
+		IsSnapshotSupported:               opts.IsSnapshotSupported,
+		IsKotsInstallEnabled:              opts.IsKotsInstallEnabled,
+		IsHelmInstallEnabled:              opts.IsHelmInstallEnabled,
+		IsKurlInstallEnabled:              opts.IsKurlInstallEnabled,
+		IsEmbeddedClusterDownloadEnabled:  opts.IsEmbeddedClusterDownloadEnabled,
+		IsEmbeddedClusterMultinodeEnabled: opts.IsEmbeddedClusterMultinodeEnabled,
+		IsGeoaxisSupported:                opts.IsGeoaxisSupported,
+		IsHelmVMDownloadEnabled:           opts.IsHelmVMDownloadEnabled,
+		IsIdentityServiceSupported:        opts.IsIdentityServiceSupported,
+		IsSupportBundleUploadEnabled:      opts.IsSupportBundleUploadEnabled,
+		IsDeveloperModeEnabled:            opts.IsDeveloperModeEnabled,
+		Email:                             opts.Email,
+		EntitlementValues:                 opts.EntitlementValues,
 	}
 
 	// If duration is set, calculate the expiry time


### PR DESCRIPTION
only send embeddedClusterDownloadEnabled and embeddedClustermultinodeenabled when they are set.  this avoid the following error:

```
ERROR: 400
METHOD: POST
ENDPOINT: https://api.replicated.com/vendor/v3/customer
is_embedded_cluster_multinode_enabled cannot be true if is_embedded_cluster_download_enabled is false
```

The problem is that embeddedClusterDownloadEnabled is true in the license policy, but the current CLI is sending false if i don't specify it.
