### PR TITLE
fix doc formatting for replicated release create

### DIFF
--- a/cli/cmd/release_create.go
+++ b/cli/cmd/release_create.go
@@ -36,25 +36,24 @@ func (r *runners) InitReleaseCreate(parent *cobra.Command) error {
 		Use:   "create",
 		Short: "Create a new release",
 		Long: `Create a new release by providing application manifests for the next release in
-  your sequence.
+your sequence.
 
-  If no flags are provided, the command will automatically use the configuration from
-  .replicated file in the current directory (or parent directories). The config should
-  specify charts and manifests to include. Charts will be automatically packaged using
-  helm, and manifests will be collected using glob patterns.
+If no flags are provided, the command will automatically use the configuration from
+.replicated file in the current directory (or parent directories). The config should
+specify charts and manifests to include. Charts will be automatically packaged using
+helm, and manifests will be collected using glob patterns.`,
+       Example: `# .replicated config:
+appSlug: "my-app"
+  charts:
+    - path: ./chart
+  manifests:
+    - ./manifests/*.yaml
 
-  Example .replicated config:
-    appSlug: "my-app"
-    charts:
-      - path: ./chart
-    manifests:
-      - ./manifests/*.yaml
+# With this config, simply run:
+replicated release create --version 1.0.0 --promote Unstable
 
-  With this config, simply run:
-    replicated release create --version 1.0.0 --promote Unstable
-
-  To mark a release as required during upgrades:
-    replicated release create --version 1.0.0 --promote Unstable --required`,
+# To mark a release as required during upgrades:
+replicated release create --version 1.0.0 --promote Unstable --required`,
 		SilenceUsage:  false,
 		SilenceErrors: true, // this command uses custom error printing
 	}


### PR DESCRIPTION
The help text for `replicated release create` was formatted in such a way that the .replicated file was not rendering well in our docs site.  This change alters the text such that the example will be formatted monospace, preserving spacing for the file to be able to copy/paste successfully.

This change follows the convention of other commands, putting examples in a separate 'Example:' field.

New help text:

```
✗ ./bin/replicated release create --help
Create a new release by providing application manifests for the next release in
your sequence.

If no flags are provided, the command will automatically use the configuration from
.replicated file in the current directory (or parent directories). The config should
specify charts and manifests to include. Charts will be automatically packaged using
helm, and manifests will be collected using glob patterns.


Usage:
  replicated release create [flags]

Example:
  # .replicated config:
  appSlug: "my-app"
    charts:
      - path: ./chart
    manifests:
      - ./manifests/*.yaml

  # With this config, simply run:
  replicated release create --version 1.0.0 --promote Unstable

  # To mark a release as required during upgrades:
  replicated release create --version 1.0.0 --promote Unstable --required

Flags:
      --auto                   generate default values for use in CI
  -y, --confirm-auto           auto-accept the configuration generated by the --auto flag
      --ensure-channel         When used with --promote <channel>, will create the channel if it doesn't exist
      --fail-on string         The minimum severity to cause the command to exit with a non-zero exit code. Supported values are [info, warn, error, none]. (default "error")
  -h, --help                   help for create
      --lint                   Lint a manifests directory prior to creation of the KOTS Release.
  -o, --output string          The output format to use. One of: json|table (default "table")
      --promote string         Channel name (case sensitive) or id to promote this release to
      --release-notes string   When used with --promote <channel>, sets the **markdown** release notes
      --required               When used with --promote <channel>, marks this release as required during upgrades.
      --version string         When used with --promote <channel>, sets the version label for the release in this channel
      --yaml-dir string        The directory containing multiple yamls for a Kots release. Cannot be used with the --yaml flag.

Global Flags:
      --app string       The app slug or app id to use in all calls
      --debug            Enable debug output
      --profile string   The authentication profile to use for this command
      --token string     The API token to use to access your app in the Vendor API
```