### PR TITLE
fix(lint): strip k8s version suffix from EC version in DiscoverECVersion

### DIFF
--- a/pkg/lint2/embedded_cluster.go
+++ b/pkg/lint2/embedded_cluster.go
@@ -6,10 +6,16 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"gopkg.in/yaml.v3"
 )
+
+// k8sVersionRegex matches the k8s version suffix in EC versions.
+// Format: +k8s-<major>.<minor> always at the end
+// Examples: "3.0.0+k8s-1.31", "3.0.0-rc0-35-g9b94-v3+k8s-1.33"
+var k8sVersionRegex = regexp.MustCompile(`\+k8s-(\d+\.\d+)$`)
 
 // ExpandManifestGlobs expands a list of manifest glob patterns to the set of
 // matching YAML files, applying the same gitignore and hidden-path filtering
@@ -136,7 +142,7 @@ func parseECVersionFromFile(path string) (string, error) {
 			break // io.EOF or parse error; stop iterating
 		}
 		if manifest.Kind == "Config" && manifest.APIVersion == ecConfigAPIVersion {
-			return manifest.Spec.Version, nil
+			return k8sVersionRegex.ReplaceAllString(manifest.Spec.Version, ""), nil
 		}
 	}
 	return "", nil

--- a/pkg/lint2/embedded_cluster_test.go
+++ b/pkg/lint2/embedded_cluster_test.go
@@ -1,0 +1,105 @@
+package lint2
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseECVersionFromFile(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name: "version with k8s suffix",
+			content: `apiVersion: embeddedcluster.replicated.com/v1beta1
+kind: Config
+spec:
+  version: "3.0.0+k8s-1.31"
+`,
+			want: "3.0.0",
+		},
+		{
+			name: "pre-release version with k8s suffix",
+			content: `apiVersion: embeddedcluster.replicated.com/v1beta1
+kind: Config
+spec:
+  version: "3.0.0-beta.2+k8s-1.34"
+`,
+			want: "3.0.0-beta.2",
+		},
+		{
+			name: "complex pre-release with k8s suffix",
+			content: `apiVersion: embeddedcluster.replicated.com/v1beta1
+kind: Config
+spec:
+  version: "3.0.0-rc0-35-g9b94-v3+k8s-1.33"
+`,
+			want: "3.0.0-rc0-35-g9b94-v3",
+		},
+		{
+			name: "wrong kind returns empty",
+			content: `apiVersion: embeddedcluster.replicated.com/v1beta1
+kind: NotConfig
+spec:
+  version: "3.0.0+k8s-1.31"
+`,
+			want: "",
+		},
+		{
+			name: "multi-doc file returns ec config version",
+			content: `apiVersion: v1
+kind: ConfigMap
+---
+apiVersion: embeddedcluster.replicated.com/v1beta1
+kind: Config
+spec:
+  version: "3.0.0-beta.2+k8s-1.34"
+`,
+			want: "3.0.0-beta.2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, err := os.CreateTemp(t.TempDir(), "ec-*.yaml")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := f.WriteString(tt.content); err != nil {
+				t.Fatal(err)
+			}
+			f.Close()
+
+			got, err := parseECVersionFromFile(f.Name())
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDiscoverECVersion(t *testing.T) {
+	dir := t.TempDir()
+	content := `apiVersion: embeddedcluster.replicated.com/v1beta1
+kind: Config
+spec:
+  version: "3.0.0-beta.2+k8s-1.34"
+`
+	if err := os.WriteFile(filepath.Join(dir, "ec.yaml"), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := DiscoverECVersion([]string{dir})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if want := "3.0.0-beta.2"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

- EC versions include a `+k8s-<major>.<minor>` suffix (e.g. `3.0.0-beta.2+k8s-1.34`) that needs to be stripped before use
- `parseECVersionFromFile` now applies the same regex the EC project uses: `\+k8s-(\d+\.\d+)$`
- Added unit tests covering the suffix-stripping cases including plain, pre-release, complex pre-release, wrong kind, and multi-doc YAML

## Test plan

- [ ] `go test ./pkg/lint2/ -run TestParseECVersionFromFile`
- [ ] `go test ./pkg/lint2/ -run TestDiscoverECVersion`

🤖 Generated with [Claude Code](https://claude.com/claude-code)