### PR TITLE
chore(cmx): Make last scheduling status header only -o wide

### DIFF
--- a/cli/print/clusters.go
+++ b/cli/print/clusters.go
@@ -15,9 +15,9 @@ var clusterFuncs = template.FuncMap{
 }
 
 // Table formatting
-var clustersTmplTableHeaderSrc = `ID	NAME	DISTRIBUTION	VERSION	STATUS	LAST SCHEDULING STATUS        NETWORK	CREATED	EXPIRES	COST`
+var clustersTmplTableHeaderSrc = `ID	NAME	DISTRIBUTION	VERSION	STATUS	NETWORK	CREATED	EXPIRES	COST`
 var clustersTmplTableRowSrc = `{{ range . -}}
-{{ .ID }}	{{ padding .Name 27	}}	{{ padding .KubernetesDistribution 12 }}	{{ padding .KubernetesVersion 10 }}	{{ padding (printf "%s" .Status) 12 }}	{{ if .LastSchedulingStatus }}{{ padding .LastSchedulingStatus 29 }}{{ else }}{{ padding "-" 29 }}{{ end }} {{ if .Network }}{{ padding (printf "%.8s" .Network) 8 }}{{else}}{{ padding "-" 8 }}{{end}}	{{ padding (printf "%s" (localeTime .CreatedAt)) 30 }}	{{if .ExpiresAt.IsZero}}{{ padding "-" 30 }}{{else}}{{ padding (printf "%s" (localeTime .ExpiresAt)) 30 }}{{end}}	{{ padding (CreditsToDollarsDisplay .EstimatedCost) 11 }}
+{{ .ID }}	{{ padding .Name 27	}}	{{ padding .KubernetesDistribution 12 }}	{{ padding .KubernetesVersion 10 }}	{{ padding (printf "%s" .Status) 12 }}	{{ if .Network }}{{ padding (printf "%.8s" .Network) 8 }}{{else}}{{ padding "-" 8 }}{{end}}	{{ padding (printf "%s" (localeTime .CreatedAt)) 30 }}	{{if .ExpiresAt.IsZero}}{{ padding "-" 30 }}{{else}}{{ padding (printf "%s" (localeTime .ExpiresAt)) 30 }}{{end}}	{{ padding (CreditsToDollarsDisplay .EstimatedCost) 11 }}
 {{ end }}`
 var clustersTmplTableSrc = fmt.Sprintln(clustersTmplTableHeaderSrc) + clustersTmplTableRowSrc
 var clustersTmplTable = template.Must(template.New("clusters").Funcs(clusterFuncs).Funcs(funcs).Parse(clustersTmplTableSrc))
@@ -25,7 +25,7 @@ var clustersTmplTableNoHeader = template.Must(template.New("clusters").Funcs(clu
 
 // Wide table formatting
 var clustersTmplWideHeaderSrc = `ID	NAME	DISTRIBUTION	VERSION	STATUS	LAST SCHEDULING STATUS        NETWORK	CREATED	EXPIRES	COST	TOTAL NODES	NODEGROUPS	TAGS`
-var clustersTmplWideRowSrc = `{{ range . -}}
+var	clustersTmplWideRowSrc    = `{{ range . -}}
 {{ .ID }}	{{ padding .Name 27	}}	{{ padding .KubernetesDistribution 12 }}	{{ padding .KubernetesVersion 10 }}	{{ padding (printf "%s" .Status) 12 }}	{{ if .LastSchedulingStatus }}{{ padding .LastSchedulingStatus 29 }}{{ else }}{{ padding "-" 29 }}{{ end }} {{ if .Network }}{{ padding (printf "%.8s" .Network) 8 }}{{else}}{{ padding "-" 8 }}{{end}}	{{ padding (printf "%s" (localeTime .CreatedAt)) 30 }}	{{if .ExpiresAt.IsZero}}{{ padding "-" 30 }}{{else}}{{ padding (printf "%s" (localeTime .ExpiresAt)) 30 }}{{end}}	{{ padding (CreditsToDollarsDisplay .EstimatedCost) 11 }}	{{$nodecount:=0}}{{ range $index, $ng := .NodeGroups}}{{$nodecount = add $nodecount $ng.NodeCount}}{{ end }}{{ padding (printf "%d" $nodecount) 11 }}	{{ len .NodeGroups}}	{{ if eq (len .Tags) 0 }}{{ padding "-" 11 }}{{ else }}{{ range $index, $tag := .Tags }}{{if $index}}, {{end}}{{ $tag.Key }}={{ $tag.Value }}{{ end }}{{ end }}
 {{ end }}`
 var clustersTmplWideSrc = fmt.Sprintln(clustersTmplWideHeaderSrc) + clustersTmplWideRowSrc

--- a/cli/print/vms.go
+++ b/cli/print/vms.go
@@ -15,9 +15,9 @@ var vmFuncs = template.FuncMap{
 }
 
 // Table formatting
-var vmsTmplTableHeaderSrc = `ID	NAME	DISTRIBUTION	VERSION	STATUS	LAST SCHEDULING STATUS        NETWORK	CREATED	EXPIRES	COST`
-var vmsTmplTableRowSrc = `{{ range . -}}
-{{ .ID }}	{{ padding .Name 27	}}	{{ padding .Distribution 12 }}	{{ padding .Version 10 }}	{{ padding (printf "%s" .Status) 12 }}	{{ if .LastSchedulingStatus }}{{ padding .LastSchedulingStatus 29 }}{{ else }}{{ padding "-" 29 }}{{ end }} {{ if .Network }}{{ padding (printf "%.8s" .Network) 8 }}{{else}}{{ padding "-" 8 }}{{end}} 	{{ padding (printf "%s" (localeTime .CreatedAt)) 30 }}	{{if .ExpiresAt.IsZero}}{{ padding "-" 30 }}{{else}}{{ padding (printf "%s" (localeTime .ExpiresAt)) 30 }}{{end}}	{{ padding (CreditsToDollarsDisplay .EstimatedCost) 11 }}
+var vmsTmplTableHeaderSrc = `ID	NAME	DISTRIBUTION	VERSION	STATUS	NETWORK	CREATED	EXPIRES	COST`
+var vmsTmplTableRowSrc    = `{{ range . -}}
+{{ .ID }}	{{ padding .Name 27	}}	{{ padding .Distribution 12 }}	{{ padding .Version 10 }}	{{ padding (printf "%s" .Status) 12 }}	{{ if .Network }}{{ padding (printf "%.8s" .Network) 8 }}{{else}}{{ padding "-" 8 }}{{end}} 	{{ padding (printf "%s" (localeTime .CreatedAt)) 30 }}	{{if .ExpiresAt.IsZero}}{{ padding "-" 30 }}{{else}}{{ padding (printf "%s" (localeTime .ExpiresAt)) 30 }}{{end}}	{{ padding (CreditsToDollarsDisplay .EstimatedCost) 11 }}
 {{ end }}`
 var vmsTmplTableSrc = fmt.Sprintln(vmsTmplTableHeaderSrc) + vmsTmplTableRowSrc
 var vmsTmplTable = template.Must(template.New("vms").Funcs(vmFuncs).Funcs(funcs).Parse(vmsTmplTableSrc))
@@ -25,7 +25,7 @@ var vmsTmplTableNoHeader = template.Must(template.New("vms").Funcs(vmFuncs).Func
 
 // Wide table formatting
 var vmsTmplWideHeaderSrc = `ID	NAME	DISTRIBUTION	VERSION	STATUS	LAST SCHEDULING STATUS        NETWORK	CREATED	EXPIRES	COST	TAGS`
-var vmsTmplWideRowSrc = `{{ range . -}}
+var vmsTmplWideRowSrc    = `{{ range . -}}
 {{ .ID }}	{{ padding .Name 27	}}	{{ padding .Distribution 12 }}	{{ padding .Version 10 }}	{{ padding (printf "%s" .Status) 12 }}	{{ if .LastSchedulingStatus }}{{ padding .LastSchedulingStatus 29 }}{{ else }}{{ padding "-" 29 }}{{ end }} {{ if .Network }}{{ padding (printf "%.8s" .Network) 8 }}{{else}}{{ padding "-" 8 }}{{end}} 	{{ padding (printf "%s" (localeTime .CreatedAt)) 30 }}	{{if .ExpiresAt.IsZero}}{{ padding "-" 30 }}{{else}}{{ padding (printf "%s" (localeTime .ExpiresAt)) 30 }}{{end}}	{{ padding (CreditsToDollarsDisplay .EstimatedCost) 11 }}	{{ if eq (len .Tags) 0 }}{{ padding "-" 11 }}{{ else }}{{ range $index, $tag := .Tags }}{{if $index}}, {{end}}{{ $tag.Key }}={{ $tag.Value }}{{ end }}{{ end }}
 {{ end }}`
 var vmsTmplWideSrc = fmt.Sprintln(vmsTmplWideHeaderSrc) + vmsTmplWideRowSrc


### PR DESCRIPTION
It looks like the recent change made `LAST SCHEDULING STATUS` appear on the standard `vm ls` and `cluster ls` views when it was only supposed to end up on `-o wide`, this changes it to only appear on `-o wide`:

```
/bin/replicated vm ls
ID          NAME                           DISTRIBUTION    VERSION       STATUS          NETWORK      CREATED                           EXPIRES                           COST
84c623b3    charming_chatterjee            ubuntu          24.04         running         b4e76b9c     2025-07-09 11:20 PDT              2025-07-09 12:21 PDT              $0.60

./bin/replicated vm ls -owide
ID          NAME                           DISTRIBUTION    VERSION       STATUS          LAST SCHEDULING STATUS        NETWORK      CREATED                           EXPIRES                           COST           TAGS
84c623b3    charming_chatterjee            ubuntu          24.04         running         -                             b4e76b9c     2025-07-09 11:20 PDT              2025-07-09 12:21 PDT              $0.60          -