### PR TITLE
Update rm/test help references to use `name`

### DIFF
--- a/cli/cmd/registry_rm.go
+++ b/cli/cmd/registry_rm.go
@@ -9,10 +9,10 @@ import (
 
 func (r *runners) InitRegistryRemove(parent *cobra.Command) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:          "rm [ENDPOINT]",
+		Use:          "rm [NAME]",
 		Aliases:      []string{"delete"},
 		Short:        "remove registry",
-		Long:         `remove registry by endpoint`,
+		Long:         `remove registry by name`,
 		RunE:         r.removeRegistry,
 		SilenceUsage: true,
 	}
@@ -23,7 +23,7 @@ func (r *runners) InitRegistryRemove(parent *cobra.Command) *cobra.Command {
 
 func (r *runners) removeRegistry(_ *cobra.Command, args []string) error {
 	if len(args) == 0 {
-		return errors.New("missing registry endpoint")
+		return errors.New("missing registry name")
 	}
 
 	if err := r.kotsAPI.RemoveRegistry(args[0]); err != nil {

--- a/cli/cmd/registry_validate.go
+++ b/cli/cmd/registry_validate.go
@@ -11,7 +11,7 @@ import (
 
 func (r *runners) InitRegistryTest(parent *cobra.Command) {
 	cmd := &cobra.Command{
-		Use:          "test HOSTNAME",
+		Use:          "test NAME",
 		Short:        "test registry",
 		Long:         `test registry`,
 		SilenceUsage: true,
@@ -26,13 +26,13 @@ func (r *runners) InitRegistryTest(parent *cobra.Command) {
 
 func (r *runners) registryTest(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
-		return errors.New("missing endpoint")
+		return errors.New("missing registry name")
 	}
-	hostname := args[0]
+	name := args[0]
 
 	kotsRestClient := kotsclient.VendorV3Client{HTTPClient: *r.platformAPI}
 
-	status, err := kotsRestClient.TestKOTSRegistry(hostname, r.args.testRegistryImage)
+	status, err := kotsRestClient.TestKOTSRegistry(name, r.args.testRegistryImage)
 	if err != nil {
 		return errors.Wrap(err, "test registry")
 	}


### PR DESCRIPTION
Missed updating the doc string refs in https://github.com/replicatedhq/replicated/pull/574 