### PR TITLE
fix(cmx): Use pointer for collect-report bool

### DIFF
--- a/cli/cmd/network_update.go
+++ b/cli/cmd/network_update.go
@@ -71,7 +71,7 @@ func (r *runners) updateNetwork(cmd *cobra.Command, args []string) error {
 	}
 
 	if cmd.Flags().Changed("collect-report") {
-		opts.CollectReport = r.args.updateNetworkCollectReport
+		opts.CollectReport = &r.args.updateNetworkCollectReport
 	}
 
 	// Update the network

--- a/pkg/kotsclient/network_update.go
+++ b/pkg/kotsclient/network_update.go
@@ -13,7 +13,7 @@ import (
 
 type UpdateNetworkRequest struct {
 	Policy        string `json:"policy"`
-	CollectReport bool   `json:"collect_report"`
+	CollectReport *bool  `json:"collect_report,omitempty"`
 }
 
 type UpdateNetworkResponse struct {
@@ -23,7 +23,7 @@ type UpdateNetworkResponse struct {
 
 type UpdateNetworkOpts struct {
 	Policy        string `json:"policy"`
-	CollectReport bool   `json:"collect_report"`
+	CollectReport *bool  `json:"collect_report,omitempty"`
 }
 
 type UpdateNetworkErrorResponse struct {
@@ -34,7 +34,10 @@ type UpdateNetworkErrorResponse struct {
 
 // UpdateNetworkPolicy updates a network's policy setting
 func (c *VendorV3Client) UpdateNetwork(networkID string, opts UpdateNetworkOpts) (*types.Network, error) {
-	req := UpdateNetworkRequest(opts)
+	req := UpdateNetworkRequest{
+		Policy:        opts.Policy,
+		CollectReport: opts.CollectReport,
+	}
 	return c.doUpdateNetworkRequest(networkID, req)
 }
 


### PR DESCRIPTION
Prior to this change the API was responding (correctly) when `--collect-report` wasn't set because it was getting set to false and a non-nil check for the feature flag was firing which makes it so that policies cannot be set since they'll make the feature flag fire.

Before change, setting policy without collect report with the feature flag off for reporting would result in:

```
./bin/replicated network update 92ce6dab --policy open
Error: update network: Network Policy Reporting feature is not enabled. Contact Replicated to get more information.
```

With change, policy can be set:

```
./bin/replicated network update 92ce6dab --policy open
ID          NAME                           STATUS          CREATED                           EXPIRES                           POLICY                            REPORTING
92ce6dab    affectionate_chebyshev         running         2025-07-11 16:20 PDT              2025-07-11 17:21 PDT              open                              off
```

Collect reporting cannot:

```
./bin/replicated network update 92ce6dab --collect-report
Error: update network: Network Policy Reporting feature is not enabled. Contact Replicated to get more information.
```