### PR TITLE
get latest release should not include demoted

### DIFF
--- a/client/channel.go
+++ b/client/channel.go
@@ -230,7 +230,7 @@ func (c *Client) GetCurrentChannelRelease(appID string, appType string, channelI
 
 		// If the channel has releases data, find the current one
 		if len(kotsChannel.Releases) > 0 {
-			currentRelease := currentChannelRelease(kotsChannel.Releases)
+			currentRelease := currentChannelRelease(kotsChannel.Releases, kotsChannel.ChannelSequence)
 			if currentRelease != nil {
 				proxyDomain := currentRelease.ProxyRegistryDomain
 				if proxyDomain == "" && kotsChannel.CustomHostNameOverrides.Proxy.Hostname != "" {
@@ -265,7 +265,7 @@ func (c *Client) GetCurrentChannelRelease(appID string, appType string, channelI
 			return nil, "", errors.New("no releases found in channel")
 		}
 
-		currentRelease := currentChannelReleasePtrs(releases)
+		currentRelease := currentChannelReleasePtrs(releases, kotsChannel.ChannelSequence)
 		if currentRelease == nil {
 			return nil, "", errors.New("no active releases found in channel")
 		}
@@ -294,7 +294,17 @@ func (c *Client) GetCurrentChannelRelease(appID string, appType string, channelI
 	return nil, "", errors.Errorf("unknown app type %q", appType)
 }
 
-func currentChannelRelease(releases []types.ChannelRelease) *types.ChannelRelease {
+// currentChannelRelease returns the release matching channelSequence (the server's
+// authoritative current sequence). Falls back to the highest non-demoted sequence
+// when channelSequence is 0 (not returned by the API).
+func currentChannelRelease(releases []types.ChannelRelease, channelSequence int32) *types.ChannelRelease {
+	if channelSequence > 0 {
+		for i := range releases {
+			if releases[i].ChannelSequence == channelSequence {
+				return &releases[i]
+			}
+		}
+	}
 	var currentRelease *types.ChannelRelease
 	for i := range releases {
 		if releases[i].IsDemoted {
@@ -307,7 +317,14 @@ func currentChannelRelease(releases []types.ChannelRelease) *types.ChannelReleas
 	return currentRelease
 }
 
-func currentChannelReleasePtrs(releases []*types.ChannelRelease) *types.ChannelRelease {
+func currentChannelReleasePtrs(releases []*types.ChannelRelease, channelSequence int32) *types.ChannelRelease {
+	if channelSequence > 0 {
+		for _, release := range releases {
+			if release != nil && release.ChannelSequence == channelSequence {
+				return release
+			}
+		}
+	}
 	var currentRelease *types.ChannelRelease
 	for _, release := range releases {
 		if release == nil || release.IsDemoted {

--- a/client/channel.go
+++ b/client/channel.go
@@ -230,12 +230,7 @@ func (c *Client) GetCurrentChannelRelease(appID string, appType string, channelI
 
 		// If the channel has releases data, find the current one
 		if len(kotsChannel.Releases) > 0 {
-			var currentRelease *types.ChannelRelease
-			for _, release := range kotsChannel.Releases {
-				if currentRelease == nil || release.ChannelSequence > currentRelease.ChannelSequence {
-					currentRelease = &release
-				}
-			}
+			currentRelease := currentChannelRelease(kotsChannel.Releases)
 			if currentRelease != nil {
 				proxyDomain := currentRelease.ProxyRegistryDomain
 				if proxyDomain == "" && kotsChannel.CustomHostNameOverrides.Proxy.Hostname != "" {
@@ -257,6 +252,7 @@ func (c *Client) GetCurrentChannelRelease(appID string, appType string, channelI
 				}
 				return currentRelease, proxyDomain, nil
 			}
+			return nil, "", errors.New("no active releases found in channel")
 		}
 
 		// Fallback to the existing approach if releases aren't included
@@ -269,11 +265,9 @@ func (c *Client) GetCurrentChannelRelease(appID string, appType string, channelI
 			return nil, "", errors.New("no releases found in channel")
 		}
 
-		var currentRelease *types.ChannelRelease
-		for _, release := range releases {
-			if currentRelease == nil || release.ChannelSequence > currentRelease.ChannelSequence {
-				currentRelease = release
-			}
+		currentRelease := currentChannelReleasePtrs(releases)
+		if currentRelease == nil {
+			return nil, "", errors.New("no active releases found in channel")
 		}
 
 		proxyDomain := currentRelease.ProxyRegistryDomain
@@ -298,6 +292,32 @@ func (c *Client) GetCurrentChannelRelease(appID string, appType string, channelI
 		return currentRelease, proxyDomain, nil
 	}
 	return nil, "", errors.Errorf("unknown app type %q", appType)
+}
+
+func currentChannelRelease(releases []types.ChannelRelease) *types.ChannelRelease {
+	var currentRelease *types.ChannelRelease
+	for i := range releases {
+		if releases[i].IsDemoted {
+			continue
+		}
+		if currentRelease == nil || releases[i].ChannelSequence > currentRelease.ChannelSequence {
+			currentRelease = &releases[i]
+		}
+	}
+	return currentRelease
+}
+
+func currentChannelReleasePtrs(releases []*types.ChannelRelease) *types.ChannelRelease {
+	var currentRelease *types.ChannelRelease
+	for _, release := range releases {
+		if release == nil || release.IsDemoted {
+			continue
+		}
+		if currentRelease == nil || release.ChannelSequence > currentRelease.ChannelSequence {
+			currentRelease = release
+		}
+	}
+	return currentRelease
 }
 
 // GetDefaultProxyHostname gets the default proxy hostname from the app's custom hostnames

--- a/client/channel_test.go
+++ b/client/channel_test.go
@@ -7,13 +7,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestCurrentChannelReleaseUsesChannelSequence(t *testing.T) {
+	releases := []types.ChannelRelease{
+		{ChannelSequence: 1},
+		{ChannelSequence: 2},
+		{ChannelSequence: 3, IsDemoted: true},
+	}
+
+	currentRelease := currentChannelRelease(releases, 2)
+
+	require.NotNil(t, currentRelease)
+	require.EqualValues(t, 2, currentRelease.ChannelSequence)
+}
+
 func TestCurrentChannelReleaseSkipsDemotedReleases(t *testing.T) {
 	releases := []types.ChannelRelease{
 		{ChannelSequence: 1},
 		{ChannelSequence: 2, IsDemoted: true},
 	}
 
-	currentRelease := currentChannelRelease(releases)
+	currentRelease := currentChannelRelease(releases, 0)
 
 	require.NotNil(t, currentRelease)
 	require.EqualValues(t, 1, currentRelease.ChannelSequence)
@@ -25,9 +38,22 @@ func TestCurrentChannelReleaseReturnsNilWhenAllReleasesAreDemoted(t *testing.T) 
 		{ChannelSequence: 2, IsDemoted: true},
 	}
 
-	currentRelease := currentChannelRelease(releases)
+	currentRelease := currentChannelRelease(releases, 0)
 
 	require.Nil(t, currentRelease)
+}
+
+func TestCurrentChannelReleasePtrsUsesChannelSequence(t *testing.T) {
+	releases := []*types.ChannelRelease{
+		{ChannelSequence: 1},
+		{ChannelSequence: 2},
+		{ChannelSequence: 3, IsDemoted: true},
+	}
+
+	currentRelease := currentChannelReleasePtrs(releases, 2)
+
+	require.NotNil(t, currentRelease)
+	require.EqualValues(t, 2, currentRelease.ChannelSequence)
 }
 
 func TestCurrentChannelReleasePtrsSkipsDemotedReleases(t *testing.T) {
@@ -36,7 +62,7 @@ func TestCurrentChannelReleasePtrsSkipsDemotedReleases(t *testing.T) {
 		{ChannelSequence: 2, IsDemoted: true},
 	}
 
-	currentRelease := currentChannelReleasePtrs(releases)
+	currentRelease := currentChannelReleasePtrs(releases, 0)
 
 	require.NotNil(t, currentRelease)
 	require.EqualValues(t, 1, currentRelease.ChannelSequence)
@@ -48,7 +74,7 @@ func TestCurrentChannelReleasePtrsReturnsNilWhenAllReleasesAreDemoted(t *testing
 		{ChannelSequence: 2, IsDemoted: true},
 	}
 
-	currentRelease := currentChannelReleasePtrs(releases)
+	currentRelease := currentChannelReleasePtrs(releases, 0)
 
 	require.Nil(t, currentRelease)
 }

--- a/client/channel_test.go
+++ b/client/channel_test.go
@@ -1,0 +1,54 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/replicatedhq/replicated/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCurrentChannelReleaseSkipsDemotedReleases(t *testing.T) {
+	releases := []types.ChannelRelease{
+		{ChannelSequence: 1},
+		{ChannelSequence: 2, IsDemoted: true},
+	}
+
+	currentRelease := currentChannelRelease(releases)
+
+	require.NotNil(t, currentRelease)
+	require.EqualValues(t, 1, currentRelease.ChannelSequence)
+}
+
+func TestCurrentChannelReleaseReturnsNilWhenAllReleasesAreDemoted(t *testing.T) {
+	releases := []types.ChannelRelease{
+		{ChannelSequence: 1, IsDemoted: true},
+		{ChannelSequence: 2, IsDemoted: true},
+	}
+
+	currentRelease := currentChannelRelease(releases)
+
+	require.Nil(t, currentRelease)
+}
+
+func TestCurrentChannelReleasePtrsSkipsDemotedReleases(t *testing.T) {
+	releases := []*types.ChannelRelease{
+		{ChannelSequence: 1},
+		{ChannelSequence: 2, IsDemoted: true},
+	}
+
+	currentRelease := currentChannelReleasePtrs(releases)
+
+	require.NotNil(t, currentRelease)
+	require.EqualValues(t, 1, currentRelease.ChannelSequence)
+}
+
+func TestCurrentChannelReleasePtrsReturnsNilWhenAllReleasesAreDemoted(t *testing.T) {
+	releases := []*types.ChannelRelease{
+		{ChannelSequence: 1, IsDemoted: true},
+		{ChannelSequence: 2, IsDemoted: true},
+	}
+
+	currentRelease := currentChannelReleasePtrs(releases)
+
+	require.Nil(t, currentRelease)
+}


### PR DESCRIPTION
problem:  GetCurrentChannelRelease defines current as the release with the highest channel sequence in both the embedded-release and fallback paths. ChannelRelease explicitly carries demotion state, but neither path excludes IsDemoted releases. If the latest promoted release was demoted, commands that ask for the current channel release can operate on the demoted release instead of the active one, returning stale or intentionally removed release data such as image lists and proxy metadata.

solution:
When selecting the current release, skip releases with IsDemoted set. If all releases are demoted, return a clear no active release error. Keep the same filtering in both the kotsChannel.Releases path and the ListChannelReleases fallback path.
