### PR TITLE
feature(cmx): add ability to set custom username

### DIFF
--- a/cli/cmd/vm_endpoints_test.go
+++ b/cli/cmd/vm_endpoints_test.go
@@ -23,8 +23,10 @@ func TestGetVMEndpoint(t *testing.T) {
 		name               string    // Test case name
 		vmID               string    // Virtual machine ID to test
 		endpointType       string    // Endpoint type (ssh, scp, or invalid)
+		username           string    // Custom username (empty to use GitHub username)
 		mockVM             *types.VM // Mock VM response from API
 		mockGithubUsername string    // Mock GitHub username response
+		githubAPIError     bool      // Should GitHub username API return an error
 		expectedOutput     string    // Expected output to stdout
 		expectedError      string    // Expected error string (empty for no error)
 	}{
@@ -32,6 +34,7 @@ func TestGetVMEndpoint(t *testing.T) {
 			name:         "Success - Get SSH endpoint for running VM",
 			vmID:         "vm-123",
 			endpointType: "ssh",
+			username:     "",
 			mockVM: &types.VM{
 				ID:                "vm-123",
 				DirectSSHEndpoint: "test-vm.example.com",
@@ -39,6 +42,7 @@ func TestGetVMEndpoint(t *testing.T) {
 				Status:            types.VMStatusRunning,
 			},
 			mockGithubUsername: "testuser",
+			githubAPIError:     false,
 			expectedOutput:     "ssh://testuser@test-vm.example.com:22\n",
 			expectedError:      "",
 		},
@@ -46,6 +50,7 @@ func TestGetVMEndpoint(t *testing.T) {
 			name:         "Success - Get SCP endpoint for running VM",
 			vmID:         "vm-456",
 			endpointType: "scp",
+			username:     "",
 			mockVM: &types.VM{
 				ID:                "vm-456",
 				DirectSSHEndpoint: "test-vm.example.com",
@@ -53,13 +58,31 @@ func TestGetVMEndpoint(t *testing.T) {
 				Status:            types.VMStatusRunning,
 			},
 			mockGithubUsername: "testuser",
+			githubAPIError:     false,
 			expectedOutput:     "scp://testuser@test-vm.example.com:22\n",
+			expectedError:      "",
+		},
+		{
+			name:         "Success - Custom username provided",
+			vmID:         "vm-123",
+			endpointType: "ssh",
+			username:     "customuser",
+			mockVM: &types.VM{
+				ID:                "vm-123",
+				DirectSSHEndpoint: "test-vm.example.com",
+				DirectSSHPort:     22,
+				Status:            types.VMStatusRunning,
+			},
+			mockGithubUsername: "testuser", // Should be ignored
+			githubAPIError:     false,      // Should be ignored
+			expectedOutput:     "ssh://customuser@test-vm.example.com:22\n",
 			expectedError:      "",
 		},
 		{
 			name:         "Error - Missing SSH endpoint configuration",
 			vmID:         "vm-789",
 			endpointType: "ssh",
+			username:     "",
 			mockVM: &types.VM{
 				ID:                "vm-789",
 				DirectSSHEndpoint: "",
@@ -67,6 +90,7 @@ func TestGetVMEndpoint(t *testing.T) {
 				Status:            types.VMStatusRunning,
 			},
 			mockGithubUsername: "testuser",
+			githubAPIError:     false,
 			expectedOutput:     "",
 			expectedError:      "VM vm-789 does not have ssh endpoint configured",
 		},
@@ -74,6 +98,7 @@ func TestGetVMEndpoint(t *testing.T) {
 			name:         "Error - Missing GitHub username",
 			vmID:         "vm-123",
 			endpointType: "ssh",
+			username:     "",
 			mockVM: &types.VM{
 				ID:                "vm-123",
 				DirectSSHEndpoint: "test-vm.example.com",
@@ -81,13 +106,31 @@ func TestGetVMEndpoint(t *testing.T) {
 				Status:            types.VMStatusRunning,
 			},
 			mockGithubUsername: "",
+			githubAPIError:     false,
 			expectedOutput:     "",
 			expectedError:      "no github account associated with vendor portal user",
+		},
+		{
+			name:         "Error - GitHub username API error",
+			vmID:         "vm-123",
+			endpointType: "ssh",
+			username:     "",
+			mockVM: &types.VM{
+				ID:                "vm-123",
+				DirectSSHEndpoint: "test-vm.example.com",
+				DirectSSHPort:     22,
+				Status:            types.VMStatusRunning,
+			},
+			mockGithubUsername: "", // Won't be used due to API error
+			githubAPIError:     true,
+			expectedOutput:     "",
+			expectedError:      "--username flag to specify a custom username", // Check for new error message
 		},
 		{
 			name:         "Error - Invalid endpoint type",
 			vmID:         "vm-123",
 			endpointType: "invalid",
+			username:     "",
 			mockVM: &types.VM{
 				ID:                "vm-123",
 				DirectSSHEndpoint: "test-vm.example.com",
@@ -95,6 +138,7 @@ func TestGetVMEndpoint(t *testing.T) {
 				Status:            types.VMStatusRunning,
 			},
 			mockGithubUsername: "testuser",
+			githubAPIError:     false,
 			expectedOutput:     "",
 			expectedError:      "invalid endpoint type: invalid",
 		},
@@ -102,6 +146,7 @@ func TestGetVMEndpoint(t *testing.T) {
 			name:         "Error - VM not in running state",
 			vmID:         "vm-123",
 			endpointType: "ssh",
+			username:     "",
 			mockVM: &types.VM{
 				ID:                "vm-123",
 				DirectSSHEndpoint: "test-vm.example.com",
@@ -109,6 +154,7 @@ func TestGetVMEndpoint(t *testing.T) {
 				Status:            types.VMStatusProvisioning,
 			},
 			mockGithubUsername: "testuser",
+			githubAPIError:     false,
 			expectedOutput:     "",
 			expectedError:      "VM vm-123 is not in running state (current state: provisioning). SSH is only available for running VMs",
 		},
@@ -117,7 +163,7 @@ func TestGetVMEndpoint(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			// Create a mock server and client for API testing
-			server, apiClient := createMockServerAndClient(tc.vmID, tc.mockVM, tc.mockGithubUsername)
+			server, apiClient := createMockServerAndClient(tc.vmID, tc.mockVM, tc.mockGithubUsername, tc.githubAPIError)
 			defer server.Close()
 
 			// Capture stdout directly
@@ -131,7 +177,7 @@ func TestGetVMEndpoint(t *testing.T) {
 			}
 
 			// Execute the function under test
-			err := runner.getVMEndpoint(tc.vmID, tc.endpointType)
+			err := runner.getVMEndpoint(tc.vmID, tc.endpointType, tc.username)
 
 			// Get captured output
 			w.Close()
@@ -153,7 +199,7 @@ func TestGetVMEndpoint(t *testing.T) {
 }
 
 // createMockServerAndClient sets up a mock HTTP server and returns both kotsAPI.GetVM and kotsAPI.GetGitHubUsername
-func createMockServerAndClient(vmID string, mockVM *types.VM, mockGithubUsername string) (*httptest.Server, *kotsclient.VendorV3Client) {
+func createMockServerAndClient(vmID string, mockVM *types.VM, mockGithubUsername string, githubAPIError bool) (*httptest.Server, *kotsclient.VendorV3Client) {
 	// Create a mock HTTP server to handle API requests
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -168,6 +214,11 @@ func createMockServerAndClient(vmID string, mockVM *types.VM, mockGithubUsername
 
 		// Handle GetGitHubUsername request
 		case r.URL.Path == "/v1/user" && r.Method == "GET":
+			if githubAPIError {
+				w.WriteHeader(http.StatusInternalServerError)
+				json.NewEncoder(w).Encode(map[string]string{"error": "GitHub API error"})
+				return
+			}
 			response := kotsclient.GetUserResponse{
 				GitHubUsername: mockGithubUsername,
 			}

--- a/cli/cmd/vm_endpoints_test.go
+++ b/cli/cmd/vm_endpoints_test.go
@@ -108,7 +108,7 @@ func TestGetVMEndpoint(t *testing.T) {
 			mockGithubUsername: "",
 			githubAPIError:     false,
 			expectedOutput:     "",
-			expectedError:      "no github account associated with vendor portal user",
+			expectedError:      "no GitHub account associated with Vendor Portal user",
 		},
 		{
 			name:         "Error - GitHub username API error",


### PR DESCRIPTION
This PR adds support for overriding the `GitHubUsername` value set in vendor-portal.  It can be overridden in the event that the username cannot be obtained from portal either for reason of error or simply the fact that the username is not populated.

## Testing
* Added unit tests to the existing tests for `vm_endpoints`
* Manual testing:

Removed github username from vendor-portal:
```
./bin/replicated vm ssh-endpoint squizzi-ubuntu
Error: no GitHub account associated with Vendor Portal user
Visit the Account Settings page in Vendor Portal to link your account
Alternatively, you can use the --username flag to specify a custom username for the endpoint

Usage:
  replicated vm ssh-endpoint VM_ID_OR_NAME [flags]

Example:
  # Get SSH endpoint for a specific VM by ID
  replicated vm ssh-endpoint aaaaa11

  # Get SSH endpoint for a specific VM by name
  replicated vm ssh-endpoint my-test-vm

  # Get SSH endpoint with a custom username
  replicated vm ssh-endpoint my-test-vm --username custom-user

Flags:
  -h, --help              help for ssh-endpoint
      --username string   Custom username to use in SSH endpoint instead of the GitHub username set in Vendor Portal

Global Flags:
      --app string     The app slug or app id to use in all calls
      --debug          Enable debug output
      --token string   The API token to use to access your app in the Vendor API
```

Use `--username` flag to override:

```
./bin/replicated vm ssh-endpoint squizzi-ubuntu --username "banana"
ssh://banana@95.217.115.173:43157

./bin/replicated vm scp-endpoint squizzi-ubuntu --username "banana"
scp://banana@95.217.115.173:43157
```

Readd username to portal:

```
./bin/replicated vm ssh-endpoint squizzi-ubuntu
ssh://squizzi@95.217.115.173:43157
```
