### PR TITLE
fix(cli): send JSON struct for enterprise portal status update

### DIFF
--- a/cli/cmd/enterpriseportal_status_update.go
+++ b/cli/cmd/enterpriseportal_status_update.go
@@ -20,8 +20,7 @@ func (r *runners) InitEnterprisePortalStatusUpdateCmd(parent *cobra.Command) *co
 		Long: `Update the current status of the Enterprise Portal for the specified application.
 
 This command allows you to change the status of the Enterprise Portal associated
-with the current application. You can use this to activate, deactivate, or set
-any other valid status for the Enterprise Portal.
+with the current application. Valid statuses are: active, inactive, pending.
 
 If no application is specified, the command will use the default application
 set in your configuration.
@@ -44,7 +43,7 @@ replicated enterprise-portal status update --status active --output table`,
 		SilenceUsage: true,
 	}
 	parent.AddCommand(cmd)
-	cmd.Flags().StringVar(&opts.status, "status", "", "The status to set for the enterprise portal")
+	cmd.Flags().StringVar(&opts.status, "status", "", "The status to set for the enterprise portal (active|inactive|pending)")
 	cmd.Flags().StringVarP(&outputFormat, "output", "o", "table", "The output format to use. One of: json|table")
 
 	cmd.MarkFlagRequired("status")

--- a/pkg/kotsclient/enterprise-portal.go
+++ b/pkg/kotsclient/enterprise-portal.go
@@ -23,10 +23,18 @@ func (c *VendorV3Client) GetEnterprisePortalStatus(appID string) (string, error)
 	return response.Status, nil
 }
 
+type UpdateEnterprisePortalStatusRequest struct {
+	Status string `json:"status"`
+}
+
 func (c *VendorV3Client) UpdateEnterprisePortalStatus(appID string, status string) (string, error) {
 	var response = GetEnterprisePortalStatusResponse{}
 
-	err := c.DoJSON(context.TODO(), "PUT", fmt.Sprintf("/v3/app/%s/enterprise-portal/status", appID), http.StatusOK, status, &response)
+	req := UpdateEnterprisePortalStatusRequest{
+		Status: status,
+	}
+
+	err := c.DoJSON(context.TODO(), "PUT", fmt.Sprintf("/v3/app/%s/enterprise-portal/status", appID), http.StatusOK, req, &response)
 	if err != nil {
 		return "", errors.Wrap(err, "update enterprise portal status")
 	}

--- a/pkg/kotsclient/enterprise-portal_test.go
+++ b/pkg/kotsclient/enterprise-portal_test.go
@@ -1,0 +1,75 @@
+package kotsclient
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/replicatedhq/replicated/pkg/platformclient"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnterprisePortalClient(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "test-token", r.Header.Get("Authorization"))
+
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v3/app/test-app/enterprise-portal/status":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"status": "active",
+			})
+		case r.Method == http.MethodPut && r.URL.Path == "/v3/app/test-app/enterprise-portal/status":
+			var body UpdateEnterprisePortalStatusRequest
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+			require.Equal(t, "inactive", body.Status)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"status": "inactive",
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/v3/app/test-app/enterprise-portal/customer-user":
+			var body InviteEnterprisePortalRequest
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+			require.Equal(t, "cus-123", body.CustomerID)
+			require.Equal(t, "user@example.com", body.EmailAddress)
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"url": "https://enterprise.example.com/invite/abc123",
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/v3/app/test-app/enterprise-portal/customer-users":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"users": []map[string]interface{}{
+					{"email": "user1@example.com"},
+					{"email": "user2@example.com"},
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	api := platformclient.NewHTTPClient(server.URL, "test-token")
+	client := VendorV3Client{HTTPClient: *api}
+
+	// Test GetEnterprisePortalStatus
+	status, err := client.GetEnterprisePortalStatus("test-app")
+	require.NoError(t, err)
+	require.Equal(t, "active", status)
+
+	// Test UpdateEnterprisePortalStatus
+	updatedStatus, err := client.UpdateEnterprisePortalStatus("test-app", "inactive")
+	require.NoError(t, err)
+	require.Equal(t, "inactive", updatedStatus)
+
+	// Test SendEnterprisePortalInvite
+	inviteURL, err := client.SendEnterprisePortalInvite("test-app", "cus-123", "user@example.com")
+	require.NoError(t, err)
+	require.Equal(t, "https://enterprise.example.com/invite/abc123", inviteURL)
+
+	// Test ListEnterprisePortalUsers
+	users, err := client.ListEnterprisePortalUsers("test-app", false)
+	require.NoError(t, err)
+	require.Len(t, users, 2)
+	require.Equal(t, "user1@example.com", users[0].Email)
+	require.Equal(t, "user2@example.com", users[1].Email)
+}

--- a/pkg/kotsclient/enterprise-portal_test.go
+++ b/pkg/kotsclient/enterprise-portal_test.go
@@ -7,12 +7,13 @@ import (
 	"testing"
 
 	"github.com/replicatedhq/replicated/pkg/platformclient"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestEnterprisePortalClient(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "test-token", r.Header.Get("Authorization"))
+		assert.Equal(t, "test-token", r.Header.Get("Authorization"))
 
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/v3/app/test-app/enterprise-portal/status":
@@ -21,16 +22,16 @@ func TestEnterprisePortalClient(t *testing.T) {
 			})
 		case r.Method == http.MethodPut && r.URL.Path == "/v3/app/test-app/enterprise-portal/status":
 			var body UpdateEnterprisePortalStatusRequest
-			require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
-			require.Equal(t, "inactive", body.Status)
+			assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+			assert.Equal(t, "inactive", body.Status)
 			_ = json.NewEncoder(w).Encode(map[string]interface{}{
 				"status": "inactive",
 			})
 		case r.Method == http.MethodPost && r.URL.Path == "/v3/app/test-app/enterprise-portal/customer-user":
 			var body InviteEnterprisePortalRequest
-			require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
-			require.Equal(t, "cus-123", body.CustomerID)
-			require.Equal(t, "user@example.com", body.EmailAddress)
+			assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+			assert.Equal(t, "cus-123", body.CustomerID)
+			assert.Equal(t, "user@example.com", body.EmailAddress)
 			w.WriteHeader(http.StatusCreated)
 			_ = json.NewEncoder(w).Encode(map[string]interface{}{
 				"url": "https://enterprise.example.com/invite/abc123",


### PR DESCRIPTION
## Shortcut Story

[sc-136041](https://app.shortcut.com/replicated/story/136041/fix-replicated-cli-enterprise-portal-status-update-sends-bare-string-instead-of-json-struct-causing-400)

## Summary

Fixes the `replicated enterprise-portal status update` command so that it sends a proper JSON object (`{\"status\":\"...\"}`) instead of a bare JSON string, which was causing the API to return a 400 error.

Also updates the CLI help text to enumerate the valid statuses (`active`, `inactive`, `pending`) instead of the vague "any other valid status" wording.

## Changes

- Updated `UpdateEnterprisePortalStatus` in `pkg/kotsclient/enterprise-portal.go` to construct and send an `UpdateEnterprisePortalStatusRequest` struct.
- Added `UpdateEnterprisePortalStatusRequest` struct with a `status` JSON field.
- Added `pkg/kotsclient/enterprise-portal_test.go` with unit tests covering all enterprise portal client methods.
- Updated `--help` text and `--status` flag description in `cli/cmd/enterpriseportal_status_update.go` to list valid statuses.

## UAT

1. Run the new unit tests: `go test ./pkg/kotsclient/... -run TestEnterprisePortalClient -v`
2. Verify the CLI builds: `go build ./cli/...`
3. Verify the updated help text: `go run ./cli enterprise-portal status update --help`
4. (Optional) Run `replicated enterprise-portal status update --status inactive` against a valid app and confirm it succeeds without a 400 error.
