### PR TITLE
feat(cmx): Add show-terminated and show-reports bools, resources and has_report columns

### DIFF
--- a/cli/cmd/network.go
+++ b/cli/cmd/network.go
@@ -51,7 +51,7 @@ func (r *runners) completeNetworkNames(cmd *cobra.Command, args []string, toComp
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
-	networks, err := r.kotsAPI.ListNetworks(nil, nil)
+	networks, err := r.kotsAPI.ListNetworks(false, nil, nil)
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveError
 	}
@@ -71,7 +71,7 @@ func (r *runners) completeNetworkIDs(cmd *cobra.Command, args []string, toComple
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
-	networks, err := r.kotsAPI.ListNetworks(nil, nil)
+	networks, err := r.kotsAPI.ListNetworks(false, nil, nil)
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveError
 	}
@@ -89,7 +89,7 @@ func (r *runners) completeNetworkIDsAndNames(cmd *cobra.Command, args []string, 
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
-	networks, err := r.kotsAPI.ListNetworks(nil, nil)
+	networks, err := r.kotsAPI.ListNetworks(false, nil, nil)
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveError
 	}
@@ -115,7 +115,7 @@ func (r *runners) getNetworkIDFromArg(arg string) (string, error) {
 		return "", errors.Wrap(err, "get network")
 	}
 
-	networks, err := r.kotsAPI.ListNetworks(nil, nil)
+	networks, err := r.kotsAPI.ListNetworks(false, nil, nil)
 	if errors.Cause(err) == platformclient.ErrForbidden {
 		return "", ErrCompatibilityMatrixTermsNotAccepted
 	} else if err != nil {

--- a/cli/cmd/network_rm.go
+++ b/cli/cmd/network_rm.go
@@ -60,7 +60,7 @@ func (r *runners) removeNetworks(_ *cobra.Command, args []string) error {
 	}
 
 	if len(r.args.removeNetworkNames) > 0 {
-		networks, err := r.kotsAPI.ListNetworks(nil, nil)
+		networks, err := r.kotsAPI.ListNetworks(false, nil, nil)
 		if err != nil {
 			return errors.Wrap(err, "list networks")
 		}
@@ -77,7 +77,7 @@ func (r *runners) removeNetworks(_ *cobra.Command, args []string) error {
 	}
 
 	if r.args.removeNetworkAll {
-		networks, err := r.kotsAPI.ListNetworks(nil, nil)
+		networks, err := r.kotsAPI.ListNetworks(false, nil, nil)
 		if err != nil {
 			return errors.Wrap(err, "list networks")
 		}
@@ -99,7 +99,7 @@ func (r *runners) removeNetworks(_ *cobra.Command, args []string) error {
 			continue
 		}
 
-		networks, err := r.kotsAPI.ListNetworks(nil, nil)
+		networks, err := r.kotsAPI.ListNetworks(false, nil, nil)
 		if err != nil {
 			return errors.Wrap(err, "list networks")
 		}

--- a/cli/cmd/network_update.go
+++ b/cli/cmd/network_update.go
@@ -91,7 +91,7 @@ func (r *runners) ensureUpdateNetworkIDArg(args []string) error {
 		}
 		r.args.updateNetworkID = networkID
 	} else if r.args.updateNetworkName != "" {
-		networks, err := r.kotsAPI.ListNetworks(nil, nil)
+		networks, err := r.kotsAPI.ListNetworks(false, nil, nil)
 		if errors.Cause(err) == platformclient.ErrForbidden {
 			return ErrCompatibilityMatrixTermsNotAccepted
 		} else if err != nil {

--- a/cli/cmd/runner.go
+++ b/cli/cmd/runner.go
@@ -247,9 +247,11 @@ type runnerArgs struct {
 	createNetworkWaitDuration time.Duration
 	createNetworkDryRun       bool
 
-	lsNetworkStartTime string
-	lsNetworkEndTime   string
-	lsNetworkWatch     bool
+	lsNetworkShowTerminated bool
+	lsNetworkShowReports    bool
+	lsNetworkStartTime      string
+	lsNetworkEndTime        string
+	lsNetworkWatch          bool
 
 	networkReportID    string
 	networkReportWatch bool

--- a/cli/print/networks.go
+++ b/cli/print/networks.go
@@ -11,9 +11,9 @@ import (
 
 // Table formatting
 var (
-	networksTmplTableHeaderSrc = `ID	NAME	STATUS	CREATED	EXPIRES	POLICY	REPORTING`
+	networksTmplTableHeaderSrc = `ID	NAME	STATUS	CREATED	EXPIRES	POLICY	HAS REPORT`
 	networksTmplTableRowSrc    = `{{ range . -}}
-{{ .ID }}	{{ padding .Name 27	}}	{{ padding (printf "%s" .Status) 12 }}	{{ padding (printf "%s" (localeTime .CreatedAt)) 30 }}	{{if .ExpiresAt.IsZero}}{{ padding "-" 30 }}{{else}}{{ padding (printf "%s" (localeTime .ExpiresAt)) 30 }}{{end}}	{{if eq .Policy ""}}{{ padding "open" 30 }}{{else}}{{ padding (printf "%s" (.Policy)) 30 }}{{end}}	{{if .CollectReport}}{{ padding "on" 30 }}{{else}}{{ padding "off" 30 }}{{end}}
+{{ printf "%.8s" .ID }}	{{ padding .Name 27	}}	{{ padding (printf "%s" .Status) 12 }}	{{ padding (printf "%s" (localeTime .CreatedAt)) 30 }}	{{if .ExpiresAt.IsZero}}{{ padding "-" 30 }}{{else}}{{ padding (printf "%s" (localeTime .ExpiresAt)) 30 }}{{end}}	{{if eq .Policy ""}}{{ padding "open" 10 }}{{else}}{{ padding (printf "%s" (.Policy)) 10 }}{{end}}	{{if .HasReport}}{{ padding "yes" 10 }}{{else}}{{ padding "no" 10 }}{{end}}
 {{ end }}`
 )
 
@@ -25,9 +25,10 @@ var (
 
 // Wide table formatting
 var (
-	networksTmplWideHeaderSrc = `ID	NAME	STATUS	CREATED	EXPIRES	POLICY	REPORTING`
+	networksTmplWideHeaderSrc = `ID	NAME	STATUS	CREATED	EXPIRES	POLICY	HAS REPORT	REPORTING	RESOURCES`
 	networksTmplWideRowSrc    = `{{ range . -}}
-{{ .ID }}	{{ padding .Name 27	}}	{{ padding (printf "%s" .Status) 12 }}	{{ padding (printf "%s" (localeTime .CreatedAt)) 30 }}	{{if .ExpiresAt.IsZero}}{{ padding "-" 30 }}{{else}}{{ padding (printf "%s" (localeTime .ExpiresAt)) 30 }}{{end}}	{{if eq .Policy ""}}{{ padding "open" 30 }}{{else}}{{ padding (printf "%s" (.Policy)) 30 }}{{end}}	{{if .CollectReport}}{{ padding "on" 30 }}{{else}}{{ padding "off" 30 }}{{end}}
+{{ printf "%.8s" .ID }}	{{ padding .Name 27	}}	{{ padding (printf "%s" .Status) 12 }}	{{ padding (printf "%s" (localeTime .CreatedAt)) 30 }}	{{if .ExpiresAt.IsZero}}{{ padding "-" 30 }}{{else}}{{ padding (printf "%s" (localeTime .ExpiresAt)) 30 }}{{end}}	{{if eq .Policy ""}}{{ padding "open" 10 }}{{else}}{{ padding (printf "%s" (.Policy)) 10 }}{{end}}	{{if .HasReport}}{{ padding "yes" 10 }}{{else}}{{ padding "no" 10 }}{{end}}	{{if .CollectReport}}{{ padding "on" 10 }}{{else}}{{ padding "off" 10 }}{{end}}	{{if eq (len .Resources) 0}}-{{else}}{{ range $index, $resource := .Resources }}{{if $index}}
+                                                                                                                                                                         {{end}}{{ $resource.Distribution }}: {{ $resource.Name }} ({{ $resource.ID }}){{ end }}{{end}}
 {{ end }}`
 )
 

--- a/pkg/kotsclient/network_list.go
+++ b/pkg/kotsclient/network_list.go
@@ -18,7 +18,7 @@ type ListNetworksResponse struct {
 	TotalNetworks int              `json:"totalNetworks"`
 }
 
-func (c *VendorV3Client) ListNetworks(startTime *time.Time, endTime *time.Time) ([]*types.Network, error) {
+func (c *VendorV3Client) ListNetworks(includeTerminated bool, startTime *time.Time, endTime *time.Time) ([]*types.Network, error) {
 	allNetworks := []*types.Network{}
 	page := 0
 	for {
@@ -32,6 +32,7 @@ func (c *VendorV3Client) ListNetworks(startTime *time.Time, endTime *time.Time) 
 			v.Set("end-time", endTime.Format(time.RFC3339))
 		}
 		v.Set("currentPage", strconv.Itoa(page))
+		v.Set("show-terminated", strconv.FormatBool(includeTerminated))
 		url := fmt.Sprintf("/v3/networks?%s", v.Encode())
 		err := c.DoJSON(context.TODO(), "GET", url, http.StatusOK, nil, &networks)
 		if err != nil {

--- a/pkg/types/network.go
+++ b/pkg/types/network.go
@@ -17,8 +17,16 @@ type Network struct {
 	OverlayEndpoint string `json:"overlay_endpoint,omitempty"`
 	OverlayToken    string `json:"overlay_token,omitempty"`
 
-	Policy        string `json:"policy,omitempty"`
-	CollectReport bool   `json:"collect_report,omitempty"`
+	Policy        string            `json:"policy,omitempty"`
+	CollectReport bool              `json:"collect_report,omitempty"`
+	HasReport     bool              `json:"has_report,omitempty"`
+	Resources     []*NetworkResource `json:"resources,omitempty"`
+}
+
+type NetworkResource struct {
+	Name         string `json:"name"`
+	Distribution string `json:"distribution"`
+	ID           string `json:"id"`
 }
 
 type NetworkStatus string


### PR DESCRIPTION
This PR adds support for the new `has_report`, `network.resources` and `show-terminated` support added to the `network ls` command within the CLI.  This change **should not be merged** until the linked vendor portal PR.

The network resources are added when `-owide` is specified:

```
./bin/replicated network ls -owide
ID          NAME                           STATUS          CREATED                           EXPIRES                           POLICY        HAS REPORT    REPORTING     RESOURCES
d2fa5db8    keen_swanson                   assigned        2025-10-01 12:25 PDT              -                                 open          no            off           k3s: keen_swanson (fc1d4edd)
034a313a    wizardly_bartik                running         2025-10-01 11:59 PDT              2025-10-01 13:12 PDT              open          yes           on            ubuntu: wizardly_bartik (617a461b)
                                                                                                                                                                         almalinux: vibrant_ride (8776849d)
```

For non-wide I removed the `REPORTING` bool in place for `HAS REPORT` since they seemed redundant, I feel `HAS REPORT` on it's own gives enough info for the non-wide setting, but `REPORTING` on/off is still visible in wide and `-ojson`

```
./bin/replicated network ls
ID          NAME                           STATUS          CREATED                           EXPIRES                           POLICY        HAS REPORT
d2fa5db8    keen_swanson                   running         2025-10-01 12:25 PDT              2025-10-01 13:27 PDT              open          no
034a313a    wizardly_bartik                running         2025-10-01 11:59 PDT              2025-10-01 13:12 PDT              open          yes
```

We also now support `--show-terminated` which acts just like clusters/vms:

```
./bin/replicated network ls --show-terminated
ID          NAME                           STATUS          CREATED                           EXPIRES                           POLICY        HAS REPORT
d2fa5db8    keen_swanson                   running         2025-10-01 12:25 PDT              2025-10-01 13:27 PDT              open          no
034a313a    wizardly_bartik                running         2025-10-01 11:59 PDT              2025-10-01 13:12 PDT              open          yes
7ae1b677    vibrant_shirley                terminated      2025-10-01 10:12 PDT              2025-10-01 10:13 PDT              open          no
ab61c69d    hopeful_wing                   terminated      2025-10-01 10:12 PDT              2025-10-01 10:12 PDT              open          yes
93f06ff8    elegant_ardinghelli            terminated      2025-10-01 10:11 PDT              2025-10-01 10:11 PDT              open          yes
69d4c8e1    trusting_wilbur                terminated      2025-10-01 10:08 PDT              2025-10-01 10:09 PDT              open          yes
aa28ad7e    sad_lumiere                    terminated      2025-10-01 10:06 PDT              2025-10-01 10:07 PDT              open          yes
05984917    charming_black                 terminated      2025-09-30 18:25 PDT              2025-09-30 19:29 PDT              open          yes
d9102050    mystifying_taussig             terminated      2025-09-30 18:16 PDT              2025-09-30 19:17 PDT              open          no
0ce9278f    optimistic_dhawan              terminated      2025-09-30 18:15 PDT              2025-09-30 19:19 PDT              open          no
```

And we have a new `--show-reports` flag which only shows `HAS REPORT=true` results:
```
./bin/replicated network ls --show-reports
ID          NAME                           STATUS          CREATED                           EXPIRES                           POLICY        HAS REPORT
034a313a    wizardly_bartik                running         2025-10-01 11:59 PDT              2025-10-01 13:12 PDT              open          yes

./bin/replicated network ls --show-reports --show-terminated
ID          NAME                           STATUS          CREATED                           EXPIRES                           POLICY        HAS REPORT
034a313a    wizardly_bartik                running         2025-10-01 11:59 PDT              2025-10-01 13:12 PDT              open          yes
ab61c69d    hopeful_wing                   terminated      2025-10-01 10:12 PDT              2025-10-01 10:12 PDT              open          yes
93f06ff8    elegant_ardinghelli            terminated      2025-10-01 10:11 PDT              2025-10-01 10:11 PDT              open          yes
69d4c8e1    trusting_wilbur                terminated      2025-10-01 10:08 PDT              2025-10-01 10:09 PDT              open          yes
aa28ad7e    sad_lumiere                    terminated      2025-10-01 10:06 PDT              2025-10-01 10:07 PDT              open          yes
05984917    charming_black                 terminated      2025-09-30 18:25 PDT              2025-09-30 19:29 PDT              open          yes
```