### PR TITLE
Do not show created at in the network report

### DIFF
--- a/cli/cmd/network_report.go
+++ b/cli/cmd/network_report.go
@@ -82,7 +82,10 @@ func (r *runners) getNetworkReport(_ *cobra.Command, args []string) error {
 		// Track the last seen event time
 		var lastEventTime *time.Time
 		if len(report.Events) > 0 {
-			lastEventTime = &report.Events[len(report.Events)-1].CreatedAt
+			// Extract timestamp from the last event
+			if parsedTime, err := time.Parse(time.RFC3339Nano, report.Events[len(report.Events)-1].Timestamp); err == nil {
+				lastEventTime = &parsedTime
+			}
 		}
 
 		// Poll for new events
@@ -104,7 +107,9 @@ func (r *runners) getNetworkReport(_ *cobra.Command, args []string) error {
 					return errors.Wrap(err, "print new network events")
 				}
 				// Update last seen time
-				lastEventTime = &newReport.Events[len(newReport.Events)-1].CreatedAt
+				if parsedTime, err := time.Parse(time.RFC3339Nano, newReport.Events[len(newReport.Events)-1].Timestamp); err == nil {
+					lastEventTime = &parsedTime
+				}
 			}
 		}
 		return nil

--- a/cli/cmd/network_report.go
+++ b/cli/cmd/network_report.go
@@ -9,6 +9,7 @@ import (
 	"github.com/replicatedhq/replicated/cli/print"
 	"github.com/replicatedhq/replicated/pkg/platformclient"
 	"github.com/replicatedhq/replicated/pkg/types"
+	"github.com/replicatedhq/replicated/pkg/util"
 	"github.com/spf13/cobra"
 )
 
@@ -83,7 +84,7 @@ func (r *runners) getNetworkReport(_ *cobra.Command, args []string) error {
 		var lastEventTime *time.Time
 		if len(report.Events) > 0 {
 			// Extract timestamp from the last event
-			if parsedTime, err := time.Parse(time.RFC3339Nano, report.Events[len(report.Events)-1].Timestamp); err == nil {
+			if parsedTime, err := util.ParseTime(report.Events[len(report.Events)-1].Timestamp); err == nil {
 				lastEventTime = &parsedTime
 			}
 		}
@@ -107,7 +108,7 @@ func (r *runners) getNetworkReport(_ *cobra.Command, args []string) error {
 					return errors.Wrap(err, "print new network events")
 				}
 				// Update last seen time
-				if parsedTime, err := time.Parse(time.RFC3339Nano, newReport.Events[len(newReport.Events)-1].Timestamp); err == nil {
+				if parsedTime, err := util.ParseTime(newReport.Events[len(newReport.Events)-1].Timestamp); err == nil {
 					lastEventTime = &parsedTime
 				}
 			}

--- a/cli/cmd/network_report.go
+++ b/cli/cmd/network_report.go
@@ -24,11 +24,8 @@ replicated network report abc123
 # Get report for a network by ID (using flag)
 replicated network report --id abc123
 
-# Watch for new network events (table format)
-replicated network report abc123 --watch --output table
-
 # Watch for new network events (JSON Lines format)
-replicated network report abc123 --watch --output json`,
+replicated network report abc123 --watch`,
 		RunE:              r.getNetworkReport,
 		ValidArgsFunction: r.completeNetworkIDs,
 		Hidden:            true,
@@ -38,7 +35,6 @@ replicated network report abc123 --watch --output json`,
 	cmd.Flags().StringVar(&r.args.networkReportID, "id", "", "Network ID to get report for")
 	cmd.RegisterFlagCompletionFunc("id", r.completeNetworkIDs)
 
-	cmd.Flags().StringVarP(&r.outputFormat, "output", "o", "json", "The output format to use. One of: json|table")
 	cmd.Flags().BoolVarP(&r.args.networkReportWatch, "watch", "w", false, "Watch for new network events")
 
 	return cmd
@@ -75,7 +71,7 @@ func (r *runners) getNetworkReport(_ *cobra.Command, args []string) error {
 
 		// Print initial events
 		if len(report.Events) > 0 {
-			if err := print.NetworkEvents(r.outputFormat, w, report.Events, true); err != nil {
+			if err := print.NetworkEvents(w, report.Events); err != nil {
 				return errors.Wrap(err, "print initial network events")
 			}
 		}
@@ -104,7 +100,7 @@ func (r *runners) getNetworkReport(_ *cobra.Command, args []string) error {
 
 			// Print new events
 			if len(newReport.Events) > 0 {
-				if err := print.NetworkEvents(r.outputFormat, w, newReport.Events, false); err != nil {
+				if err := print.NetworkEvents(w, newReport.Events); err != nil {
 					return errors.Wrap(err, "print new network events")
 				}
 				// Update last seen time
@@ -118,5 +114,5 @@ func (r *runners) getNetworkReport(_ *cobra.Command, args []string) error {
 
 	// Output the report (non-watch mode)
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	return print.NetworkReport(r.outputFormat, w, report)
+	return print.NetworkReport(w, report)
 }

--- a/cli/print/network_reports.go
+++ b/cli/print/network_reports.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/replicatedhq/replicated/pkg/types"
+	"github.com/replicatedhq/replicated/pkg/util"
 )
 
 // Table formatting for network reports
@@ -100,9 +101,9 @@ func parseNetworkEventsData(events []*types.NetworkEventData) ([]*NetworkEventsW
 	var eventsWithData []*NetworkEventsWithData
 
 	for _, event := range events {
-		// Extract timestamp
+		// Extract timestamp using the robust ParseTime utility
 		var timestamp time.Time
-		if parsedTime, err := time.Parse(time.RFC3339Nano, event.Timestamp); err == nil {
+		if parsedTime, err := util.ParseTime(event.Timestamp); err == nil {
 			timestamp = parsedTime
 		}
 

--- a/cli/print/network_reports.go
+++ b/cli/print/network_reports.go
@@ -12,9 +12,9 @@ import (
 
 // Table formatting for network reports
 var (
-	networkReportTmplTableHeaderSrc = `CREATED AT	SRC IP	DST IP	SRC PORT	DST PORT	PROTOCOL	COMMAND	PID	DNS QUERY	SERVICE`
+	networkReportTmplTableHeaderSrc = `TIMESTAMP	SRC IP	DST IP	SRC PORT	DST PORT	PROTOCOL	COMMAND	PID	DNS QUERY	SERVICE`
 	networkReportTmplTableRowSrc    = `{{ range . -}}
-{{ padding (printf "%s" (.CreatedAt | localeTime)) 20 }}	{{ if .EventData.SrcIP }}{{ padding .EventData.SrcIP 15 }}{{ else }}{{ padding "-" 15 }}{{ end }}	{{ if .EventData.DstIP }}{{ padding .EventData.DstIP 15 }}{{ else }}{{ padding "-" 15 }}{{ end }}	{{ if .EventData.SrcPort }}{{ padding (printf "%d" .EventData.SrcPort) 8 }}{{ else }}{{ padding "-" 8 }}{{ end }}	{{ if .EventData.DstPort }}{{ padding (printf "%d" .EventData.DstPort) 8 }}{{ else }}{{ padding "-" 8 }}{{ end }}	{{ if .EventData.Protocol }}{{ padding .EventData.Protocol 8 }}{{ else }}{{ padding "-" 8 }}{{ end }}	{{ if .EventData.Command }}{{ padding .EventData.Command 15 }}{{ else }}{{ padding "-" 15 }}{{ end }}	{{ if .EventData.PID }}{{ padding (printf "%d" .EventData.PID) 8 }}{{ else }}{{ padding "-" 8 }}{{ end }}	{{ if .EventData.DNSQueryName }}{{ padding .EventData.DNSQueryName 20 }}{{ else }}{{ padding "-" 20 }}{{ end }}	{{ if .EventData.LikelyService }}{{ padding .EventData.LikelyService 15 }}{{ else }}{{ padding "-" 15 }}{{ end }}
+{{ padding (printf "%s" (.Timestamp | localeTime)) 20 }}	{{ if .EventData.SrcIP }}{{ padding .EventData.SrcIP 15 }}{{ else }}{{ padding "-" 15 }}{{ end }}	{{ if .EventData.DstIP }}{{ padding .EventData.DstIP 15 }}{{ else }}{{ padding "-" 15 }}{{ end }}	{{ if .EventData.SrcPort }}{{ padding (printf "%d" .EventData.SrcPort) 8 }}{{ else }}{{ padding "-" 8 }}{{ end }}	{{ if .EventData.DstPort }}{{ padding (printf "%d" .EventData.DstPort) 8 }}{{ else }}{{ padding "-" 8 }}{{ end }}	{{ if .EventData.Protocol }}{{ padding .EventData.Protocol 8 }}{{ else }}{{ padding "-" 8 }}{{ end }}	{{ if .EventData.Command }}{{ padding .EventData.Command 15 }}{{ else }}{{ padding "-" 15 }}{{ end }}	{{ if .EventData.PID }}{{ padding (printf "%d" .EventData.PID) 8 }}{{ else }}{{ padding "-" 8 }}{{ end }}	{{ if .EventData.DNSQueryName }}{{ padding .EventData.DNSQueryName 20 }}{{ else }}{{ padding "-" 20 }}{{ end }}	{{ if .EventData.LikelyService }}{{ padding .EventData.LikelyService 15 }}{{ else }}{{ padding "-" 15 }}{{ end }}
 {{ end }}`
 )
 
@@ -26,7 +26,7 @@ var (
 
 // NetworkEventsWithData represents network events with parsed event data
 type NetworkEventsWithData struct {
-	CreatedAt time.Time
+	Timestamp time.Time
 	EventData *types.NetworkEventData
 }
 
@@ -60,7 +60,7 @@ func NetworkReport(outputFormat string, w *tabwriter.Writer, report *types.Netwo
 }
 
 // NetworkEvents prints network events in table format (for watch mode)
-func NetworkEvents(outputFormat string, w *tabwriter.Writer, events []*types.NetworkEvent, includeHeader bool) error {
+func NetworkEvents(outputFormat string, w *tabwriter.Writer, events []*types.NetworkEventData, includeHeader bool) error {
 	switch outputFormat {
 	case "table":
 		if len(events) == 0 {
@@ -95,24 +95,21 @@ func NetworkEvents(outputFormat string, w *tabwriter.Writer, events []*types.Net
 	return w.Flush()
 }
 
-// parseNetworkEventsData parses the JSON event data for template consumption
-func parseNetworkEventsData(events []*types.NetworkEvent) ([]*NetworkEventsWithData, error) {
+// parseNetworkEventsData converts NetworkEventData to template format
+func parseNetworkEventsData(events []*types.NetworkEventData) ([]*NetworkEventsWithData, error) {
 	var eventsWithData []*NetworkEventsWithData
 
 	for _, event := range events {
-		var eventData types.NetworkEventData
-		if err := json.Unmarshal([]byte(event.EventData), &eventData); err != nil {
-			// For events that can't be parsed, create a minimal entry
-			eventsWithData = append(eventsWithData, &NetworkEventsWithData{
-				CreatedAt: event.CreatedAt,
-				EventData: &types.NetworkEventData{},
-			})
-		} else {
-			eventsWithData = append(eventsWithData, &NetworkEventsWithData{
-				CreatedAt: event.CreatedAt,
-				EventData: &eventData,
-			})
+		// Extract timestamp
+		var timestamp time.Time
+		if parsedTime, err := time.Parse(time.RFC3339Nano, event.Timestamp); err == nil {
+			timestamp = parsedTime
 		}
+
+		eventsWithData = append(eventsWithData, &NetworkEventsWithData{
+			Timestamp: timestamp,
+			EventData: event,
+		})
 	}
 
 	return eventsWithData, nil

--- a/cli/print/network_reports.go
+++ b/cli/print/network_reports.go
@@ -4,114 +4,34 @@ import (
 	"encoding/json"
 	"fmt"
 	"text/tabwriter"
-	"text/template"
-	"time"
 
 	"github.com/replicatedhq/replicated/pkg/types"
-	"github.com/replicatedhq/replicated/pkg/util"
 )
 
-// Table formatting for network reports
-var (
-	networkReportTmplTableHeaderSrc = `TIMESTAMP	SRC IP	DST IP	SRC PORT	DST PORT	PROTOCOL	COMMAND	PID	DNS QUERY	SERVICE`
-	networkReportTmplTableRowSrc    = `{{ range . -}}
-{{ padding (printf "%s" (.Timestamp | localeTime)) 20 }}	{{ if .EventData.SrcIP }}{{ padding .EventData.SrcIP 15 }}{{ else }}{{ padding "-" 15 }}{{ end }}	{{ if .EventData.DstIP }}{{ padding .EventData.DstIP 15 }}{{ else }}{{ padding "-" 15 }}{{ end }}	{{ if .EventData.SrcPort }}{{ padding (printf "%d" .EventData.SrcPort) 8 }}{{ else }}{{ padding "-" 8 }}{{ end }}	{{ if .EventData.DstPort }}{{ padding (printf "%d" .EventData.DstPort) 8 }}{{ else }}{{ padding "-" 8 }}{{ end }}	{{ if .EventData.Protocol }}{{ padding .EventData.Protocol 8 }}{{ else }}{{ padding "-" 8 }}{{ end }}	{{ if .EventData.Command }}{{ padding .EventData.Command 15 }}{{ else }}{{ padding "-" 15 }}{{ end }}	{{ if .EventData.PID }}{{ padding (printf "%d" .EventData.PID) 8 }}{{ else }}{{ padding "-" 8 }}{{ end }}	{{ if .EventData.DNSQueryName }}{{ padding .EventData.DNSQueryName 20 }}{{ else }}{{ padding "-" 20 }}{{ end }}	{{ if .EventData.LikelyService }}{{ padding .EventData.LikelyService 15 }}{{ else }}{{ padding "-" 15 }}{{ end }}
-{{ end }}`
-)
 
-var (
-	networkReportTmplTableSrc      = fmt.Sprintln(networkReportTmplTableHeaderSrc) + networkReportTmplTableRowSrc
-	networkReportTmplTable         = template.Must(template.New("networkReport").Funcs(funcs).Parse(networkReportTmplTableSrc))
-	networkReportTmplTableNoHeader = template.Must(template.New("networkReport").Funcs(funcs).Parse(networkReportTmplTableRowSrc))
-)
-
-// NetworkEventsWithData represents network events with parsed event data
-type NetworkEventsWithData struct {
-	Timestamp time.Time
-	EventData *types.NetworkEventData
-}
-
-// NetworkReport prints network report in various formats
-func NetworkReport(outputFormat string, w *tabwriter.Writer, report *types.NetworkReport) error {
-	switch outputFormat {
-	case "table":
-		if len(report.Events) == 0 {
-			_, err := fmt.Fprintln(w, "No network events found.")
-			return err
-		}
-		eventsWithData, err := parseNetworkEventsData(report.Events)
-		if err != nil {
-			return fmt.Errorf("failed to parse network events: %v", err)
-		}
-		if err := networkReportTmplTable.Execute(w, eventsWithData); err != nil {
-			return err
-		}
-	case "json":
-		reportBytes, err := json.MarshalIndent(report, "", "  ")
-		if err != nil {
-			return fmt.Errorf("failed to marshal report to json: %v", err)
-		}
-		if _, err := fmt.Fprintln(w, string(reportBytes)); err != nil {
-			return err
-		}
-	default:
-		return fmt.Errorf("unsupported output format: %s", outputFormat)
+// NetworkReport prints network report in JSON format
+func NetworkReport(w *tabwriter.Writer, report *types.NetworkReport) error {
+	reportBytes, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal report to json: %v", err)
+	}
+	if _, err := fmt.Fprintln(w, string(reportBytes)); err != nil {
+		return err
 	}
 	return w.Flush()
 }
 
-// NetworkEvents prints network events in table format (for watch mode)
-func NetworkEvents(outputFormat string, w *tabwriter.Writer, events []*types.NetworkEventData, includeHeader bool) error {
-	switch outputFormat {
-	case "table":
-		if len(events) == 0 {
-			return nil
-		}
-		eventsWithData, err := parseNetworkEventsData(events)
-		if err != nil {
-			return fmt.Errorf("failed to parse network events: %v", err)
-		}
-		if includeHeader {
-			if err := networkReportTmplTable.Execute(w, eventsWithData); err != nil {
-				return err
-			}
-		} else {
-			if err := networkReportTmplTableNoHeader.Execute(w, eventsWithData); err != nil {
-				return err
-			}
-		}
-	case "json":
-		for _, event := range events {
-			eventBytes, err := json.Marshal(event)
-			if err != nil {
-				continue // Skip events that can't be marshaled
-			}
-			if _, err := fmt.Fprintln(w, string(eventBytes)); err != nil {
-				return err
-			}
-		}
-	default:
-		return fmt.Errorf("unsupported output format: %s", outputFormat)
-	}
-	return w.Flush()
-}
-
-// parseNetworkEventsData converts NetworkEventData to template format
-func parseNetworkEventsData(events []*types.NetworkEventData) ([]*NetworkEventsWithData, error) {
-	var eventsWithData []*NetworkEventsWithData
-
+// NetworkEvents prints network events in JSON format (for watch mode)
+func NetworkEvents(w *tabwriter.Writer, events []*types.NetworkEventData) error {
 	for _, event := range events {
-		// Extract timestamp using the robust ParseTime utility
-		var timestamp time.Time
-		if parsedTime, err := util.ParseTime(event.Timestamp); err == nil {
-			timestamp = parsedTime
+		eventBytes, err := json.Marshal(event)
+		if err != nil {
+			continue // Skip events that can't be marshaled
 		}
-
-		eventsWithData = append(eventsWithData, &NetworkEventsWithData{
-			Timestamp: timestamp,
-			EventData: event,
-		})
+		if _, err := fmt.Fprintln(w, string(eventBytes)); err != nil {
+			return err
+		}
 	}
-
-	return eventsWithData, nil
+	return w.Flush()
 }
+

--- a/pkg/types/network.go
+++ b/pkg/types/network.go
@@ -37,12 +37,7 @@ const (
 )
 
 type NetworkReport struct {
-	Events []*NetworkEvent `json:"events"`
-}
-
-type NetworkEvent struct {
-	CreatedAt time.Time `json:"created_at"`
-	EventData string    `json:"event_data"`
+	Events []*NetworkEventData `json:"events"`
 }
 
 type NetworkEventData struct {


### PR DESCRIPTION
Removes `created_at` for network reports, and replaces it with the timestamp field from the event data

Example output:
```
❯ rdev network report 2979703b -w
TIMESTAMP             SRC IP           DST IP           SRC PORT  DST PORT  PROTOCOL  COMMAND          PID       DNS QUERY             SERVICE
2025-09-17 11:03 PDT  10.0.0.11        216.58.210.164   63108     80        TCP       curl             1556      www.google.com        http
2025-09-17 11:03 PDT  10.0.0.11        216.58.210.164   63108     80        TCP       -                -         -                     http
2025-09-17 11:03 PDT  10.0.0.11        216.58.210.164   63108     80        TCP       curl             1556      www.google.com        http
2025-09-17 11:03 PDT  10.0.0.11        216.58.210.164   63108     80        TCP       -                -         -                     http
2025-09-17 11:04 PDT  10.0.0.11        185.125.190.56   1251      123       TCP       chronyd          1038      -                     ntp
2025-09-17 11:04 PDT  10.0.0.11        185.125.190.57   9872      123       TCP       chronyd          1038      -                     ntp
2025-09-17 11:04 PDT  10.0.0.11        91.189.91.157    3973      123       TCP       chronyd          1038      -                     ntp
```