### PR TITLE
fix(cli): remove spurious 'release' from channel demote/un-demote examples

### DIFF
--- a/cli/cmd/channel_release_demote.go
+++ b/cli/cmd/channel_release_demote.go
@@ -13,7 +13,7 @@ func (r *runners) InitChannelReleaseDemote(parent *cobra.Command) {
 		Use:   "demote CHANNEL_ID_OR_NAME",
 		Short: "Demote a release from a channel",
 		Long:  "Demote a channel release from a channel using a channel sequence or release sequence.",
-  	Example: `  # Demote a release from a channel by channel sequence
+		Example: `  # Demote a release from a channel by channel sequence
   replicated channel demote Beta --channel-sequence 15
 
   # Demote a release from a channel by release sequence

--- a/cli/cmd/channel_release_demote.go
+++ b/cli/cmd/channel_release_demote.go
@@ -13,11 +13,11 @@ func (r *runners) InitChannelReleaseDemote(parent *cobra.Command) {
 		Use:   "demote CHANNEL_ID_OR_NAME",
 		Short: "Demote a release from a channel",
 		Long:  "Demote a channel release from a channel using a channel sequence or release sequence.",
-		Example: `  # Demote a release from a channel by channel sequence
-  replicated channel release demote Beta --channel-sequence 15
+  	Example: `  # Demote a release from a channel by channel sequence
+  replicated channel demote Beta --channel-sequence 15
 
   # Demote a release from a channel by release sequence
-  replicated channel release demote Beta --release-sequence 12`,
+  replicated channel demote Beta --release-sequence 12`,
 		Args: cobra.ExactArgs(1),
 	}
 

--- a/cli/cmd/channel_release_undemote.go
+++ b/cli/cmd/channel_release_undemote.go
@@ -13,7 +13,7 @@ func (r *runners) InitChannelReleaseUnDemote(parent *cobra.Command) {
 		Use:   "un-demote CHANNEL_ID_OR_NAME",
 		Short: "Un-demote a release from a channel",
 		Long:  "Un-demote a channel release from a channel using a channel sequence or release sequence.",
-  	Example: `  # Un-demote a release from a channel by channel sequence
+		Example: `  # Un-demote a release from a channel by channel sequence
   replicated channel un-demote Beta --channel-sequence 15
 
   # Un-demote a release from a channel by release sequence

--- a/cli/cmd/channel_release_undemote.go
+++ b/cli/cmd/channel_release_undemote.go
@@ -13,11 +13,11 @@ func (r *runners) InitChannelReleaseUnDemote(parent *cobra.Command) {
 		Use:   "un-demote CHANNEL_ID_OR_NAME",
 		Short: "Un-demote a release from a channel",
 		Long:  "Un-demote a channel release from a channel using a channel sequence or release sequence.",
-		Example: `  # Un-demote a release from a channel by channel sequence
-  replicated channel release un-demote Beta --channel-sequence 15
+  	Example: `  # Un-demote a release from a channel by channel sequence
+  replicated channel un-demote Beta --channel-sequence 15
 
   # Un-demote a release from a channel by release sequence
-  replicated channel release un-demote Beta --release-sequence 12`,
+  replicated channel un-demote Beta --release-sequence 12`,
 		Args: cobra.ExactArgs(1),
 	}
 


### PR DESCRIPTION
Fixes the auto-generated CLI docs examples for channel demote and un-demote commands.

The commands are registered directly under channel, so the correct syntax is:
- replicated channel demote ...
- replicated channel un-demote ...

The examples incorrectly included a non-existent 'release' subcommand.

fixes: https://github.com/replicatedhq/replicated-docs/issues/3973