### PR TITLE
Customer archive --app flag not working

### DIFF
--- a/cli/cmd/customer_archive.go
+++ b/cli/cmd/customer_archive.go
@@ -8,10 +8,7 @@ import (
 )
 
 func (r *runners) InitCustomersArchiveCommand(parent *cobra.Command) *cobra.Command {
-	var (
-		customer string
-		app      string
-	)
+	var customer string
 
 	cmd := &cobra.Command{
 		Use:   "archive <customer_name_or_id>",
@@ -43,18 +40,18 @@ replicated customer archive --app myapp "Acme Inc"`,
 				customers = args
 			}
 
-			return r.archiveCustomer(cmd, customers, app)
+			return r.archiveCustomer(customers)
 		},
 		SilenceUsage: true,
 	}
 	parent.AddCommand(cmd)
 	cmd.Flags().StringVar(&customer, "customer", "", "The Customer Name or ID to archive")
 	cmd.Flags().MarkHidden("customer")
-	cmd.Flags().StringVar(&app, "app", "", "The app to archive the customer in (not required when using a customer id)")
+	// Local --app flag removed - will use global flag from parent
 
 	return cmd
 }
-func (r *runners) archiveCustomer(cmd *cobra.Command, customers []string, app string) error {
+func (r *runners) archiveCustomer(customers []string) error {
 	if !r.hasApp() {
 		return errors.New("no app specified")
 	}
@@ -81,7 +78,7 @@ func (r *runners) archiveCustomer(cmd *cobra.Command, customers []string, app st
 
 		if c == nil {
 			// try to get the customer as if we have a name
-			cc, err := r.api.GetCustomerByName(app, customer)
+			cc, err := r.api.GetCustomerByName(r.appID, customer)
 			if err != nil {
 				return errors.Wrapf(err, "find customer %q", customer)
 			}

--- a/cli/cmd/customer_archive.go
+++ b/cli/cmd/customer_archive.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"github.com/pkg/errors"
-	"github.com/replicatedhq/replicated/pkg/kotsclient"
+	"github.com/replicatedhq/replicated/pkg/platformclient"
 	"github.com/replicatedhq/replicated/pkg/types"
 	"github.com/spf13/cobra"
 )
@@ -69,7 +69,7 @@ func (r *runners) archiveCustomer(customers []string) error {
 
 		// try to get the customer as if we have an id first
 		cc, err := r.api.GetCustomerByID(customer)
-		if err != nil && err != kotsclient.ErrNotFound {
+		if err != nil && errors.Cause(err) != platformclient.ErrNotFound {
 			return errors.Wrapf(err, "find customer %q", customer)
 		}
 		if cc != nil {


### PR DESCRIPTION
## Summary

Fixes the `customer archive` command which was ignoring the `--app` flag and always returning "Error: no app specified".

## Problem

The `customer archive` command defined its own local `--app` flag that shadowed the global `--app` flag. This prevented the parent command from properly initializing the app context.

**Before:**
$ replicated customer archive --app myapp customer_123
Error: no app specified  
**After:**
$ replicated customer archive --app myapp customer_123
Customer archived successfully

## Solution

- Removed the local `--app` flag definition
- Updated code to use `r.appID` from the runner context (which is set by the global flag)
- Added comment explaining the design decision

## Changes

- **1 file modified:** `cli/cmd/customer_archive.go`
- Removed local `app` variable and flag
- Updated `archiveCustomer()` function signature
- Changed `GetCustomerByName(app, ...)` to `GetCustomerByName(r.appID, ...)`

## Testing

 **Manual testing verified:**
- Created test customer
- Archived with `--app` flag (previously failed, now works)
- Verified customer removed from active list
- Verified customer still accessible via inspect

 **Build & Tests:**
- Build passes
- No linter errors
- All tests pass
- No regressions in other customer commands