### PR TITLE
Adds container image listing for channel releases

### DIFF
--- a/cli/cmd/channel_image_ls.go
+++ b/cli/cmd/channel_image_ls.go
@@ -1,0 +1,134 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/replicatedhq/replicated/cli/print"
+	"github.com/replicatedhq/replicated/pkg/types"
+	"github.com/spf13/cobra"
+)
+
+func (r *runners) InitChannelImageLS(parent *cobra.Command) {
+	imageCmd := &cobra.Command{
+		Use:   "image",
+		Short: "Manage channel images",
+		Long:  "Manage channel images",
+	}
+	
+	lsCmd := &cobra.Command{
+		Use:   "ls --channel CHANNEL_NAME_OR_ID [--version SEMVER]",
+		Short: "List images in a channel's current or specified release",
+		Long:  "List all container images in the current release or a specific version of a channel",
+		Example: `# List images in current release of a channel by name
+replicated channel image ls --channel Stable
+
+# List images in a specific version of a channel
+replicated channel image ls --channel Stable --version 1.2.1
+
+# List images in a channel by ID  
+replicated channel image ls --channel 2abc123`,
+	}
+	
+	lsCmd.Flags().StringVar(&r.args.channelImageLSChannel, "channel", "", "The channel name, slug, or ID (required)")
+	lsCmd.Flags().StringVar(&r.args.channelImageLSVersion, "version", "", "The specific semver version to get images for (optional, defaults to current release)")
+	lsCmd.MarkFlagRequired("channel")
+	
+	parent.AddCommand(imageCmd)
+	imageCmd.AddCommand(lsCmd)
+	lsCmd.RunE = r.channelImageLS
+}
+
+func (r *runners) channelImageLS(cmd *cobra.Command, args []string) error {
+	if !r.hasApp() {
+		return errors.New("no app specified")
+	}
+
+	if r.args.channelImageLSChannel == "" {
+		return errors.New("channel is required")
+	}
+
+	// Get the channel to find its current release
+	channel, err := r.api.GetChannelByName(r.appID, r.appType, r.args.channelImageLSChannel)
+	if err != nil {
+		return fmt.Errorf("failed to get channel: %w", err)
+	}
+
+	// Get all releases for this channel
+	channelReleases, err := r.api.ListChannelReleases(r.appID, r.appType, channel.ID)
+	if err != nil {
+		return fmt.Errorf("failed to list channel releases: %w", err)
+	}
+
+	if len(channelReleases) == 0 {
+		return errors.New("no releases found in channel")
+	}
+
+	// Find the target release
+	var targetRelease *types.ChannelRelease
+	if r.args.channelImageLSVersion != "" {
+		// Find release by semver
+		for _, release := range channelReleases {
+			if release.Semver == r.args.channelImageLSVersion {
+				targetRelease = release
+				break
+			}
+		}
+		if targetRelease == nil {
+			return fmt.Errorf("no release found with version %q in channel", r.args.channelImageLSVersion)
+		}
+	} else {
+		// Find the current release (highest channel sequence)
+		for _, release := range channelReleases {
+			if targetRelease == nil || release.ChannelSequence > targetRelease.ChannelSequence {
+				targetRelease = release
+			}
+		}
+		if targetRelease == nil {
+			return errors.New("no current release found")
+		}
+	}
+
+	// Extract and clean up image names
+	images := make([]string, 0)
+	for _, image := range targetRelease.AirgapBundleImages {
+		// Remove registry prefixes and clean up image names
+		cleanImage := cleanImageName(image)
+		if cleanImage != "" {
+			images = append(images, cleanImage)
+		}
+	}
+
+	// Print images
+	return print.ChannelImages(r.w, images)
+}
+
+func cleanImageName(image string) string {
+	cleaned := image
+	
+	// Handle proxy registry patterns first - "images.shortrib.io/proxy/app-name/"
+	if strings.HasPrefix(cleaned, "images.shortrib.io/proxy/") {
+		// Remove prefix and find first occurrence after app name
+		withoutPrefix := strings.TrimPrefix(cleaned, "images.shortrib.io/proxy/")
+		parts := strings.SplitN(withoutPrefix, "/", 2)
+		if len(parts) == 2 {
+			cleaned = parts[1] // Take everything after the app name
+		}
+	}
+	
+	// Remove other common registry prefixes
+	prefixes := []string{
+		"images.shortrib.io/anonymous/index.",
+		"images.shortrib.io/anonymous/",
+		"index.",
+	}
+	
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(cleaned, prefix) {
+			cleaned = strings.TrimPrefix(cleaned, prefix)
+		}
+	}
+	
+	return cleaned
+}

--- a/cli/cmd/channel_image_ls_test.go
+++ b/cli/cmd/channel_image_ls_test.go
@@ -1,0 +1,147 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/replicatedhq/replicated/pkg/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCleanImageName(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{
+			input:    "images.shortrib.io/anonymous/index.docker.io/library/nginx:1.25.3",
+			expected: "docker.io/library/nginx:1.25.3",
+		},
+		{
+			input:    "images.shortrib.io/proxy/testapp/ghcr.io/example/app:v1.0.0",
+			expected: "ghcr.io/example/app:v1.0.0",
+		},
+		{
+			input:    "docker.io/library/postgres:14",
+			expected: "docker.io/library/postgres:14",
+		},
+		{
+			input:    "index.docker.io/replicated/replicated-sdk:1.0.0-beta.32",
+			expected: "docker.io/replicated/replicated-sdk:1.0.0-beta.32",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := cleanImageName(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestFindReleaseLogic(t *testing.T) {
+	tests := []struct {
+		name               string
+		releases           []*types.ChannelRelease
+		requestedVersion   string
+		expectedSequence   int32
+		expectError        bool
+		errorMsg           string
+	}{
+		{
+			name: "find current release (highest channel sequence)",
+			releases: []*types.ChannelRelease{
+				{ChannelSequence: 5, Semver: "1.0.0"},
+				{ChannelSequence: 10, Semver: "1.1.0"},
+				{ChannelSequence: 8, Semver: "1.0.5"},
+			},
+			requestedVersion: "",
+			expectedSequence: 10,
+		},
+		{
+			name: "find specific version",
+			releases: []*types.ChannelRelease{
+				{ChannelSequence: 5, Semver: "1.0.0"},
+				{ChannelSequence: 10, Semver: "1.1.0"},
+				{ChannelSequence: 8, Semver: "1.0.5"},
+			},
+			requestedVersion: "1.0.5",
+			expectedSequence: 8,
+		},
+		{
+			name: "version not found",
+			releases: []*types.ChannelRelease{
+				{ChannelSequence: 5, Semver: "1.0.0"},
+				{ChannelSequence: 10, Semver: "1.1.0"},
+			},
+			requestedVersion: "2.0.0",
+			expectError:      true,
+			errorMsg:         "no release found with version \"2.0.0\"",
+		},
+		{
+			name:             "no releases",
+			releases:         []*types.ChannelRelease{},
+			requestedVersion: "",
+			expectError:      true,
+			errorMsg:         "no releases found in channel",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Simulate the logic from channelImageLS function
+			if len(tt.releases) == 0 {
+				err := errors.New("no releases found in channel")
+				if tt.expectError {
+					assert.Contains(t, err.Error(), tt.errorMsg)
+				} else {
+					t.Errorf("Unexpected error: %v", err)
+				}
+				return
+			}
+
+			var targetRelease *types.ChannelRelease
+			if tt.requestedVersion != "" {
+				// Find release by semver
+				for _, release := range tt.releases {
+					if release.Semver == tt.requestedVersion {
+						targetRelease = release
+						break
+					}
+				}
+				if targetRelease == nil {
+					err := fmt.Errorf("no release found with version %q in channel", tt.requestedVersion)
+					if tt.expectError {
+						assert.Contains(t, err.Error(), tt.errorMsg)
+					} else {
+						t.Errorf("Unexpected error: %v", err)
+					}
+					return
+				}
+			} else {
+				// Find the current release (highest channel sequence)
+				for _, release := range tt.releases {
+					if targetRelease == nil || release.ChannelSequence > targetRelease.ChannelSequence {
+						targetRelease = release
+					}
+				}
+				if targetRelease == nil {
+					err := errors.New("no current release found")
+					if tt.expectError {
+						assert.Contains(t, err.Error(), tt.errorMsg)
+					} else {
+						t.Errorf("Unexpected error: %v", err)
+					}
+					return
+				}
+			}
+
+			if tt.expectError {
+				t.Errorf("Expected error but got none")
+			} else {
+				assert.Equal(t, tt.expectedSequence, targetRelease.ChannelSequence)
+			}
+		})
+	}
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -151,6 +151,7 @@ func Execute(rootCmd *cobra.Command, stdin io.Reader, stdout io.Writer, stderr i
 	runCmds.InitChannelDisableSemanticVersioning(channelCmd)
 	runCmds.InitChannelReleaseDemote(channelCmd)
 	runCmds.InitChannelReleaseUnDemote(channelCmd)
+	runCmds.InitChannelImageLS(channelCmd)
 
 	runCmds.rootCmd.AddCommand(releaseCmd)
 	err := runCmds.InitReleaseCreate(releaseCmd)

--- a/cli/cmd/runner.go
+++ b/cli/cmd/runner.go
@@ -39,6 +39,8 @@ func (r *runners) hasApp() bool {
 type runnerArgs struct {
 	channelCreateName        string
 	channelCreateDescription string
+	channelImageLSChannel    string
+	channelImageLSVersion    string
 
 	createCollectorName     string
 	createCollectorYaml     string

--- a/cli/print/channel_images.go
+++ b/cli/print/channel_images.go
@@ -1,0 +1,22 @@
+package print
+
+import (
+	"fmt"
+	"sort"
+	"text/tabwriter"
+)
+
+func ChannelImages(w *tabwriter.Writer, images []string) error {
+	// Sort images for consistent output
+	sort.Strings(images)
+	
+	// Print header
+	fmt.Fprintln(w, "IMAGE")
+	
+	// Print each image
+	for _, image := range images {
+		fmt.Fprintln(w, image)
+	}
+	
+	return w.Flush()
+}

--- a/client/channel.go
+++ b/client/channel.go
@@ -187,3 +187,12 @@ func (c *Client) ChannelReleaseUnDemote(appID string, appType string, channelID 
 	}
 	return nil, errors.Errorf("unknown app type %q", appType)
 }
+
+func (c *Client) ListChannelReleases(appID string, appType string, channelID string) ([]*types.ChannelRelease, error) {
+	if appType == "platform" {
+		return nil, errors.New("This feature is not currently supported for Platform applications.")
+	} else if appType == "kots" {
+		return c.KotsClient.ListChannelReleases(appID, channelID)
+	}
+	return nil, errors.Errorf("unknown app type %q", appType)
+}

--- a/pkg/kotsclient/channel.go
+++ b/pkg/kotsclient/channel.go
@@ -149,3 +149,18 @@ func (c *VendorV3Client) UnDemoteChannelRelease(appID string, channelID string, 
 
 	return &response.Release, nil
 }
+
+func (c *VendorV3Client) ListChannelReleases(appID string, channelID string) ([]*types.ChannelRelease, error) {
+	type listChannelReleasesResponse struct {
+		Releases []*types.ChannelRelease `json:"releases"`
+	}
+
+	response := listChannelReleasesResponse{}
+	url := fmt.Sprintf("/v3/app/%s/channel/%s/releases", appID, url.QueryEscape(channelID))
+	err := c.DoJSON(context.TODO(), "GET", url, http.StatusOK, nil, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, "list channel releases")
+	}
+
+	return response.Releases, nil
+}

--- a/pkg/types/channel.go
+++ b/pkg/types/channel.go
@@ -63,19 +63,20 @@ type CustomerAdoption struct {
 }
 
 type ChannelRelease struct {
-	AirgapBuildError  string    `json:"airgapBuildError,omitempty"`
-	AirgapBuildStatus string    `json:"airgapBuildStatus,omitempty"`
-	ChannelIcon       string    `json:"channelIcon,omitempty"`
-	ChannelId         string    `json:"channelId,omitempty"`
-	ChannelName       string    `json:"channelName,omitempty"`
-	ChannelSequence   int32     `json:"channelSequence,omitempty"`
-	Created           time.Time `json:"created,omitempty"`
-	RegistrySecret    string    `json:"registrySecret,omitempty"`
-	ReleaseNotes      string    `json:"releaseNotes,omitempty"`
-	ReleasedAt        time.Time `json:"releasedAt,omitempty"`
-	Semver            string    `json:"semver,omitempty"`
-	Sequence          int32     `json:"sequence,omitempty"`
-	Updated           time.Time `json:"updated,omitempty"`
+	AirgapBuildError     string    `json:"airgapBuildError,omitempty"`
+	AirgapBuildStatus    string    `json:"airgapBuildStatus,omitempty"`
+	AirgapBundleImages   []string  `json:"airgapBundleImages,omitempty"`
+	ChannelIcon          string    `json:"channelIcon,omitempty"`
+	ChannelId            string    `json:"channelId,omitempty"`
+	ChannelName          string    `json:"channelName,omitempty"`
+	ChannelSequence      int32     `json:"channelSequence,omitempty"`
+	Created              time.Time `json:"created,omitempty"`
+	RegistrySecret       string    `json:"registrySecret,omitempty"`
+	ReleaseNotes         string    `json:"releaseNotes,omitempty"`
+	ReleasedAt           time.Time `json:"releasedAt,omitempty"`
+	Semver               string    `json:"semver,omitempty"`
+	Sequence             int32     `json:"sequence,omitempty"`
+	Updated              time.Time `json:"updated,omitempty"`
 }
 
 type CreateChannelRequest struct {


### PR DESCRIPTION
TL;DR
-----

Implements a new CLI command that lists all container images used in a
channel's release, making it easier to prepare air-gapped environments
or audit container dependencies.

Details
--------

Air-gapped installations require knowing which container images are
needed for an application. Previously, there was no simple way to list
all images used by a specific channel or release, forcing users to
manually inspect manifests or guess which images were needed.

This change adds a new `replicated channel image ls` command that shows
all container images included in a channel's current release or a
specific version. The command handles both current releases and
historical versions via an optional `--version` flag, and works with
channels specified by name, slug, or ID.

The implementation cleans image names to remove common registry
prefixes, providing a more readable output that can be directly used for
mirroring or documentation purposes. Users can now quickly generate
lists of required images when preparing for air-gapped installations or
when auditing container dependencies.

Key features:
- Lists all images in a channel's current release
- Supports retrieving images from a specific version with `--version` flag
- Presents image names in a clean, sorted format
- Handles various registry prefixes and proxy patterns automatically
- Includes comprehensive help text and examples for easy discovery

AI-gapped environments and container image management are critical for
enterprise customers, and this command makes preparation significantly
easier by providing clear visibility into image requirements.
