### PR TITLE
Add last_scheduling_status to JSON output for VMs, clusters, and networks

### DIFF
--- a/pkg/types/cluster.go
+++ b/pkg/types/cluster.go
@@ -24,10 +24,12 @@ type Cluster struct {
 	KubernetesVersion      string       `json:"kubernetes_version"`
 	NodeGroups             []*NodeGroup `json:"node_groups"`
 
-	Status    ClusterStatus `json:"status"`
-	Network   string        `json:"network_id"`
-	CreatedAt time.Time     `json:"created_at"`
-	ExpiresAt time.Time     `json:"expires_at"`
+	Status               ClusterStatus `json:"status"`
+	LastSchedulingStatus string        `json:"last_scheduling_status"`
+
+	Network   string    `json:"network_id"`
+	CreatedAt time.Time `json:"created_at"`
+	ExpiresAt time.Time `json:"expires_at"`
 
 	TTL string `json:"ttl"`
 

--- a/pkg/types/network.go
+++ b/pkg/types/network.go
@@ -6,9 +6,11 @@ type Network struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
 
-	Status    NetworkStatus `json:"status"`
-	CreatedAt time.Time     `json:"created_at"`
-	ExpiresAt time.Time     `json:"expires_at"`
+	Status               NetworkStatus `json:"status"`
+	LastSchedulingStatus string        `json:"last_scheduling_status"`
+
+	CreatedAt time.Time `json:"created_at"`
+	ExpiresAt time.Time `json:"expires_at"`
 
 	TTL string `json:"ttl"`
 

--- a/pkg/types/vm.go
+++ b/pkg/types/vm.go
@@ -11,7 +11,9 @@ type VM struct {
 	Network      string `json:"network_id"`
 	DiskGiB      int64  `json:"disk_gib"`
 
-	Status    VMStatus  `json:"status"`
+	Status               VMStatus `json:"status"`
+	LastSchedulingStatus string   `json:"last_scheduling_status"`
+
 	CreatedAt time.Time `json:"created_at"`
 	ExpiresAt time.Time `json:"expires_at"`
 


### PR DESCRIPTION
Adds additional status info:

```
$ replicated vm ls -o json | jq '.[] | {id: .id, status: .status, last_scheduling_status: .last_scheduling_status}'
{
  "id": "0ded16aa",
  "status": "queued",
  "last_scheduling_status": "exceeds-limits"
}
{
  "id": "fcc76736",
  "status": "running",
  "last_scheduling_status": ""
}
{
  "id": "7c663f0f",
  "status": "queued",
  "last_scheduling_status": "exceeds-limits"
}
{
  "id": "dd2351b0",
  "status": "queued",
  "last_scheduling_status": "exceeds-limits"
}
```