### PR TITLE
Support lookup by channel name or ID for channel delete command

### DIFF
--- a/cli/cmd/channel_rm.go
+++ b/cli/cmd/channel_rm.go
@@ -9,7 +9,7 @@ import (
 
 func (r *runners) InitChannelRemove(parent *cobra.Command) {
 	cmd := &cobra.Command{
-		Use:     "rm CHANNEL_ID",
+		Use:     "rm CHANNEL_ID_OR_NAME",
 		Aliases: []string{"delete"},
 		Short:   "Remove (archive) a channel",
 		Long:    "Remove (archive) a channel",
@@ -24,16 +24,21 @@ func (r *runners) channelRemove(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(args) != 1 {
-		return errors.New("channel ID is required")
+		return errors.New("channel name or ID is required")
 	}
-	chanID := args[0]
 
-	if err := r.api.ArchiveChannel(r.appID, r.appType, chanID); err != nil {
+	channelNameOrID := args[0]
+	channel, err := r.api.GetChannelByName(r.appID, r.appType, channelNameOrID)
+	if err != nil {
+		return err
+	}
+
+	if err := r.api.ArchiveChannel(r.appID, r.appType, channel.ID); err != nil {
 		return err
 	}
 
 	// ignore the error since operation was successful
-	fmt.Fprintf(r.w, "Channel %s successfully archived\n", chanID)
+	fmt.Fprintf(r.w, "Channel %s successfully archived\n", channelNameOrID)
 	r.w.Flush()
 
 	return nil


### PR DESCRIPTION
## Summary

Updates `replicated channel delete` (and its alias `rm`) to accept either a **channel name** or a **channel ID**, matching the behavior of other channel commands such as `inspect` and `release demote`.

## Problem

Previously, `replicated channel delete <name>` failed with `archive app channel: Not found.` because the command passed the raw argument directly to the archive API as an ID, with no name resolution.

## Solution

Uses the existing `GetChannelByName` helper (already used by `channel inspect`) to resolve the input to a channel before calling `ArchiveChannel`. This provides:

- Lookup by exact channel ID (fast path)
- Fallback to name matching against the app's channel list
- Built-in ambiguous-match and not-found error handling

## Changes

- `cli/cmd/channel_rm.go`:
  - Updated usage string: `rm CHANNEL_ID_OR_NAME`
  - Updated missing-arg error: `channel name or ID is required`
  - Added `GetChannelByName` resolution before `ArchiveChannel`