### PR TITLE
feat(vm): add hidden --overlayfs flag to vm create (alpha)

### DIFF
--- a/cli/cmd/runner.go
+++ b/cli/cmd/runner.go
@@ -225,6 +225,7 @@ type runnerArgs struct {
 	createVMDryRun          bool
 	createVMPublicKeys      []string
 	createVMRBACPolicyName  string
+	createVMOverlayFS       bool
 
 	lsVMShowTerminated bool
 	lsVMStartTime      string

--- a/cli/cmd/vm_create.go
+++ b/cli/cmd/vm_create.go
@@ -76,7 +76,7 @@ replicated vm create --distribution ubuntu --version 20.04 --ssh-public-key ~/.s
 	cmd.Flags().StringArrayVar(&r.args.createVMPublicKeys, "ssh-public-key", []string{}, "Path to SSH public key file to add to the VM (can be specified multiple times)")
 	cmd.Flags().StringVar(&r.args.createVMRBACPolicyName, "rbac-policy-name", "", "(alpha) Name of the RBAC policy to assign to the VM (enables automatic vendor-api authentication inside the VM)")
 	cmd.Flags().MarkHidden("rbac-policy-name")
-	cmd.Flags().BoolVar(&r.args.createVMOverlayFS, "overlayfs", false, "(alpha) Use overlayfs-backed rootfs management for the VM (requires server-side cmx_overlayfs feature flag)")
+	cmd.Flags().BoolVar(&r.args.createVMOverlayFS, "overlayfs", false, "(alpha) Use overlayfs-backed rootfs management for the VM")
 	cmd.Flags().MarkHidden("overlayfs")
 
 	cmd.Flags().BoolVar(&r.args.createVMDryRun, "dry-run", false, "Dry run")

--- a/cli/cmd/vm_create.go
+++ b/cli/cmd/vm_create.go
@@ -76,6 +76,8 @@ replicated vm create --distribution ubuntu --version 20.04 --ssh-public-key ~/.s
 	cmd.Flags().StringArrayVar(&r.args.createVMPublicKeys, "ssh-public-key", []string{}, "Path to SSH public key file to add to the VM (can be specified multiple times)")
 	cmd.Flags().StringVar(&r.args.createVMRBACPolicyName, "rbac-policy-name", "", "(alpha) Name of the RBAC policy to assign to the VM (enables automatic vendor-api authentication inside the VM)")
 	cmd.Flags().MarkHidden("rbac-policy-name")
+	cmd.Flags().BoolVar(&r.args.createVMOverlayFS, "overlayfs", false, "(alpha) Use overlayfs-backed rootfs management for the VM (requires server-side cmx_overlayfs feature flag)")
+	cmd.Flags().MarkHidden("overlayfs")
 
 	cmd.Flags().BoolVar(&r.args.createVMDryRun, "dry-run", false, "Dry run")
 
@@ -127,6 +129,7 @@ func (r *runners) createVM(cmd *cobra.Command, args []string) error {
 		PublicKeys:   publicKeys,
 		DryRun:       r.args.createVMDryRun,
 		RBACPolicyID: rbacPolicyID,
+		OverlayFS:    r.args.createVMOverlayFS,
 	}
 
 	vms, err := r.createAndWaitForVM(opts)

--- a/cli/cmd/vm_create_test.go
+++ b/cli/cmd/vm_create_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -78,6 +79,7 @@ func TestCreateVM_OverlayFSRequestBody(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var capturedBody map[string]any
+			var handlerErr error
 
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if r.URL.Path != "/v3/vm" || r.Method != http.MethodPost {
@@ -86,8 +88,16 @@ func TestCreateVM_OverlayFSRequestBody(t *testing.T) {
 				}
 
 				bodyBytes, err := io.ReadAll(r.Body)
-				require.NoError(t, err)
-				require.NoError(t, json.Unmarshal(bodyBytes, &capturedBody))
+				if err != nil {
+					handlerErr = fmt.Errorf("read body: %w", err)
+					http.Error(w, handlerErr.Error(), http.StatusInternalServerError)
+					return
+				}
+				if err := json.Unmarshal(bodyBytes, &capturedBody); err != nil {
+					handlerErr = fmt.Errorf("unmarshal body: %w", err)
+					http.Error(w, handlerErr.Error(), http.StatusInternalServerError)
+					return
+				}
 
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusCreated)
@@ -107,6 +117,7 @@ func TestCreateVM_OverlayFSRequestBody(t *testing.T) {
 				Count:        1,
 				OverlayFS:    tt.overlayFS,
 			})
+			require.NoError(t, handlerErr, "handler failed to capture request body")
 			require.NoError(t, err)
 
 			val, ok := capturedBody["overlayfs"]

--- a/cli/cmd/vm_create_test.go
+++ b/cli/cmd/vm_create_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -58,6 +60,62 @@ func TestCreateAndWaitForVM_ForbiddenErrors(t *testing.T) {
 			})
 			require.Error(t, err)
 			require.Equal(t, tt.expectedError, err.Error())
+		})
+	}
+}
+
+func TestCreateVM_OverlayFSRequestBody(t *testing.T) {
+	tests := []struct {
+		name              string
+		overlayFS         bool
+		expectFieldPresent bool
+		expectFieldValue   bool
+	}{
+		{name: "overlayfs true sends overlayfs:true", overlayFS: true, expectFieldPresent: true, expectFieldValue: true},
+		{name: "overlayfs false omits the field", overlayFS: false, expectFieldPresent: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var capturedBody map[string]any
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/v3/vm" || r.Method != http.MethodPost {
+					http.NotFound(w, r)
+					return
+				}
+
+				bodyBytes, err := io.ReadAll(r.Body)
+				require.NoError(t, err)
+				require.NoError(t, json.Unmarshal(bodyBytes, &capturedBody))
+
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusCreated)
+				_, _ = w.Write([]byte(`{"vms":[{"id":"vm-1","status":"assigned"}]}`))
+			}))
+			defer server.Close()
+
+			httpClient := platformclient.NewHTTPClient(server.URL, "fake-api-key")
+			runner := &runners{
+				kotsAPI: &kotsclient.VendorV3Client{HTTPClient: *httpClient},
+			}
+
+			_, err := runner.createAndWaitForVM(kotsclient.CreateVMOpts{
+				Name:         "test-vm",
+				Distribution: "ubuntu",
+				Version:      "24.04",
+				Count:        1,
+				OverlayFS:    tt.overlayFS,
+			})
+			require.NoError(t, err)
+
+			val, ok := capturedBody["overlayfs"]
+			if tt.expectFieldPresent {
+				require.True(t, ok, "expected overlayfs field in request body")
+				require.Equal(t, tt.expectFieldValue, val)
+			} else {
+				require.False(t, ok, "expected overlayfs field to be omitted from request body")
+			}
 		})
 	}
 }

--- a/cli/cmd/vm_create_test.go
+++ b/cli/cmd/vm_create_test.go
@@ -66,8 +66,8 @@ func TestCreateAndWaitForVM_ForbiddenErrors(t *testing.T) {
 
 func TestCreateVM_OverlayFSRequestBody(t *testing.T) {
 	tests := []struct {
-		name              string
-		overlayFS         bool
+		name               string
+		overlayFS          bool
 		expectFieldPresent bool
 		expectFieldValue   bool
 	}{

--- a/pkg/kotsclient/vm_create.go
+++ b/pkg/kotsclient/vm_create.go
@@ -23,6 +23,7 @@ type CreateVMRequest struct {
 	Tags         []types.Tag `json:"tags"`
 	PublicKeys   []string    `json:"public_keys,omitempty"`
 	RBACPolicyID string      `json:"rbac_policy_id,omitempty"`
+	OverlayFS    bool        `json:"overlayfs,omitempty"`
 }
 
 type CreateVMResponse struct {
@@ -50,6 +51,7 @@ type CreateVMOpts struct {
 	PublicKeys   []string
 	DryRun       bool
 	RBACPolicyID string
+	OverlayFS    bool
 }
 
 type CreateVMErrorResponse struct {
@@ -80,6 +82,7 @@ func (c *VendorV3Client) CreateVM(opts CreateVMOpts) ([]*types.VM, *CreateVMErro
 		Tags:         opts.Tags,
 		PublicKeys:   opts.PublicKeys,
 		RBACPolicyID: opts.RBACPolicyID,
+		OverlayFS:    opts.OverlayFS,
 	}
 
 	if opts.DryRun {


### PR DESCRIPTION
## Summary

- Adds a hidden alpha-stage `--overlayfs` boolean flag to `replicated vm create` that opts a VM into the new overlayfs-backed rootfs primitive.
- Plumbs the flag from cobra → `runnerArgs` → `kotsclient.CreateVMOpts` → JSON `"overlayfs"` field on `POST /v3/vm`.
- Behavior is unchanged when the flag is omitted (`omitempty` keeps the existing wire format identical for users who don't pass the flag).
- Server-side gating is enforced by [vandoor#9598](https://github.com/replicatedhq/vandoor/pull/9598) behind the `cmx_overlayfs` team feature flag; the underlying provisioner work is in [reliability-matrix#2064](https://github.com/replicatedhq/reliability-matrix/pull/2064).

## Visibility

- Flag is registered with `MarkHidden("overlayfs")`, mirroring the precedent set by `--rbac-policy-name`.
- Description is prefixed with `(alpha)`.
- Not added to the `cmd.Example` block.

Refs: sc-135055

## Test plan

- [x] `go test ./cli/cmd/... ./pkg/kotsclient/... -count=1` — all pass
- [x] `go vet ./...` — clean
- [x] New end-to-end test (`TestCreateVM_OverlayFSRequestBody`) uses `httptest.Server` to assert the wire format: `"overlayfs": true` is sent when the field is set, and the field is absent when not (covers the `omitempty` invariant)
- [x] `vm create --help | grep overlayfs` returns empty (flag is hidden)
- [x] `vm create --overlayfs <...>` is accepted by cobra (no "unknown flag" error)