### PR TITLE
escape json example in CLI docs to fit docs site

### DIFF
--- a/cli/cmd/policy_create.go
+++ b/cli/cmd/policy_create.go
@@ -24,6 +24,7 @@ func (r *runners) InitPolicyCreate(parent *cobra.Command) *cobra.Command {
 		Long: `Create a new RBAC policy from a JSON definition file.
 
 The definition file must be valid JSON in the following format:
+  ` + "```json" + `
   {
     "v1": {
       "name": "My Policy",
@@ -33,6 +34,7 @@ The definition file must be valid JSON in the following format:
       }
     }
   }
+  ` + "```" + `
 
 Vendors not on an enterprise plan cannot create policies.`,
 		Example: `  # Create a policy from a definition file


### PR DESCRIPTION
New content (ignore the \\ before the triple backticks)

```
% go run ./cli/main.go policy create --help
Create a new RBAC policy from a JSON definition file.

The definition file must be valid JSON in the following format:
  \```json
  {
    "v1": {
      "name": "My Policy",
      "resources": {
        "allowed": ["**/*"],
        "denied": []
      }
    }
  }
  \```

Vendors not on an enterprise plan cannot create policies.


Usage:
  replicated policy create [flags]

Example:
    # Create a policy from a definition file
    replicated policy create --name "My Policy" --definition policy.json

    # Create a policy with a description
    replicated policy create --name "My Policy" --description "Custom access policy" --definition policy.json

Flags:
      --definition string    Path to the JSON file containing the policy definition
      --description string   Description of the policy
  -h, --help                 help for create
      --name string          Name of the policy
  -o, --output string        The output format to use. One of: json|table (default "table")

Global Flags:
      --app string       The app slug or app id to use in all calls
      --debug            Enable debug output
      --profile string   The authentication profile to use for this command
      --token string     The API token to use to access your app in the Vendor API
```