### PR TITLE
Add source and destination pod

### DIFF
--- a/pkg/types/network.go
+++ b/pkg/types/network.go
@@ -41,14 +41,16 @@ type NetworkReport struct {
 }
 
 type NetworkEventData struct {
-	Timestamp     string `json:"timestamp"`
-	SrcIP         string `json:"srcIp"`
-	DstIP         string `json:"dstIp"`
-	SrcPort       int    `json:"srcPort"`
-	DstPort       int    `json:"dstPort"`
-	Protocol      string `json:"proto"`
-	Command       string `json:"comm"`
-	PID           int    `json:"pid"`
-	LikelyService string `json:"likelyService"`
-	DNSQueryName  string `json:"dnsQueryName"`
+	Timestamp      string `json:"timestamp,omitempty"`
+	SrcIP          string `json:"srcIp,omitempty"`
+	DstIP          string `json:"dstIp,omitempty"`
+	SrcPort        int    `json:"srcPort,omitempty"`
+	DstPort        int    `json:"dstPort,omitempty"`
+	SourcePod      string `json:"sourcePod,omitempty"`
+	DestinationPod string `json:"dstPod,omitempty"`
+	Protocol       string `json:"proto,omitempty"`
+	Command        string `json:"comm,omitempty"`
+	PID            int    `json:"pid,omitempty"`
+	LikelyService  string `json:"likelyService,omitempty"`
+	DNSQueryName   string `json:"dnsQueryName,omitempty"`
 }


### PR DESCRIPTION
Example output
```
{"timestamp":"2025-09-19T01:27:27.671401693Z","srcIp":"10.42.1.2","dstIp":"162.159.138.43","srcPort":11984,"dstPort":80,"sourcePod":"default/netshoot-l9574","proto":"TCP","likelyService":"http"}
{"timestamp":"2025-09-19T01:27:27.682874197Z","srcIp":"10.42.1.2","dstIp":"162.159.138.43","srcPort":11984,"dstPort":80,"sourcePod":"default/netshoot-l9574","proto":"TCP","comm":"containerd","pid":2179,"likelyService":"http"}
```