### PR TITLE
Add CLI support for notification management

### DIFF
--- a/cli/cmd/notification.go
+++ b/cli/cmd/notification.go
@@ -299,7 +299,7 @@ func (r *runners) InitNotificationEventTypeList(parent *cobra.Command) *cobra.Co
 	}
 	parent.AddCommand(cmd)
 	cmd.Flags().StringVar(&query, "q", "", "Search query")
-	cmd.Flags().IntVar(&limit, "limit", 0, "Maximum results to request from the API")
+	cmd.Flags().IntVar(&limit, "limit", 0, "Maximum results to request from the API (0 means no limit)")
 	cmd.Flags().StringVarP(&outputFormat, "output", "o", "table", "The output format to use. One of: json|table")
 	return cmd
 }

--- a/cli/cmd/notification.go
+++ b/cli/cmd/notification.go
@@ -1,0 +1,444 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/replicated/cli/print"
+	"github.com/replicatedhq/replicated/pkg/kotsclient"
+	"github.com/spf13/cobra"
+)
+
+func (r *runners) InitNotificationCommand(parent *cobra.Command) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "notification",
+		Short: "Manage event notifications",
+		Long:  "List, create, update, test, and manage event notification subscriptions and delivery events.",
+	}
+	parent.AddCommand(cmd)
+	return cmd
+}
+
+func (r *runners) InitNotificationSubscriptionCommand(parent *cobra.Command) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "subscription",
+		Short: "Manage notification subscriptions",
+	}
+	parent.AddCommand(cmd)
+	return cmd
+}
+
+func (r *runners) InitNotificationEventCommand(parent *cobra.Command) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "event",
+		Short: "Manage notification delivery events",
+	}
+	parent.AddCommand(cmd)
+	return cmd
+}
+
+func (r *runners) InitNotificationEventTypeCommand(parent *cobra.Command) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "event-type",
+		Short: "List available notification event types",
+	}
+	parent.AddCommand(cmd)
+	return cmd
+}
+
+func (r *runners) InitNotificationEmailCommand(parent *cobra.Command) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "email",
+		Short: "Manage notification email verification",
+	}
+	parent.AddCommand(cmd)
+	return cmd
+}
+
+func (r *runners) InitNotificationWebhookCommand(parent *cobra.Command) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "webhook",
+		Short: "Test notification webhooks",
+	}
+	parent.AddCommand(cmd)
+	return cmd
+}
+
+func (r *runners) InitNotificationSubscriptionList(parent *cobra.Command) *cobra.Command {
+	var outputFormat, search, subscriptionType string
+
+	cmd := &cobra.Command{
+		Use:     "ls",
+		Aliases: []string{"list"},
+		Short:   "List notification subscriptions",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			resp, err := r.kotsAPI.ListNotificationSubscriptions(search, subscriptionType)
+			if err != nil {
+				return errors.Wrap(err, "list notification subscriptions")
+			}
+			if len(resp.Subscriptions) == 0 {
+				return print.NoNotifications(outputFormat, r.w)
+			}
+			return print.Notifications(outputFormat, r.w, resp.Subscriptions)
+		},
+		SilenceUsage: true,
+	}
+	parent.AddCommand(cmd)
+	cmd.Flags().StringVar(&search, "search", "", "Text search filter")
+	cmd.Flags().StringVar(&subscriptionType, "type", "", "Filter by subscription type: personal|team")
+	cmd.Flags().StringVarP(&outputFormat, "output", "o", "table", "The output format to use. One of: json|table")
+	return cmd
+}
+
+func (r *runners) InitNotificationSubscriptionGet(parent *cobra.Command) *cobra.Command {
+	var outputFormat string
+
+	cmd := &cobra.Command{
+		Use:   "get ID",
+		Short: "Get a notification subscription",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			subscription, err := r.kotsAPI.GetNotificationSubscription(args[0])
+			if err != nil {
+				return errors.Wrap(err, "get notification subscription")
+			}
+			return print.Notification(outputFormat, r.w, subscription)
+		},
+		SilenceUsage: true,
+	}
+	parent.AddCommand(cmd)
+	cmd.Flags().StringVarP(&outputFormat, "output", "o", "table", "The output format to use. One of: json|table")
+	return cmd
+}
+
+func (r *runners) InitNotificationSubscriptionCreate(parent *cobra.Command) *cobra.Command {
+	var outputFormat, file string
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a notification subscription from a JSON file",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			req, err := readNotificationCreateRequest(file)
+			if err != nil {
+				return err
+			}
+			subscription, err := r.kotsAPI.CreateNotificationSubscription(req)
+			if err != nil {
+				return errors.Wrap(err, "create notification subscription")
+			}
+			return print.Notification(outputFormat, r.w, subscription)
+		},
+		SilenceUsage: true,
+	}
+	parent.AddCommand(cmd)
+	cmd.Flags().StringVar(&file, "file", "", "Path to a JSON file containing the subscription definition")
+	cmd.Flags().StringVarP(&outputFormat, "output", "o", "table", "The output format to use. One of: json|table")
+	_ = cmd.MarkFlagRequired("file")
+	return cmd
+}
+
+func (r *runners) InitNotificationSubscriptionUpdate(parent *cobra.Command) *cobra.Command {
+	var outputFormat, file string
+
+	cmd := &cobra.Command{
+		Use:   "update ID",
+		Short: "Update a notification subscription from a JSON file",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			req, err := readNotificationUpdateRequest(file)
+			if err != nil {
+				return err
+			}
+			subscription, err := r.kotsAPI.UpdateNotificationSubscription(args[0], req)
+			if err != nil {
+				return errors.Wrap(err, "update notification subscription")
+			}
+			return print.Notification(outputFormat, r.w, subscription)
+		},
+		SilenceUsage: true,
+	}
+	parent.AddCommand(cmd)
+	cmd.Flags().StringVar(&file, "file", "", "Path to a JSON file containing the subscription patch")
+	cmd.Flags().StringVarP(&outputFormat, "output", "o", "table", "The output format to use. One of: json|table")
+	_ = cmd.MarkFlagRequired("file")
+	return cmd
+}
+
+func (r *runners) InitNotificationSubscriptionRemove(parent *cobra.Command) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "rm ID",
+		Aliases: []string{"delete", "remove"},
+		Short:   "Delete a notification subscription",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := r.kotsAPI.DeleteNotificationSubscription(args[0]); err != nil {
+				return errors.Wrap(err, "delete notification subscription")
+			}
+			_, err := fmt.Fprintf(r.w, "Notification subscription %s deleted\n", args[0])
+			if err != nil {
+				return err
+			}
+			return r.w.Flush()
+		},
+		SilenceUsage: true,
+	}
+	parent.AddCommand(cmd)
+	return cmd
+}
+
+func (r *runners) InitNotificationSubscriptionEvents(parent *cobra.Command) *cobra.Command {
+	var outputFormat string
+
+	cmd := &cobra.Command{
+		Use:   "events ID",
+		Short: "List delivery events for a notification subscription",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			resp, err := r.kotsAPI.ListNotificationSubscriptionEvents(args[0])
+			if err != nil {
+				return errors.Wrap(err, "list notification subscription events")
+			}
+			if len(resp.Events) == 0 {
+				return print.NoNotificationEvents(outputFormat, r.w)
+			}
+			return print.NotificationEvents(outputFormat, r.w, resp.Events)
+		},
+		SilenceUsage: true,
+	}
+	parent.AddCommand(cmd)
+	cmd.Flags().StringVarP(&outputFormat, "output", "o", "table", "The output format to use. One of: json|table")
+	return cmd
+}
+
+func (r *runners) InitNotificationEventList(parent *cobra.Command) *cobra.Command {
+	var outputFormat string
+	opts := kotsclient.ListNotificationEventsOpts{}
+
+	cmd := &cobra.Command{
+		Use:     "ls",
+		Aliases: []string{"list"},
+		Short:   "List notification delivery events",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.StartTime != "" {
+				if _, err := time.Parse(time.RFC3339, opts.StartTime); err != nil {
+					return errors.Wrap(err, "parse start-time")
+				}
+			}
+			if opts.EndTime != "" {
+				if _, err := time.Parse(time.RFC3339, opts.EndTime); err != nil {
+					return errors.Wrap(err, "parse end-time")
+				}
+			}
+			resp, err := r.kotsAPI.ListNotificationEvents(opts)
+			if err != nil {
+				return errors.Wrap(err, "list notification events")
+			}
+			if len(resp.Events) == 0 {
+				return print.NoNotificationEvents(outputFormat, r.w)
+			}
+			return print.NotificationEvents(outputFormat, r.w, resp.Events)
+		},
+		SilenceUsage: true,
+	}
+	parent.AddCommand(cmd)
+	cmd.Flags().StringVar(&opts.Type, "type", "", "Filter by category prefix: all|instance|release|customer|channel|support|support_bundle")
+	cmd.Flags().StringArrayVar(&opts.EventTypes, "event-type", []string{}, "Filter by event type key (repeatable)")
+	cmd.Flags().StringVar(&opts.SubscriptionID, "subscription-id", "", "Filter by subscription ID")
+	cmd.Flags().StringVar(&opts.SubscriptionType, "subscription-type", "", "Filter by subscription type: personal|team")
+	cmd.Flags().StringVar(&opts.StartTime, "start-time", "", "Filter events after this time (RFC3339)")
+	cmd.Flags().StringVar(&opts.EndTime, "end-time", "", "Filter events before this time (RFC3339)")
+	cmd.Flags().StringVar(&opts.Search, "search", "", "Search event content")
+	cmd.Flags().StringVar(&opts.Status, "status", "", "Filter by status: success|pending|failed")
+	cmd.Flags().IntVar(&opts.CurrentPage, "current-page", 0, "Pagination page index")
+	cmd.Flags().IntVar(&opts.PageSize, "page-size", 20, "Pagination page size")
+	cmd.Flags().StringVarP(&outputFormat, "output", "o", "table", "The output format to use. One of: json|table")
+	return cmd
+}
+
+func (r *runners) InitNotificationEventRetry(parent *cobra.Command) *cobra.Command {
+	var outputFormat string
+
+	cmd := &cobra.Command{
+		Use:   "retry EVENT_ID",
+		Short: "Retry a notification event",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			resp, err := r.kotsAPI.RetryNotificationEvent(args[0])
+			if err != nil {
+				return errors.Wrap(err, "retry notification event")
+			}
+			return print.NotificationRetry(outputFormat, r.w, resp)
+		},
+		SilenceUsage: true,
+	}
+	parent.AddCommand(cmd)
+	cmd.Flags().StringVarP(&outputFormat, "output", "o", "table", "The output format to use. One of: json|table")
+	return cmd
+}
+
+func (r *runners) InitNotificationEventTypeList(parent *cobra.Command) *cobra.Command {
+	var outputFormat, query string
+	var limit int
+
+	cmd := &cobra.Command{
+		Use:     "ls",
+		Aliases: []string{"list"},
+		Short:   "List notification event types",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			resp, err := r.kotsAPI.ListNotificationEventTypes(query, limit)
+			if err != nil {
+				return errors.Wrap(err, "list notification event types")
+			}
+			return print.NotificationEventTypes(outputFormat, r.w, resp)
+		},
+		SilenceUsage: true,
+	}
+	parent.AddCommand(cmd)
+	cmd.Flags().StringVar(&query, "q", "", "Search query")
+	cmd.Flags().IntVar(&limit, "limit", 0, "Maximum results to request from the API")
+	cmd.Flags().StringVarP(&outputFormat, "output", "o", "table", "The output format to use. One of: json|table")
+	return cmd
+}
+
+func (r *runners) InitNotificationEmailResendVerification(parent *cobra.Command) *cobra.Command {
+	var outputFormat, email string
+
+	cmd := &cobra.Command{
+		Use:   "resend-verification",
+		Short: "Resend a verification email",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if strings.TrimSpace(email) == "" {
+				return errors.New("the --email flag is required")
+			}
+			resp, err := r.kotsAPI.ResendNotificationVerification(kotsclient.ResendNotificationVerificationRequest{
+				EmailAddress: email,
+			})
+			if err != nil {
+				return errors.Wrap(err, "resend verification email")
+			}
+			return print.NotificationEmailAction(outputFormat, r.w, resp)
+		},
+		SilenceUsage: true,
+	}
+	parent.AddCommand(cmd)
+	cmd.Flags().StringVar(&email, "email", "", "Email address to verify")
+	cmd.Flags().StringVarP(&outputFormat, "output", "o", "table", "The output format to use. One of: json|table")
+	_ = cmd.MarkFlagRequired("email")
+	return cmd
+}
+
+func (r *runners) InitNotificationEmailVerify(parent *cobra.Command) *cobra.Command {
+	var outputFormat, email, code string
+
+	cmd := &cobra.Command{
+		Use:   "verify",
+		Short: "Verify an email address for notifications",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if strings.TrimSpace(email) == "" {
+				return errors.New("the --email flag is required")
+			}
+			if strings.TrimSpace(code) == "" {
+				return errors.New("the --code flag is required")
+			}
+			resp, err := r.kotsAPI.VerifyNotificationEmail(kotsclient.VerifyNotificationEmailRequest{
+				EmailAddress:     email,
+				VerificationCode: code,
+			})
+			if err != nil {
+				return errors.Wrap(err, "verify notification email")
+			}
+			return print.NotificationEmailAction(outputFormat, r.w, resp)
+		},
+		SilenceUsage: true,
+	}
+	parent.AddCommand(cmd)
+	cmd.Flags().StringVar(&email, "email", "", "Email address to verify")
+	cmd.Flags().StringVar(&code, "code", "", "Verification code")
+	cmd.Flags().StringVarP(&outputFormat, "output", "o", "table", "The output format to use. One of: json|table")
+	_ = cmd.MarkFlagRequired("email")
+	_ = cmd.MarkFlagRequired("code")
+	return cmd
+}
+
+func (r *runners) InitNotificationWebhookTest(parent *cobra.Command) *cobra.Command {
+	var outputFormat, file string
+
+	cmd := &cobra.Command{
+		Use:   "test",
+		Short: "Send a test webhook from a JSON file",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			req, err := readNotificationWebhookTestRequest(file)
+			if err != nil {
+				return err
+			}
+			resp, err := r.kotsAPI.TestNotificationWebhook(req)
+			if err != nil {
+				return errors.Wrap(err, "test notification webhook")
+			}
+			return print.NotificationWebhookTest(outputFormat, r.w, resp)
+		},
+		SilenceUsage: true,
+	}
+	parent.AddCommand(cmd)
+	cmd.Flags().StringVar(&file, "file", "", "Path to a JSON file containing the webhook test payload")
+	cmd.Flags().StringVarP(&outputFormat, "output", "o", "table", "The output format to use. One of: json|table")
+	_ = cmd.MarkFlagRequired("file")
+	return cmd
+}
+
+func readNotificationCreateRequest(path string) (kotsclient.CreateNotificationSubscriptionRequest, error) {
+	var req kotsclient.CreateNotificationSubscriptionRequest
+	if err := readJSONFile(path, &req); err != nil {
+		return req, err
+	}
+	if len(req.EventConfigs) == 0 {
+		return req, errors.New("eventConfigs must contain at least one event config")
+	}
+	if strings.TrimSpace(req.EmailAddress) == "" && strings.TrimSpace(req.WebhookURL) == "" {
+		return req, errors.New("one of emailAddress or webhookUrl must be set")
+	}
+	return req, nil
+}
+
+func readNotificationUpdateRequest(path string) (kotsclient.UpdateNotificationSubscriptionRequest, error) {
+	var req kotsclient.UpdateNotificationSubscriptionRequest
+	if err := readJSONFile(path, &req); err != nil {
+		return req, err
+	}
+	if req.Name == nil && len(req.EventConfigs) == 0 && req.IsEnabled == nil && req.EmailAddress == "" && req.WebhookURL == "" && req.WebhookSecret == "" && req.CustomHeaders == nil {
+		return req, errors.New("subscription update file must include at least one field")
+	}
+	return req, nil
+}
+
+func readNotificationWebhookTestRequest(path string) (kotsclient.TestNotificationWebhookRequest, error) {
+	var req kotsclient.TestNotificationWebhookRequest
+	if err := readJSONFile(path, &req); err != nil {
+		return req, err
+	}
+	if strings.TrimSpace(req.WebhookURL) == "" {
+		return req, errors.New("webhookUrl is required")
+	}
+	if strings.TrimSpace(req.EventType) == "" {
+		return req, errors.New("eventType is required")
+	}
+	return req, nil
+}
+
+func readJSONFile(path string, target interface{}) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return errors.Wrap(err, "read file")
+	}
+	if !json.Valid(data) {
+		return errors.New("file is not valid JSON")
+	}
+	if err := json.Unmarshal(data, target); err != nil {
+		return errors.Wrap(err, "unmarshal json")
+	}
+	return nil
+}

--- a/cli/cmd/notification_test.go
+++ b/cli/cmd/notification_test.go
@@ -1,0 +1,88 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadNotificationCreateRequest(t *testing.T) {
+	t.Run("valid webhook request", func(t *testing.T) {
+		path := writeNotificationJSON(t, `{
+  "eventConfigs": [{"eventType":"customer.created","filters":{}}],
+  "isEnabled": true,
+  "webhookUrl": "https://example.com/webhook"
+}`)
+
+		req, err := readNotificationCreateRequest(path)
+		require.NoError(t, err)
+		require.Equal(t, "https://example.com/webhook", req.WebhookURL)
+		require.Len(t, req.EventConfigs, 1)
+	})
+
+	t.Run("missing delivery target", func(t *testing.T) {
+		path := writeNotificationJSON(t, `{
+  "eventConfigs": [{"eventType":"customer.created","filters":{}}],
+  "isEnabled": true
+}`)
+
+		_, err := readNotificationCreateRequest(path)
+		require.EqualError(t, err, "one of emailAddress or webhookUrl must be set")
+	})
+
+	t.Run("missing event configs", func(t *testing.T) {
+		path := writeNotificationJSON(t, `{
+  "isEnabled": true,
+  "emailAddress": "alerts@example.com"
+}`)
+
+		_, err := readNotificationCreateRequest(path)
+		require.EqualError(t, err, "eventConfigs must contain at least one event config")
+	})
+}
+
+func TestReadNotificationUpdateRequest(t *testing.T) {
+	t.Run("reject empty patch", func(t *testing.T) {
+		path := writeNotificationJSON(t, `{}`)
+
+		_, err := readNotificationUpdateRequest(path)
+		require.EqualError(t, err, "subscription update file must include at least one field")
+	})
+
+	t.Run("accept explicit false enable flag", func(t *testing.T) {
+		path := writeNotificationJSON(t, `{"isEnabled":false}`)
+
+		req, err := readNotificationUpdateRequest(path)
+		require.NoError(t, err)
+		require.NotNil(t, req.IsEnabled)
+		require.False(t, *req.IsEnabled)
+	})
+}
+
+func TestReadNotificationWebhookTestRequest(t *testing.T) {
+	t.Run("reject missing event type", func(t *testing.T) {
+		path := writeNotificationJSON(t, `{"webhookUrl":"https://example.com/webhook"}`)
+
+		_, err := readNotificationWebhookTestRequest(path)
+		require.EqualError(t, err, "eventType is required")
+	})
+
+	t.Run("reject invalid json", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "bad.json")
+		require.NoError(t, os.WriteFile(path, []byte(`{"webhookUrl":`), 0644))
+
+		_, err := readNotificationWebhookTestRequest(path)
+		require.EqualError(t, err, "file is not valid JSON")
+	})
+}
+
+func writeNotificationJSON(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "notification.json")
+	require.NoError(t, os.WriteFile(path, []byte(body), 0644))
+	return path
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -506,6 +506,30 @@ func Execute(rootCmd *cobra.Command, stdin io.Reader, stdout io.Writer, stderr i
 	runCmds.InitPolicyRm(policyCmd)
 	policyCmd.PersistentPreRunE = preRunSetupAPIs
 
+	notificationCmd := runCmds.InitNotificationCommand(runCmds.rootCmd)
+	notificationSubscriptionCmd := runCmds.InitNotificationSubscriptionCommand(notificationCmd)
+	runCmds.InitNotificationSubscriptionList(notificationSubscriptionCmd)
+	runCmds.InitNotificationSubscriptionGet(notificationSubscriptionCmd)
+	runCmds.InitNotificationSubscriptionCreate(notificationSubscriptionCmd)
+	runCmds.InitNotificationSubscriptionUpdate(notificationSubscriptionCmd)
+	runCmds.InitNotificationSubscriptionRemove(notificationSubscriptionCmd)
+	runCmds.InitNotificationSubscriptionEvents(notificationSubscriptionCmd)
+
+	notificationEventCmd := runCmds.InitNotificationEventCommand(notificationCmd)
+	runCmds.InitNotificationEventList(notificationEventCmd)
+	runCmds.InitNotificationEventRetry(notificationEventCmd)
+
+	notificationEventTypeCmd := runCmds.InitNotificationEventTypeCommand(notificationCmd)
+	runCmds.InitNotificationEventTypeList(notificationEventTypeCmd)
+
+	notificationEmailCmd := runCmds.InitNotificationEmailCommand(notificationCmd)
+	runCmds.InitNotificationEmailResendVerification(notificationEmailCmd)
+	runCmds.InitNotificationEmailVerify(notificationEmailCmd)
+
+	notificationWebhookCmd := runCmds.InitNotificationWebhookCommand(notificationCmd)
+	runCmds.InitNotificationWebhookTest(notificationWebhookCmd)
+	notificationCmd.PersistentPreRunE = preRunSetupAPIs
+
 	// Add config command with init subcommand
 	configCmd := runCmds.InitConfigCommand(runCmds.rootCmd)
 	runCmds.InitInitCommand(configCmd)

--- a/cli/print/notifications.go
+++ b/cli/print/notifications.go
@@ -1,0 +1,257 @@
+package print
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"text/tabwriter"
+	"text/template"
+
+	"github.com/replicatedhq/replicated/pkg/types"
+)
+
+var notificationTemplateFuncs = template.FuncMap{
+	"notificationName":        notificationName,
+	"subscriptionType":        subscriptionType,
+	"subscriptionDestination": subscriptionDestination,
+	"subscriptionVerified":    subscriptionVerified,
+	"webhookStatusCode":       webhookStatusCode,
+}
+
+var notificationSubscriptionsTmpl = template.Must(template.New("notification-subscriptions").Funcs(notificationTemplateFuncs).Parse(`ID	NAME	TYPE	DESTINATION	ENABLED	VERIFIED
+{{ range . -}}
+{{ .ID }}	{{ notificationName . }}	{{ subscriptionType . }}	{{ subscriptionDestination . }}	{{ .IsEnabled }}	{{ subscriptionVerified . }}
+{{ end }}`))
+
+var notificationEventsTmpl = template.Must(template.New("notification-events").Funcs(funcs).Parse(`ID	EVENT TYPE	STATUS	SUBSCRIPTION	CREATED	ATTEMPTS
+{{ range . -}}
+{{ .ID }}	{{ .EventType }}	{{ .Status }}	{{ .SubscriptionID }}	{{ localeTime .CreatedAt }}	{{ len .Attempts }}
+{{ end }}`))
+
+var notificationEventTypesTmpl = template.Must(template.New("notification-event-types").Parse(`KEY	DISPLAY NAME	CATEGORY	DESCRIPTION
+{{ range . -}}
+{{ .Key }}	{{ .DisplayName }}	{{ .Category }}	{{ .Description }}
+{{ end }}`))
+
+var notificationEmailActionTmpl = template.Must(template.New("notification-email-action").Parse(`SUCCESS	MESSAGE
+{{ .Success }}	{{ .Message }}
+`))
+
+var notificationRetryTmpl = template.Must(template.New("notification-retry").Parse(`SUCCESS	MESSAGE
+{{ .Success }}	{{ .Message }}
+`))
+
+var notificationWebhookTestTmpl = template.Must(template.New("notification-webhook-test").Funcs(notificationTemplateFuncs).Parse(`SUCCESS	STATUS CODE	DURATION (MS)	ERROR
+{{ .Success }}	{{ webhookStatusCode .StatusCode }}	{{ .DurationMs }}	{{ .Error }}
+`))
+
+func Notifications(outputFormat string, w *tabwriter.Writer, subscriptions []types.NotificationSubscription) error {
+	switch outputFormat {
+	case "table":
+		if err := notificationSubscriptionsTmpl.Execute(w, subscriptions); err != nil {
+			return err
+		}
+	case "json":
+		b, err := json.MarshalIndent(subscriptions, "", "  ")
+		if err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintln(w, string(b)); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("invalid output format: %s", outputFormat)
+	}
+	return w.Flush()
+}
+
+func Notification(outputFormat string, w *tabwriter.Writer, subscription *types.NotificationSubscription) error {
+	return Notifications(outputFormat, w, []types.NotificationSubscription{*subscription})
+}
+
+func NotificationEvents(outputFormat string, w *tabwriter.Writer, events []types.NotificationEvent) error {
+	switch outputFormat {
+	case "table":
+		if err := notificationEventsTmpl.Execute(w, events); err != nil {
+			return err
+		}
+	case "json":
+		b, err := json.MarshalIndent(events, "", "  ")
+		if err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintln(w, string(b)); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("invalid output format: %s", outputFormat)
+	}
+	return w.Flush()
+}
+
+func NotificationEventTypes(outputFormat string, w *tabwriter.Writer, response *types.NotificationEventTypesResponse) error {
+	switch outputFormat {
+	case "table":
+		if err := notificationEventTypesTmpl.Execute(w, response.EventTypes); err != nil {
+			return err
+		}
+	case "json":
+		b, err := json.MarshalIndent(response, "", "  ")
+		if err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintln(w, string(b)); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("invalid output format: %s", outputFormat)
+	}
+	return w.Flush()
+}
+
+func NotificationEmailAction(outputFormat string, w *tabwriter.Writer, response *types.NotificationEmailResponse) error {
+	switch outputFormat {
+	case "table":
+		if err := notificationEmailActionTmpl.Execute(w, response); err != nil {
+			return err
+		}
+	case "json":
+		b, err := json.MarshalIndent(response, "", "  ")
+		if err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintln(w, string(b)); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("invalid output format: %s", outputFormat)
+	}
+	return w.Flush()
+}
+
+func NotificationRetry(outputFormat string, w *tabwriter.Writer, response *types.NotificationRetryResponse) error {
+	switch outputFormat {
+	case "table":
+		if err := notificationRetryTmpl.Execute(w, response); err != nil {
+			return err
+		}
+	case "json":
+		b, err := json.MarshalIndent(response, "", "  ")
+		if err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintln(w, string(b)); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("invalid output format: %s", outputFormat)
+	}
+	return w.Flush()
+}
+
+func NotificationWebhookTest(outputFormat string, w *tabwriter.Writer, response *types.NotificationWebhookTestResponse) error {
+	switch outputFormat {
+	case "table":
+		if err := notificationWebhookTestTmpl.Execute(w, response); err != nil {
+			return err
+		}
+	case "json":
+		b, err := json.MarshalIndent(response, "", "  ")
+		if err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintln(w, string(b)); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("invalid output format: %s", outputFormat)
+	}
+	return w.Flush()
+}
+
+func NoNotifications(outputFormat string, w *tabwriter.Writer) error {
+	switch outputFormat {
+	case "table":
+		_, err := fmt.Fprintln(w, "No notification subscriptions found.")
+		if err != nil {
+			return err
+		}
+	case "json":
+		if _, err := fmt.Fprintln(w, "[]"); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("invalid output format: %s", outputFormat)
+	}
+	return w.Flush()
+}
+
+func NoNotificationEvents(outputFormat string, w *tabwriter.Writer) error {
+	switch outputFormat {
+	case "table":
+		_, err := fmt.Fprintln(w, "No notification events found.")
+		if err != nil {
+			return err
+		}
+	case "json":
+		if _, err := fmt.Fprintln(w, "[]"); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("invalid output format: %s", outputFormat)
+	}
+	return w.Flush()
+}
+
+func notificationName(sub types.NotificationSubscription) string {
+	if strings.TrimSpace(sub.Name) != "" {
+		return sub.Name
+	}
+	if len(sub.EventConfigs) == 1 {
+		return sub.EventConfigs[0].EventType
+	}
+	if len(sub.EventConfigs) > 1 {
+		return fmt.Sprintf("%d event types", len(sub.EventConfigs))
+	}
+	return "-"
+}
+
+func subscriptionType(sub types.NotificationSubscription) string {
+	if strings.TrimSpace(sub.WebhookURL) != "" {
+		return "webhook"
+	}
+	if strings.TrimSpace(sub.EmailAddress) != "" {
+		return "email"
+	}
+	return "unknown"
+}
+
+func subscriptionDestination(sub types.NotificationSubscription) string {
+	if strings.TrimSpace(sub.WebhookURL) != "" {
+		return sub.WebhookURL
+	}
+	if strings.TrimSpace(sub.EmailAddress) != "" {
+		return sub.EmailAddress
+	}
+	return "-"
+}
+
+func subscriptionVerified(sub types.NotificationSubscription) string {
+	if strings.TrimSpace(sub.EmailAddress) == "" {
+		return "-"
+	}
+	if sub.EmailVerified {
+		return "true"
+	}
+	if sub.RequiresVerification {
+		return "pending"
+	}
+	return "false"
+}
+
+func webhookStatusCode(code *int) string {
+	if code == nil {
+		return "-"
+	}
+	return fmt.Sprintf("%d", *code)
+}

--- a/pact/kotsclient/notification_test.go
+++ b/pact/kotsclient/notification_test.go
@@ -1,0 +1,437 @@
+package kotsclient
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pact-foundation/pact-go/dsl"
+	realkotsclient "github.com/replicatedhq/replicated/pkg/kotsclient"
+	"github.com/replicatedhq/replicated/pkg/platformclient"
+	"github.com/replicatedhq/replicated/pkg/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ListNotificationSubscriptions(t *testing.T) {
+	test := func() error {
+		u := fmt.Sprintf("http://localhost:%d", pact.Server.Port)
+		api := platformclient.NewHTTPClient(u, "replicated-cli-list-notifications-token")
+		client := realkotsclient.VendorV3Client{HTTPClient: *api}
+
+		resp, err := client.ListNotificationSubscriptions("release", "team")
+		assert.NoError(t, err)
+		assert.Equal(t, 1, resp.TotalCount)
+		assert.Len(t, resp.Subscriptions, 1)
+		assert.Equal(t, "Release webhook", resp.Subscriptions[0].Name)
+
+		return nil
+	}
+
+	pact.AddInteraction().
+		Given("List notification subscriptions").
+		UponReceiving("A request to list notification subscriptions").
+		WithRequest(dsl.Request{
+			Method: "GET",
+			Path:   dsl.String("/v3/notification_subscriptions"),
+			Query: dsl.MapMatcher{
+				"search": dsl.String("release"),
+				"type":   dsl.String("team"),
+			},
+			Headers: dsl.MapMatcher{
+				"Authorization": dsl.String("replicated-cli-list-notifications-token"),
+				"Content-Type":  dsl.String("application/json"),
+			},
+		}).
+		WillRespondWith(dsl.Response{
+			Status: 200,
+			Body: map[string]interface{}{
+				"subscriptions": []map[string]interface{}{
+					{
+						"id":         dsl.Like("notif-sub-1"),
+						"userId":     dsl.Like("user-1"),
+						"teamId":     dsl.Like("team-1"),
+						"name":       dsl.String("Release webhook"),
+						"isEnabled":  true,
+						"webhookUrl": dsl.String("https://example.com/hook"),
+						"eventConfigs": []map[string]interface{}{
+							{
+								"eventType": dsl.String("release.promoted"),
+								"filters":   map[string]interface{}{},
+							},
+						},
+					},
+				},
+				"totalCount": dsl.Like(1),
+			},
+		})
+
+	if err := pact.Verify(test); err != nil {
+		t.Fatalf("Error on Verify: %v", err)
+	}
+}
+
+func Test_CreateUpdateGetDeleteNotificationSubscription(t *testing.T) {
+	test := func() error {
+		u := fmt.Sprintf("http://localhost:%d", pact.Server.Port)
+		api := platformclient.NewHTTPClient(u, "replicated-cli-subscription-token")
+		client := realkotsclient.VendorV3Client{HTTPClient: *api}
+
+		created, err := client.CreateNotificationSubscription(realkotsclient.CreateNotificationSubscriptionRequest{
+			Name:       "Release webhook",
+			IsEnabled:  true,
+			WebhookURL: "https://example.com/hook",
+			EventConfigs: []types.NotificationEventConfig{
+				{
+					EventType: "release.promoted",
+					Filters:   map[string]interface{}{},
+				},
+			},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, "notif-sub-1", created.ID)
+
+		got, err := client.GetNotificationSubscription("notif-sub-1")
+		assert.NoError(t, err)
+		assert.Equal(t, "Release webhook", got.Name)
+
+		enabled := false
+		updated, err := client.UpdateNotificationSubscription("notif-sub-1", realkotsclient.UpdateNotificationSubscriptionRequest{
+			IsEnabled: &enabled,
+		})
+		assert.NoError(t, err)
+		assert.False(t, updated.IsEnabled)
+
+		err = client.DeleteNotificationSubscription("notif-sub-1")
+		assert.NoError(t, err)
+
+		return nil
+	}
+
+	eventConfigs := []map[string]interface{}{
+		{
+			"eventType": "release.promoted",
+			"filters":   map[string]interface{}{},
+		},
+	}
+
+	pact.AddInteraction().
+		Given("Create notification subscription").
+		UponReceiving("A request to create a notification subscription").
+		WithRequest(dsl.Request{
+			Method: "POST",
+			Path:   dsl.String("/v3/notification_subscription"),
+			Headers: dsl.MapMatcher{
+				"Authorization": dsl.String("replicated-cli-subscription-token"),
+				"Content-Type":  dsl.String("application/json"),
+			},
+			Body: map[string]interface{}{
+				"name":         "Release webhook",
+				"isEnabled":    true,
+				"webhookUrl":   "https://example.com/hook",
+				"eventConfigs": eventConfigs,
+			},
+		}).
+		WillRespondWith(dsl.Response{
+			Status: 201,
+			Body: map[string]interface{}{
+				"id":           dsl.Like("notif-sub-1"),
+				"userId":       dsl.Like("user-1"),
+				"teamId":       dsl.Like("team-1"),
+				"name":         dsl.String("Release webhook"),
+				"isEnabled":    true,
+				"webhookUrl":   dsl.String("https://example.com/hook"),
+				"eventConfigs": eventConfigs,
+			},
+		})
+
+	pact.AddInteraction().
+		Given("Get notification subscription").
+		UponReceiving("A request to get a notification subscription").
+		WithRequest(dsl.Request{
+			Method: "GET",
+			Path:   dsl.String("/v3/notification_subscription/notif-sub-1"),
+			Headers: dsl.MapMatcher{
+				"Authorization": dsl.String("replicated-cli-subscription-token"),
+				"Content-Type":  dsl.String("application/json"),
+			},
+		}).
+		WillRespondWith(dsl.Response{
+			Status: 200,
+			Body: map[string]interface{}{
+				"id":           dsl.Like("notif-sub-1"),
+				"userId":       dsl.Like("user-1"),
+				"teamId":       dsl.Like("team-1"),
+				"name":         dsl.String("Release webhook"),
+				"isEnabled":    true,
+				"webhookUrl":   dsl.String("https://example.com/hook"),
+				"eventConfigs": eventConfigs,
+			},
+		})
+
+	pact.AddInteraction().
+		Given("Update notification subscription").
+		UponReceiving("A request to update a notification subscription").
+		WithRequest(dsl.Request{
+			Method: "PUT",
+			Path:   dsl.String("/v3/notification_subscription/notif-sub-1"),
+			Headers: dsl.MapMatcher{
+				"Authorization": dsl.String("replicated-cli-subscription-token"),
+				"Content-Type":  dsl.String("application/json"),
+			},
+			Body: map[string]interface{}{
+				"isEnabled": false,
+			},
+		}).
+		WillRespondWith(dsl.Response{
+			Status: 200,
+			Body: map[string]interface{}{
+				"id":           dsl.Like("notif-sub-1"),
+				"userId":       dsl.Like("user-1"),
+				"teamId":       dsl.Like("team-1"),
+				"name":         dsl.String("Release webhook"),
+				"isEnabled":    false,
+				"webhookUrl":   dsl.String("https://example.com/hook"),
+				"eventConfigs": eventConfigs,
+			},
+		})
+
+	pact.AddInteraction().
+		Given("Delete notification subscription").
+		UponReceiving("A request to delete a notification subscription").
+		WithRequest(dsl.Request{
+			Method: "DELETE",
+			Path:   dsl.String("/v3/notification_subscription/notif-sub-1"),
+			Headers: dsl.MapMatcher{
+				"Authorization": dsl.String("replicated-cli-subscription-token"),
+				"Content-Type":  dsl.String("application/json"),
+			},
+		}).
+		WillRespondWith(dsl.Response{
+			Status: 204,
+		})
+
+	if err := pact.Verify(test); err != nil {
+		t.Fatalf("Error on Verify: %v", err)
+	}
+}
+
+func Test_ListNotificationEventsAndTypes(t *testing.T) {
+	test := func() error {
+		u := fmt.Sprintf("http://localhost:%d", pact.Server.Port)
+		api := platformclient.NewHTTPClient(u, "replicated-cli-events-token")
+		client := realkotsclient.VendorV3Client{HTTPClient: *api}
+
+		eventsResp, err := client.ListNotificationEvents(realkotsclient.ListNotificationEventsOpts{
+			Status:         "failed",
+			SubscriptionID: "notif-sub-1",
+			PageSize:       20,
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, 1, eventsResp.TotalCount)
+		assert.Len(t, eventsResp.Events, 1)
+
+		typesResp, err := client.ListNotificationEventTypes("release", 20)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, typesResp.Total)
+		assert.Equal(t, "release.promoted", typesResp.EventTypes[0].Key)
+
+		return nil
+	}
+
+	pact.AddInteraction().
+		Given("List notification events").
+		UponReceiving("A request to list notification events").
+		WithRequest(dsl.Request{
+			Method: "GET",
+			Path:   dsl.String("/v3/notification_events"),
+			Query: dsl.MapMatcher{
+				"status":          dsl.String("failed"),
+				"subscription_id": dsl.String("notif-sub-1"),
+				"pageSize":        dsl.String("20"),
+			},
+			Headers: dsl.MapMatcher{
+				"Authorization": dsl.String("replicated-cli-events-token"),
+				"Content-Type":  dsl.String("application/json"),
+			},
+		}).
+		WillRespondWith(dsl.Response{
+			Status: 200,
+			Body: map[string]interface{}{
+				"events": []map[string]interface{}{
+					{
+						"id":             dsl.Like("evt-1"),
+						"subscriptionId": dsl.Like("notif-sub-1"),
+						"eventType":      dsl.String("release.promoted"),
+						"eventData":      map[string]interface{}{"releaseId": "rel-1"},
+						"payloadType":    dsl.String("webhook"),
+						"payload":        map[string]interface{}{"event": "release.promoted"},
+						"retryCount":     dsl.Like(8),
+						"status":         dsl.String("failed"),
+						"attempts":       []map[string]interface{}{},
+					},
+				},
+				"totalCount": dsl.Like(1),
+			},
+		})
+
+	pact.AddInteraction().
+		Given("List notification event types").
+		UponReceiving("A request to list notification event types").
+		WithRequest(dsl.Request{
+			Method: "GET",
+			Path:   dsl.String("/v3/notification_event_types"),
+			Query: dsl.MapMatcher{
+				"q":     dsl.String("release"),
+				"limit": dsl.String("20"),
+			},
+			Headers: dsl.MapMatcher{
+				"Authorization": dsl.String("replicated-cli-events-token"),
+				"Content-Type":  dsl.String("application/json"),
+			},
+		}).
+		WillRespondWith(dsl.Response{
+			Status: 200,
+			Body: map[string]interface{}{
+				"eventTypes": []map[string]interface{}{
+					{
+						"key":         dsl.String("release.promoted"),
+						"displayName": dsl.String("Release Promoted"),
+						"description": dsl.String("A release was promoted."),
+						"category":    dsl.String("Release"),
+						"filters":     []map[string]interface{}{},
+					},
+				},
+				"total": dsl.Like(1),
+			},
+		})
+
+	if err := pact.Verify(test); err != nil {
+		t.Fatalf("Error on Verify: %v", err)
+	}
+}
+
+func Test_NotificationRetryEmailAndWebhook(t *testing.T) {
+	test := func() error {
+		u := fmt.Sprintf("http://localhost:%d", pact.Server.Port)
+		api := platformclient.NewHTTPClient(u, "replicated-cli-notification-actions-token")
+		client := realkotsclient.VendorV3Client{HTTPClient: *api}
+
+		retryResp, err := client.RetryNotificationEvent("evt-1")
+		assert.NoError(t, err)
+		assert.True(t, retryResp.Success)
+
+		resendResp, err := client.ResendNotificationVerification(realkotsclient.ResendNotificationVerificationRequest{
+			EmailAddress: "alerts@example.com",
+		})
+		assert.NoError(t, err)
+		assert.True(t, resendResp.Success)
+
+		verifyResp, err := client.VerifyNotificationEmail(realkotsclient.VerifyNotificationEmailRequest{
+			EmailAddress:     "alerts@example.com",
+			VerificationCode: "123456",
+		})
+		assert.NoError(t, err)
+		assert.True(t, verifyResp.Success)
+
+		webhookResp, err := client.TestNotificationWebhook(realkotsclient.TestNotificationWebhookRequest{
+			WebhookURL: "https://example.com/hook",
+			EventType:  "release.promoted",
+		})
+		assert.NoError(t, err)
+		assert.True(t, webhookResp.Success)
+		assert.NotNil(t, webhookResp.StatusCode)
+
+		return nil
+	}
+
+	pact.AddInteraction().
+		Given("Retry notification event").
+		UponReceiving("A request to retry a notification event").
+		WithRequest(dsl.Request{
+			Method: "POST",
+			Path:   dsl.String("/v3/notification_event/evt-1/retry"),
+			Headers: dsl.MapMatcher{
+				"Authorization": dsl.String("replicated-cli-notification-actions-token"),
+				"Content-Type":  dsl.String("application/json"),
+			},
+		}).
+		WillRespondWith(dsl.Response{
+			Status: 200,
+			Body: map[string]interface{}{
+				"success": dsl.Like(true),
+				"message": dsl.String("Notification event queued for retry"),
+			},
+		})
+
+	pact.AddInteraction().
+		Given("Resend notification verification email").
+		UponReceiving("A request to resend notification verification email").
+		WithRequest(dsl.Request{
+			Method: "POST",
+			Path:   dsl.String("/v3/notification_email/resend_verification"),
+			Headers: dsl.MapMatcher{
+				"Authorization": dsl.String("replicated-cli-notification-actions-token"),
+				"Content-Type":  dsl.String("application/json"),
+			},
+			Body: map[string]interface{}{
+				"emailAddress": "alerts@example.com",
+			},
+		}).
+		WillRespondWith(dsl.Response{
+			Status: 200,
+			Body: map[string]interface{}{
+				"success": dsl.Like(true),
+				"message": dsl.String("Verification email sent successfully"),
+			},
+		})
+
+	pact.AddInteraction().
+		Given("Verify notification email").
+		UponReceiving("A request to verify notification email").
+		WithRequest(dsl.Request{
+			Method: "POST",
+			Path:   dsl.String("/v3/notification_email/verify"),
+			Headers: dsl.MapMatcher{
+				"Authorization": dsl.String("replicated-cli-notification-actions-token"),
+				"Content-Type":  dsl.String("application/json"),
+			},
+			Body: map[string]interface{}{
+				"emailAddress":     "alerts@example.com",
+				"verificationCode": "123456",
+			},
+		}).
+		WillRespondWith(dsl.Response{
+			Status: 200,
+			Body: map[string]interface{}{
+				"success": dsl.Like(true),
+				"message": dsl.String("Email address verified successfully"),
+			},
+		})
+
+	pact.AddInteraction().
+		Given("Test notification webhook").
+		UponReceiving("A request to test notification webhook").
+		WithRequest(dsl.Request{
+			Method: "POST",
+			Path:   dsl.String("/v3/notification_webhook/test"),
+			Headers: dsl.MapMatcher{
+				"Authorization": dsl.String("replicated-cli-notification-actions-token"),
+				"Content-Type":  dsl.String("application/json"),
+			},
+			Body: map[string]interface{}{
+				"webhookUrl": "https://example.com/hook",
+				"eventType":  "release.promoted",
+			},
+		}).
+		WillRespondWith(dsl.Response{
+			Status: 200,
+			Body: map[string]interface{}{
+				"success":    dsl.Like(true),
+				"statusCode": dsl.Like(200),
+				"durationMs": dsl.Like(15),
+			},
+		})
+
+	if err := pact.Verify(test); err != nil {
+		t.Fatalf("Error on Verify: %v", err)
+	}
+}

--- a/pacts/replicated-cli-vendor-api.json
+++ b/pacts/replicated-cli-vendor-api.json
@@ -28,11 +28,11 @@
           "app": {
             "channels": [
               {
-              },
+        },
               {
-              },
+        },
               {
-              }
+        }
             ],
             "created": "2000-02-01T12:30:00Z",
             "description": "",
@@ -83,7 +83,7 @@
             {
               "channels": [
                 {
-                }
+        }
               ],
               "id": "replicated-cli-list-apps-app",
               "name": "Replicated CLI List Apps App",
@@ -223,8 +223,7 @@
             "id": "replicated-cli-get-channel-unstable",
             "name": "Unstable",
             "releases": [
-
-            ]
+        ]
           }
         },
         "matchingRules": {
@@ -1203,8 +1202,7 @@
         },
         "body": {
           "releases": [
-
-          ]
+        ]
         }
       }
     },
@@ -1491,6 +1489,430 @@
             "match": "type"
           },
           "$.body.cluster.ttl": {
+            "match": "type"
+          }
+        }
+      }
+    },
+    {
+      "description": "A request to list notification subscriptions",
+      "providerState": "List notification subscriptions",
+      "request": {
+        "method": "GET",
+        "path": "/v3/notification_subscriptions",
+        "query": "search=release&type=team",
+        "headers": {
+          "Authorization": "replicated-cli-list-notifications-token",
+          "Content-Type": "application/json"
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+        },
+        "body": {
+          "subscriptions": [
+            {
+              "eventConfigs": [
+                {
+                  "eventType": "release.promoted",
+                  "filters": {
+        }
+                }
+              ],
+              "id": "notif-sub-1",
+              "isEnabled": true,
+              "name": "Release webhook",
+              "teamId": "team-1",
+              "userId": "user-1",
+              "webhookUrl": "https://example.com/hook"
+            }
+          ],
+          "totalCount": 1
+        },
+        "matchingRules": {
+          "$.body.subscriptions[0].id": {
+            "match": "type"
+          },
+          "$.body.subscriptions[0].teamId": {
+            "match": "type"
+          },
+          "$.body.subscriptions[0].userId": {
+            "match": "type"
+          },
+          "$.body.totalCount": {
+            "match": "type"
+          }
+        }
+      }
+    },
+    {
+      "description": "A request to create a notification subscription",
+      "providerState": "Create notification subscription",
+      "request": {
+        "method": "POST",
+        "path": "/v3/notification_subscription",
+        "headers": {
+          "Authorization": "replicated-cli-subscription-token",
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "eventConfigs": [
+            {
+              "eventType": "release.promoted",
+              "filters": {
+        }
+            }
+          ],
+          "isEnabled": true,
+          "name": "Release webhook",
+          "webhookUrl": "https://example.com/hook"
+        }
+      },
+      "response": {
+        "status": 201,
+        "headers": {
+        },
+        "body": {
+          "eventConfigs": [
+            {
+              "eventType": "release.promoted",
+              "filters": {
+        }
+            }
+          ],
+          "id": "notif-sub-1",
+          "isEnabled": true,
+          "name": "Release webhook",
+          "teamId": "team-1",
+          "userId": "user-1",
+          "webhookUrl": "https://example.com/hook"
+        },
+        "matchingRules": {
+          "$.body.id": {
+            "match": "type"
+          },
+          "$.body.teamId": {
+            "match": "type"
+          },
+          "$.body.userId": {
+            "match": "type"
+          }
+        }
+      }
+    },
+    {
+      "description": "A request to get a notification subscription",
+      "providerState": "Get notification subscription",
+      "request": {
+        "method": "GET",
+        "path": "/v3/notification_subscription/notif-sub-1",
+        "headers": {
+          "Authorization": "replicated-cli-subscription-token",
+          "Content-Type": "application/json"
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+        },
+        "body": {
+          "eventConfigs": [
+            {
+              "eventType": "release.promoted",
+              "filters": {
+        }
+            }
+          ],
+          "id": "notif-sub-1",
+          "isEnabled": true,
+          "name": "Release webhook",
+          "teamId": "team-1",
+          "userId": "user-1",
+          "webhookUrl": "https://example.com/hook"
+        },
+        "matchingRules": {
+          "$.body.id": {
+            "match": "type"
+          },
+          "$.body.teamId": {
+            "match": "type"
+          },
+          "$.body.userId": {
+            "match": "type"
+          }
+        }
+      }
+    },
+    {
+      "description": "A request to update a notification subscription",
+      "providerState": "Update notification subscription",
+      "request": {
+        "method": "PUT",
+        "path": "/v3/notification_subscription/notif-sub-1",
+        "headers": {
+          "Authorization": "replicated-cli-subscription-token",
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "isEnabled": false
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+        },
+        "body": {
+          "eventConfigs": [
+            {
+              "eventType": "release.promoted",
+              "filters": {
+        }
+            }
+          ],
+          "id": "notif-sub-1",
+          "isEnabled": false,
+          "name": "Release webhook",
+          "teamId": "team-1",
+          "userId": "user-1",
+          "webhookUrl": "https://example.com/hook"
+        },
+        "matchingRules": {
+          "$.body.id": {
+            "match": "type"
+          },
+          "$.body.teamId": {
+            "match": "type"
+          },
+          "$.body.userId": {
+            "match": "type"
+          }
+        }
+      }
+    },
+    {
+      "description": "A request to delete a notification subscription",
+      "providerState": "Delete notification subscription",
+      "request": {
+        "method": "DELETE",
+        "path": "/v3/notification_subscription/notif-sub-1",
+        "headers": {
+          "Authorization": "replicated-cli-subscription-token",
+          "Content-Type": "application/json"
+        }
+      },
+      "response": {
+        "status": 204,
+        "headers": {
+        }
+      }
+    },
+    {
+      "description": "A request to list notification events",
+      "providerState": "List notification events",
+      "request": {
+        "method": "GET",
+        "path": "/v3/notification_events",
+        "query": "pageSize=20&status=failed&subscription_id=notif-sub-1",
+        "headers": {
+          "Authorization": "replicated-cli-events-token",
+          "Content-Type": "application/json"
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+        },
+        "body": {
+          "events": [
+            {
+              "attempts": [
+        ],
+              "eventData": {
+                "releaseId": "rel-1"
+              },
+              "eventType": "release.promoted",
+              "id": "evt-1",
+              "payload": {
+                "event": "release.promoted"
+              },
+              "payloadType": "webhook",
+              "retryCount": 8,
+              "status": "failed",
+              "subscriptionId": "notif-sub-1"
+            }
+          ],
+          "totalCount": 1
+        },
+        "matchingRules": {
+          "$.body.events[0].id": {
+            "match": "type"
+          },
+          "$.body.events[0].retryCount": {
+            "match": "type"
+          },
+          "$.body.events[0].subscriptionId": {
+            "match": "type"
+          },
+          "$.body.totalCount": {
+            "match": "type"
+          }
+        }
+      }
+    },
+    {
+      "description": "A request to list notification event types",
+      "providerState": "List notification event types",
+      "request": {
+        "method": "GET",
+        "path": "/v3/notification_event_types",
+        "query": "limit=20&q=release",
+        "headers": {
+          "Authorization": "replicated-cli-events-token",
+          "Content-Type": "application/json"
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+        },
+        "body": {
+          "eventTypes": [
+            {
+              "category": "Release",
+              "description": "A release was promoted.",
+              "displayName": "Release Promoted",
+              "filters": [
+        ],
+              "key": "release.promoted"
+            }
+          ],
+          "total": 1
+        },
+        "matchingRules": {
+          "$.body.total": {
+            "match": "type"
+          }
+        }
+      }
+    },
+    {
+      "description": "A request to retry a notification event",
+      "providerState": "Retry notification event",
+      "request": {
+        "method": "POST",
+        "path": "/v3/notification_event/evt-1/retry",
+        "headers": {
+          "Authorization": "replicated-cli-notification-actions-token",
+          "Content-Type": "application/json"
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+        },
+        "body": {
+          "message": "Notification event queued for retry",
+          "success": true
+        },
+        "matchingRules": {
+          "$.body.success": {
+            "match": "type"
+          }
+        }
+      }
+    },
+    {
+      "description": "A request to resend notification verification email",
+      "providerState": "Resend notification verification email",
+      "request": {
+        "method": "POST",
+        "path": "/v3/notification_email/resend_verification",
+        "headers": {
+          "Authorization": "replicated-cli-notification-actions-token",
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "emailAddress": "alerts@example.com"
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+        },
+        "body": {
+          "message": "Verification email sent successfully",
+          "success": true
+        },
+        "matchingRules": {
+          "$.body.success": {
+            "match": "type"
+          }
+        }
+      }
+    },
+    {
+      "description": "A request to verify notification email",
+      "providerState": "Verify notification email",
+      "request": {
+        "method": "POST",
+        "path": "/v3/notification_email/verify",
+        "headers": {
+          "Authorization": "replicated-cli-notification-actions-token",
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "emailAddress": "alerts@example.com",
+          "verificationCode": "123456"
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+        },
+        "body": {
+          "message": "Email address verified successfully",
+          "success": true
+        },
+        "matchingRules": {
+          "$.body.success": {
+            "match": "type"
+          }
+        }
+      }
+    },
+    {
+      "description": "A request to test notification webhook",
+      "providerState": "Test notification webhook",
+      "request": {
+        "method": "POST",
+        "path": "/v3/notification_webhook/test",
+        "headers": {
+          "Authorization": "replicated-cli-notification-actions-token",
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "eventType": "release.promoted",
+          "webhookUrl": "https://example.com/hook"
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+        },
+        "body": {
+          "durationMs": 15,
+          "statusCode": 200,
+          "success": true
+        },
+        "matchingRules": {
+          "$.body.durationMs": {
+            "match": "type"
+          },
+          "$.body.statusCode": {
+            "match": "type"
+          },
+          "$.body.success": {
             "match": "type"
           }
         }

--- a/pkg/kotsclient/notification.go
+++ b/pkg/kotsclient/notification.go
@@ -1,0 +1,215 @@
+package kotsclient
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/replicatedhq/replicated/pkg/types"
+)
+
+type CreateNotificationSubscriptionRequest struct {
+	Name          string                          `json:"name,omitempty"`
+	EventConfigs  []types.NotificationEventConfig `json:"eventConfigs"`
+	IsEnabled     bool                            `json:"isEnabled"`
+	EmailAddress  string                          `json:"emailAddress,omitempty"`
+	WebhookURL    string                          `json:"webhookUrl,omitempty"`
+	WebhookSecret string                          `json:"webhookSecret,omitempty"`
+	CustomHeaders []types.CustomHeaderInput       `json:"customHeaders,omitempty"`
+}
+
+type UpdateNotificationSubscriptionRequest struct {
+	Name          *string                         `json:"name,omitempty"`
+	EventConfigs  []types.NotificationEventConfig `json:"eventConfigs,omitempty"`
+	IsEnabled     *bool                           `json:"isEnabled,omitempty"`
+	EmailAddress  string                          `json:"emailAddress,omitempty"`
+	WebhookURL    string                          `json:"webhookUrl,omitempty"`
+	WebhookSecret string                          `json:"webhookSecret,omitempty"`
+	CustomHeaders *[]types.CustomHeaderInput      `json:"customHeaders,omitempty"`
+}
+
+type VerifyNotificationEmailRequest struct {
+	EmailAddress     string `json:"emailAddress"`
+	VerificationCode string `json:"verificationCode"`
+}
+
+type ResendNotificationVerificationRequest struct {
+	EmailAddress string `json:"emailAddress"`
+}
+
+type TestNotificationWebhookRequest struct {
+	WebhookURL    string                    `json:"webhookUrl"`
+	WebhookSecret string                    `json:"webhookSecret,omitempty"`
+	EventType     string                    `json:"eventType"`
+	CustomHeaders []types.CustomHeaderInput `json:"customHeaders,omitempty"`
+}
+
+type ListNotificationEventsOpts struct {
+	Type             string
+	EventTypes       []string
+	SubscriptionID   string
+	SubscriptionType string
+	StartTime        string
+	EndTime          string
+	Search           string
+	Status           string
+	CurrentPage      int
+	PageSize         int
+}
+
+func (c *VendorV3Client) ListNotificationSubscriptions(search string, subscriptionType string) (*types.NotificationListSubscriptionsResponse, error) {
+	v := url.Values{}
+	if strings.TrimSpace(search) != "" {
+		v.Set("search", search)
+	}
+	if strings.TrimSpace(subscriptionType) != "" {
+		v.Set("type", subscriptionType)
+	}
+
+	path := "/v3/notification_subscriptions"
+	if encoded := v.Encode(); encoded != "" {
+		path = path + "?" + encoded
+	}
+
+	resp := &types.NotificationListSubscriptionsResponse{}
+	if err := c.DoJSON(context.TODO(), "GET", path, http.StatusOK, nil, resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (c *VendorV3Client) GetNotificationSubscription(id string) (*types.NotificationSubscription, error) {
+	resp := &types.NotificationSubscription{}
+	if err := c.DoJSON(context.TODO(), "GET", fmt.Sprintf("/v3/notification_subscription/%s", url.PathEscape(id)), http.StatusOK, nil, resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (c *VendorV3Client) CreateNotificationSubscription(req CreateNotificationSubscriptionRequest) (*types.NotificationSubscription, error) {
+	resp := &types.NotificationSubscription{}
+	if err := c.DoJSON(context.TODO(), "POST", "/v3/notification_subscription", http.StatusCreated, req, resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (c *VendorV3Client) UpdateNotificationSubscription(id string, req UpdateNotificationSubscriptionRequest) (*types.NotificationSubscription, error) {
+	resp := &types.NotificationSubscription{}
+	if err := c.DoJSON(context.TODO(), "PUT", fmt.Sprintf("/v3/notification_subscription/%s", url.PathEscape(id)), http.StatusOK, req, resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (c *VendorV3Client) DeleteNotificationSubscription(id string) error {
+	return c.DoJSON(context.TODO(), "DELETE", fmt.Sprintf("/v3/notification_subscription/%s", url.PathEscape(id)), http.StatusNoContent, nil, nil)
+}
+
+func (c *VendorV3Client) ListNotificationSubscriptionEvents(id string) (*types.NotificationSubscriptionEventsResponse, error) {
+	resp := &types.NotificationSubscriptionEventsResponse{}
+	if err := c.DoJSON(context.TODO(), "GET", fmt.Sprintf("/v3/notification_subscription/%s/events", url.PathEscape(id)), http.StatusOK, nil, resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (c *VendorV3Client) ListNotificationEvents(opts ListNotificationEventsOpts) (*types.NotificationEventsResponse, error) {
+	v := url.Values{}
+	if opts.Type != "" {
+		v.Set("type", opts.Type)
+	}
+	for _, eventType := range opts.EventTypes {
+		v.Add("event_types", eventType)
+	}
+	if opts.SubscriptionID != "" {
+		v.Set("subscription_id", opts.SubscriptionID)
+	}
+	if opts.SubscriptionType != "" {
+		v.Set("subscription_type", opts.SubscriptionType)
+	}
+	if opts.StartTime != "" {
+		v.Set("start_time", opts.StartTime)
+	}
+	if opts.EndTime != "" {
+		v.Set("end_time", opts.EndTime)
+	}
+	if opts.Search != "" {
+		v.Set("search", opts.Search)
+	}
+	if opts.Status != "" {
+		v.Set("status", opts.Status)
+	}
+	if opts.CurrentPage > 0 {
+		v.Set("currentPage", fmt.Sprintf("%d", opts.CurrentPage))
+	}
+	if opts.PageSize > 0 {
+		v.Set("pageSize", fmt.Sprintf("%d", opts.PageSize))
+	}
+
+	path := "/v3/notification_events"
+	if encoded := v.Encode(); encoded != "" {
+		path = path + "?" + encoded
+	}
+
+	resp := &types.NotificationEventsResponse{}
+	if err := c.DoJSON(context.TODO(), "GET", path, http.StatusOK, nil, resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (c *VendorV3Client) RetryNotificationEvent(id string) (*types.NotificationRetryResponse, error) {
+	resp := &types.NotificationRetryResponse{}
+	if err := c.DoJSON(context.TODO(), "POST", fmt.Sprintf("/v3/notification_event/%s/retry", url.PathEscape(id)), http.StatusOK, nil, resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (c *VendorV3Client) ListNotificationEventTypes(query string, limit int) (*types.NotificationEventTypesResponse, error) {
+	v := url.Values{}
+	if strings.TrimSpace(query) != "" {
+		v.Set("q", query)
+	}
+	if limit > 0 {
+		v.Set("limit", fmt.Sprintf("%d", limit))
+	}
+
+	path := "/v3/notification_event_types"
+	if encoded := v.Encode(); encoded != "" {
+		path = path + "?" + encoded
+	}
+
+	resp := &types.NotificationEventTypesResponse{}
+	if err := c.DoJSON(context.TODO(), "GET", path, http.StatusOK, nil, resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (c *VendorV3Client) ResendNotificationVerification(req ResendNotificationVerificationRequest) (*types.NotificationEmailResponse, error) {
+	resp := &types.NotificationEmailResponse{}
+	if err := c.DoJSON(context.TODO(), "POST", "/v3/notification_email/resend_verification", http.StatusOK, req, resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (c *VendorV3Client) VerifyNotificationEmail(req VerifyNotificationEmailRequest) (*types.NotificationEmailResponse, error) {
+	resp := &types.NotificationEmailResponse{}
+	if err := c.DoJSON(context.TODO(), "POST", "/v3/notification_email/verify", http.StatusOK, req, resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (c *VendorV3Client) TestNotificationWebhook(req TestNotificationWebhookRequest) (*types.NotificationWebhookTestResponse, error) {
+	resp := &types.NotificationWebhookTestResponse{}
+	if err := c.DoJSON(context.TODO(), "POST", "/v3/notification_webhook/test", http.StatusOK, req, resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}

--- a/pkg/kotsclient/notification_test.go
+++ b/pkg/kotsclient/notification_test.go
@@ -1,0 +1,203 @@
+package kotsclient
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/replicatedhq/replicated/pkg/platformclient"
+	"github.com/replicatedhq/replicated/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNotificationSubscriptionClient(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "test-token", r.Header.Get("Authorization"))
+
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v3/notification_subscriptions":
+			require.Equal(t, "release", r.URL.Query().Get("search"))
+			require.Equal(t, "team", r.URL.Query().Get("type"))
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"subscriptions": []map[string]interface{}{
+					{
+						"id":         "sub-1",
+						"userId":     "user-1",
+						"teamId":     "team-1",
+						"name":       "Release webhook",
+						"isEnabled":  true,
+						"webhookUrl": "https://example.com/hook",
+						"eventConfigs": []map[string]interface{}{
+							{"eventType": "release.promoted", "filters": map[string]interface{}{}},
+						},
+					},
+				},
+				"totalCount": 1,
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/v3/notification_subscription":
+			var body CreateNotificationSubscriptionRequest
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+			require.Equal(t, "Release webhook", body.Name)
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"id":           "sub-1",
+				"userId":       "user-1",
+				"teamId":       "team-1",
+				"name":         body.Name,
+				"isEnabled":    body.IsEnabled,
+				"webhookUrl":   body.WebhookURL,
+				"eventConfigs": body.EventConfigs,
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/v3/notification_subscription/sub-1":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"id":         "sub-1",
+				"userId":     "user-1",
+				"teamId":     "team-1",
+				"name":       "Release webhook",
+				"isEnabled":  true,
+				"webhookUrl": "https://example.com/hook",
+				"eventConfigs": []map[string]interface{}{
+					{"eventType": "release.promoted", "filters": map[string]interface{}{}},
+				},
+			})
+		case r.Method == http.MethodPut && r.URL.Path == "/v3/notification_subscription/sub-1":
+			var body UpdateNotificationSubscriptionRequest
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+			require.NotNil(t, body.IsEnabled)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"id":         "sub-1",
+				"userId":     "user-1",
+				"teamId":     "team-1",
+				"name":       "Release webhook",
+				"isEnabled":  *body.IsEnabled,
+				"webhookUrl": "https://example.com/hook",
+				"eventConfigs": []map[string]interface{}{
+					{"eventType": "release.promoted", "filters": map[string]interface{}{}},
+				},
+			})
+		case r.Method == http.MethodDelete && r.URL.Path == "/v3/notification_subscription/sub-1":
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	api := platformclient.NewHTTPClient(server.URL, "test-token")
+	client := VendorV3Client{HTTPClient: *api}
+
+	listResp, err := client.ListNotificationSubscriptions("release", "team")
+	require.NoError(t, err)
+	require.Equal(t, 1, listResp.TotalCount)
+
+	created, err := client.CreateNotificationSubscription(CreateNotificationSubscriptionRequest{
+		Name:       "Release webhook",
+		IsEnabled:  true,
+		WebhookURL: "https://example.com/hook",
+		EventConfigs: []types.NotificationEventConfig{
+			{EventType: "release.promoted", Filters: map[string]interface{}{}},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "sub-1", created.ID)
+
+	got, err := client.GetNotificationSubscription("sub-1")
+	require.NoError(t, err)
+	require.Equal(t, "Release webhook", got.Name)
+
+	enabled := false
+	updated, err := client.UpdateNotificationSubscription("sub-1", UpdateNotificationSubscriptionRequest{
+		IsEnabled: &enabled,
+	})
+	require.NoError(t, err)
+	require.False(t, updated.IsEnabled)
+
+	require.NoError(t, client.DeleteNotificationSubscription("sub-1"))
+}
+
+func TestNotificationActionClients(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v3/notification_events":
+			require.Equal(t, "failed", r.URL.Query().Get("status"))
+			require.Equal(t, "sub-1", r.URL.Query().Get("subscription_id"))
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"events": []map[string]interface{}{
+					{
+						"id":             "evt-1",
+						"subscriptionId": "sub-1",
+						"eventType":      "release.promoted",
+						"eventData":      map[string]interface{}{"releaseId": "rel-1"},
+						"payloadType":    "webhook",
+						"payload":        map[string]interface{}{"event": "release.promoted"},
+						"retryCount":     8,
+						"status":         "failed",
+						"attempts":       []map[string]interface{}{},
+					},
+				},
+				"totalCount": 1,
+			})
+		case "/v3/notification_event_types":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"eventTypes": []map[string]interface{}{
+					{
+						"key":         "release.promoted",
+						"displayName": "Release Promoted",
+						"description": "A release was promoted.",
+						"category":    "Release",
+					},
+				},
+				"total": 1,
+			})
+		case "/v3/notification_event/evt-1/retry":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"success": true, "message": "queued"})
+		case "/v3/notification_email/resend_verification":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"success": true, "message": "resent"})
+		case "/v3/notification_email/verify":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"success": true, "message": "verified"})
+		case "/v3/notification_webhook/test":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"success": true, "statusCode": 200, "durationMs": 12})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	api := platformclient.NewHTTPClient(server.URL, "test-token")
+	client := VendorV3Client{HTTPClient: *api}
+
+	eventsResp, err := client.ListNotificationEvents(ListNotificationEventsOpts{
+		Status:         "failed",
+		SubscriptionID: "sub-1",
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, eventsResp.TotalCount)
+
+	eventTypesResp, err := client.ListNotificationEventTypes("release", 20)
+	require.NoError(t, err)
+	require.Equal(t, 1, eventTypesResp.Total)
+
+	retryResp, err := client.RetryNotificationEvent("evt-1")
+	require.NoError(t, err)
+	require.True(t, retryResp.Success)
+
+	resendResp, err := client.ResendNotificationVerification(ResendNotificationVerificationRequest{EmailAddress: "alerts@example.com"})
+	require.NoError(t, err)
+	require.True(t, resendResp.Success)
+
+	verifyResp, err := client.VerifyNotificationEmail(VerifyNotificationEmailRequest{
+		EmailAddress:     "alerts@example.com",
+		VerificationCode: "123456",
+	})
+	require.NoError(t, err)
+	require.True(t, verifyResp.Success)
+
+	webhookResp, err := client.TestNotificationWebhook(TestNotificationWebhookRequest{
+		WebhookURL: "https://example.com/hook",
+		EventType:  "release.promoted",
+	})
+	require.NoError(t, err)
+	require.True(t, webhookResp.Success)
+	require.NotNil(t, webhookResp.StatusCode)
+}

--- a/pkg/types/notification.go
+++ b/pkg/types/notification.go
@@ -1,0 +1,145 @@
+package types
+
+import (
+	"encoding/json"
+	"time"
+)
+
+type Actor struct {
+	ID          string    `json:"id"`
+	Type        string    `json:"type"`
+	Description string    `json:"description"`
+	Link        string    `json:"link"`
+	Timestamp   time.Time `json:"timestamp"`
+}
+
+type NotificationEventConfig struct {
+	EventType string                 `json:"eventType"`
+	Filters   map[string]interface{} `json:"filters"`
+}
+
+type CustomHeaderInput struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+type CustomHeaderMasked struct {
+	Name        string `json:"name"`
+	MaskedValue string `json:"maskedValue"`
+}
+
+type NotificationSubscription struct {
+	ID                   string                    `json:"id"`
+	UserID               string                    `json:"userId"`
+	TeamID               string                    `json:"teamId"`
+	Name                 string                    `json:"name,omitempty"`
+	CreatedAt            time.Time                 `json:"createdAt"`
+	UpdatedAt            time.Time                 `json:"updatedAt,omitempty"`
+	DeletedAt            *time.Time                `json:"deletedAt,omitempty"`
+	CreatedBy            *Actor                    `json:"createdBy,omitempty"`
+	EventConfigs         []NotificationEventConfig `json:"eventConfigs"`
+	IsEnabled            bool                      `json:"isEnabled"`
+	EmailAddress         string                    `json:"emailAddress"`
+	WebhookURL           string                    `json:"webhookUrl,omitempty"`
+	CustomHeaders        []CustomHeaderMasked      `json:"customHeaders,omitempty"`
+	EmailVerified        bool                      `json:"emailVerified,omitempty"`
+	RequiresVerification bool                      `json:"requiresVerification,omitempty"`
+	Readonly             bool                      `json:"readonly,omitempty"`
+}
+
+type NotificationListSubscriptionsResponse struct {
+	Subscriptions []NotificationSubscription `json:"subscriptions"`
+	TotalCount    int                        `json:"totalCount"`
+}
+
+type NotificationEventTypeFilterOption struct {
+	Value      string `json:"value"`
+	Label      string `json:"label"`
+	AppID      string `json:"appId,omitempty"`
+	MetricType string `json:"metricType,omitempty"`
+}
+
+type NotificationEventTypeFilterField struct {
+	Key         string                              `json:"key"`
+	Label       string                              `json:"label"`
+	Type        string                              `json:"type"`
+	Placeholder string                              `json:"placeholder,omitempty"`
+	Options     []NotificationEventTypeFilterOption `json:"options,omitempty"`
+	Required    bool                                `json:"required"`
+}
+
+type NotificationPayloadField struct {
+	Key         string `json:"key"`
+	Type        string `json:"type"`
+	Description string `json:"description,omitempty"`
+}
+
+type NotificationEventType struct {
+	Key                  string                             `json:"key"`
+	DisplayName          string                             `json:"displayName"`
+	Description          string                             `json:"description"`
+	Category             string                             `json:"category"`
+	Filters              []NotificationEventTypeFilterField `json:"filters,omitempty"`
+	WebhookPayloadFormat []NotificationPayloadField         `json:"webhookPayloadFormat,omitempty"`
+}
+
+type NotificationEventTypesResponse struct {
+	EventTypes []NotificationEventType `json:"eventTypes"`
+	Total      int                     `json:"total"`
+}
+
+type NotificationEventAttempt struct {
+	ID           string          `json:"id"`
+	EventID      string          `json:"eventId"`
+	AttemptedAt  time.Time       `json:"attemptedAt"`
+	Success      bool            `json:"success"`
+	StatusCode   *int            `json:"statusCode,omitempty"`
+	DurationMs   *int            `json:"durationMs,omitempty"`
+	ErrorMessage *string         `json:"errorMessage,omitempty"`
+	ResponseBody *string         `json:"responseBody,omitempty"`
+	RequestBody  json.RawMessage `json:"requestBody,omitempty"`
+}
+
+type NotificationEvent struct {
+	ID                    string                     `json:"id"`
+	SubscriptionID        string                     `json:"subscriptionId"`
+	EventType             string                     `json:"eventType"`
+	EventData             json.RawMessage            `json:"eventData"`
+	PayloadType           string                     `json:"payloadType"`
+	Payload               json.RawMessage            `json:"payload"`
+	CreatedAt             time.Time                  `json:"createdAt"`
+	SentAt                *time.Time                 `json:"sentAt,omitempty"`
+	RetryCount            int                        `json:"retryCount"`
+	LastError             *string                    `json:"lastError,omitempty"`
+	Status                string                     `json:"status,omitempty"`
+	NextRetryAt           *time.Time                 `json:"nextRetryAt,omitempty"`
+	Attempts              []NotificationEventAttempt `json:"attempts,omitempty"`
+	CreatedByUserID       string                     `json:"createdByUserId,omitempty"`
+	SubscriptionDeletedAt *time.Time                 `json:"subscriptionDeletedAt,omitempty"`
+}
+
+type NotificationEventsResponse struct {
+	Events     []NotificationEvent `json:"events"`
+	TotalCount int                 `json:"totalCount"`
+}
+
+type NotificationSubscriptionEventsResponse struct {
+	Events []NotificationEvent `json:"events"`
+}
+
+type NotificationRetryResponse struct {
+	Success bool   `json:"success"`
+	Message string `json:"message,omitempty"`
+}
+
+type NotificationEmailResponse struct {
+	Success bool   `json:"success"`
+	Message string `json:"message,omitempty"`
+}
+
+type NotificationWebhookTestResponse struct {
+	Success    bool   `json:"success"`
+	StatusCode *int   `json:"statusCode,omitempty"`
+	DurationMs int64  `json:"durationMs"`
+	Error      string `json:"error,omitempty"`
+}


### PR DESCRIPTION
## Summary

- Add a top-level `notification` command for subscription, event, email, and webhook management
- Add vendor v3 client and types for all notification APIs
- Add CLI validation and client tests for the new notification flows

Shortcut story: https://app.shortcut.com/replicated/story/135446/cli-support-for-notification-management

Backend counterpart: [replicatedhq/vandoor#9650](https://github.com/replicatedhq/vandoor/pull/9650)

## Commands added

| Command | Description |
|---|---|
| `notification subscription ls` | List notification subscriptions |
| `notification subscription get ID` | Get a subscription by ID |
| `notification subscription create --file FILE` | Create a subscription from a JSON file |
| `notification subscription update ID --file FILE` | Update a subscription from a JSON file |
| `notification subscription rm ID` | Delete a subscription |
| `notification subscription events ID` | List delivery events for a subscription |
| `notification event ls` | List all notification delivery events |
| `notification event retry EVENT_ID` | Retry a failed notification event |
| `notification event-type ls` | List available event types (supports `-q` search and `--limit`) |
| `notification email resend-verification --email EMAIL` | Resend a verification email |
| `notification email verify --email EMAIL --code CODE` | Verify an email address |
| `notification webhook test --file FILE` | Send a test payload to a webhook URL |

## Test output

```
star@StarR-CK2R4J3VHV replicated % ./bin/testrep notification event-type ls --q customer
KEY                           DISPLAY NAME                        CATEGORY    DESCRIPTION
customer.created              Customer Created                    Customer    When a new customer is created
customer.updated              Customer Updated                    Customer    When a customer's details or license is updated
customer.archived             Customer Archived                   Customer    When a customer is archived
customer.unarchived           Customer Unarchived                 Customer    When a customer is restored from archived state
customer.license_expiring     Customer License Expiring           Customer    When a customer's license is approaching expiration
customer.pending_signup       Pending Self-Service Signup         Customer    When someone signs up for a trial via self-service
customer.ep_invite_sent       Enterprise Portal Invite Sent       Customer    When an Enterprise Portal invite is sent to a user
customer.ep_access_granted    Enterprise Portal Access Granted    Customer    When a customer first accesses the Enterprise Portal for a given license type
customer.ep_user_joined       Enterprise Portal User Joined       Customer    When a user joins an Enterprise Portal customer (invite acceptance, self-signup, or SAML JIT)
release.asset_downloaded      Release Asset Downloaded            Release     When a release asset (such as a Helm chart or .tgz bundle) is pulled by a customer


star@StarR-CK2R4J3VHV replicated % ./bin/testrep notification subscription ls
ID                                  NAME                                            TYPE       DESTINATION                                                                        ENABLED    VERIFIED
42c051231677dcb67d4c605b25881d79    release.build_failed                            email      star@replicated.com                                                                true       true
ba4619e7b11b6c8c3701e41d365e7083    3 event types                                   email      star@replicated.com                                                                true       true
b2d65d09f99fd128c23707e7f681553a    2 event types                                   webhook    https://hooks.slack.com/services/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    true       -
3645fa47f77687442016d7691b91216f    Customer Updated Notification Test (Marc W.)    email      marcw@replicated.com                                                               true       false
ad6d4cf4a41af4f60b5f0fa0e5f06e4d    14 event types                                  webhook    https://webhook.site/9d2888ba-81b8-495f-9a18-18c826387194                          false      -
41c200225ff89372491417fe0866c20c    customer.created                                email      grant@replicated.com                                                               true       true
ef4a53735a0b6c0da48e0b10307840dc    release.created                                 email      grant@replicated.com                                                               true       true

star@StarR-CK2R4J3VHV replicated %  ./bin/testrep notification subscription create --file /tmp/sub.json
ID                                  NAME                 TYPE     DESTINATION            ENABLED    VERIFIED
d2f144ee21db632798316779daf3c7bd    test subscription    email    star@replicated.com    true       true
```

<img width="1465" height="172" alt="Screenshot 2026-05-01 at 2 44 37 PM" src="https://github.com/user-attachments/assets/dcd262d8-5ad5-4f5c-91f9-e2e6e15d8606" />


Flow for verifying emails:
```
star@StarR-CK2R4J3VHV replicated % ./bin/testrep notification email resend-verification --email star+newnew@replicated.com
SUCCESS    MESSAGE
true       Verification email sent successfully

star@StarR-CK2R4J3VHV replicated % ./bin/testrep notification email verify --email star+newnew@replicated.com --code GOT25I
SUCCESS    MESSAGE
true       Email address verified successfully
```