### PR TITLE
bump go release version

### DIFF
--- a/dagger/release.go
+++ b/dagger/release.go
@@ -12,7 +12,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-var goreleaserVersion = "v2.3.2"
+var goreleaserVersion = "v2.10.2"
 
 func (r *Replicated) Release(
 	ctx context.Context,


### PR DESCRIPTION
Bump go releaser to version v2.10.2 to attempt to resolve release failures due to Go 1.23 being used:


![Screenshot 2025-07-08 at 17 41 53](https://github.com/user-attachments/assets/cede9b16-0609-4fbe-8b72-b8318ce1b9b5)
