### PR TITLE
chore(cmx): Make disk_gib viewable in 'vm ls -o json'

### DIFF
--- a/pkg/types/vm.go
+++ b/pkg/types/vm.go
@@ -9,6 +9,7 @@ type VM struct {
 	InstanceType string `json:"instance_type"`
 	Version      string `json:"version"`
 	Network      string `json:"network_id"`
+	DiskGiB      int64  `json:"disk_gib"`
 
 	Status    VMStatus  `json:"status"`
 	CreatedAt time.Time `json:"created_at"`


### PR DESCRIPTION
Quick fix to make `disk_gib` a viewable entry in `vm ls -o json`

```
./bin/replicated vm ls -ojson
[
  {
    "id": "b1f451e6",
    "name": "awesome_easley",
    "distribution": "ubuntu",
    "instance_type": "r1.small",
    "version": "24.04",
    "network_id": "596f0dba10e8a4bfa77e0552eb8aec4aca6ca81d676799eaf0fa4a70889990b2",
    "disk_gib": 20, <---
    "status": "running",
    "created_at": "2025-05-06T20:56:28Z",
    "expires_at": "2025-05-06T21:58:02Z",
    "ttl": "1h",
    "credits_per_hour": 9600,
    "flat_fee": 50000,
    "total_credits": 0,
    "estimated_cost": 59600,
    "direct_ssh_port": 45663,
    "direct_ssh_endpoint": "65.109.157.169",
    "tags": []
  }
]
```