### PR TITLE
fix: 'replicated lint' removed in favor of 'replicated release lint'

### DIFF
--- a/cli/cmd/init.go
+++ b/cli/cmd/init.go
@@ -513,7 +513,7 @@ func (r *runners) initConfig(cmd *cobra.Command, nonInteractive bool, skipDetect
 
 	fmt.Fprintf(r.w, "\nNext steps:\n")
 	if len(config.Charts) > 0 || len(config.Preflights) > 0 {
-		fmt.Fprintf(r.w, "  Run 'replicated lint' to validate your resources\n")
+		fmt.Fprintf(r.w, "  Run 'replicated release lint' to validate your resources\n")
 	}
 	fmt.Fprintf(r.w, "  Run 'replicated release create' to create a release\n")
 

--- a/docs/lint-format.md
+++ b/docs/lint-format.md
@@ -81,7 +81,7 @@ Notes:
 
 ## Glob Pattern Support
 
-The `replicated lint` command supports glob patterns for discovering files. This allows you to lint multiple charts, preflights, or manifests with a single pattern.
+The `replicated release lint` command supports glob patterns for discovering files. This allows you to lint multiple charts, preflights, or manifests with a single pattern.
 
 ### Supported Patterns
 

--- a/testdata/README.md
+++ b/testdata/README.md
@@ -1,6 +1,6 @@
 # Lint Integration Tests
 
-This directory contains integration/e2e tests for the `replicated lint` command.
+This directory contains integration/e2e tests for the `replicated release lint` command.
 
 ## Structure
 
@@ -82,7 +82,7 @@ make test-lint
 This will:
 1. Build the `replicated` binary (if needed)
 2. Find all test cases in `testdata/`
-3. Run `replicated lint` in each test directory
+3. Run `replicated release lint` in each test directory
 4. Compare actual results with `expect.json`
 5. Report pass/fail for each test
 
@@ -100,7 +100,7 @@ make build
 
 ```bash
 cd testdata/chart-with-required-values
-../../bin/replicated lint
+../../bin/replicated release lint
 ```
 
 ## Test Validation
@@ -149,7 +149,7 @@ The test script validates:
 4. Run lint manually to see what messages are produced:
    ```bash
    cd testdata/my-new-test
-   ../../bin/replicated lint
+   ../../bin/replicated release lint
    ```
 
 5. Create `expect.json` based on the output:


### PR DESCRIPTION
## Entry 1 — 2026-04-06 — blocker

**Trying to:** Run `replicated lint` as instructed by the `replicated config init` output
**Expected:** `replicated lint` would validate resources as advertised in the next-steps output
**Actual:** `Error: unknown command "lint" for "replicated"` — the command does not exist in the CLI
**Resolution:** Command should suggest `replicated release lint` rather than `replicated lint`
**Severity:** blocker
