### PR TITLE
Allow ssh/scp while vm is updating

### DIFF
--- a/cli/cmd/vm_endpoints.go
+++ b/cli/cmd/vm_endpoints.go
@@ -146,8 +146,8 @@ func (r *runners) getVMEndpoint(vmID, endpointType, username string) error {
 		Status:         string(vmFromAPI.Status),
 	}
 
-	if vm.Status != "running" {
-		return errors.Errorf("VM %s is not in running state (current state: %s). %s is only available for running VMs",
+	if vm.Status != "running" && vm.Status != "updating" {
+		return errors.Errorf("VM %s is not in running or updating state (current state: %s). %s is only available for running or updating VMs",
 			vm.ID, vm.Status, strings.ToUpper(endpointType))
 	}
 

--- a/cli/cmd/vm_endpoints_test.go
+++ b/cli/cmd/vm_endpoints_test.go
@@ -156,7 +156,7 @@ func TestGetVMEndpoint(t *testing.T) {
 			mockGithubUsername: "testuser",
 			githubAPIError:     false,
 			expectedOutput:     "",
-			expectedError:      "VM vm-123 is not in running state (current state: provisioning). SSH is only available for running VMs",
+			expectedError:      "VM vm-123 is not in running or updating state (current state: provisioning). SSH is only available for running or updating VMs",
 		},
 	}
 


### PR DESCRIPTION
Allow to ssh or scp into a vm while the VM is in an updating state.