### PR TITLE
properly handle app type in api

### DIFF
--- a/client/app.go
+++ b/client/app.go
@@ -3,6 +3,9 @@ package client
 import (
 	"context"
 
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/replicated/pkg/kotsclient"
+	"github.com/replicatedhq/replicated/pkg/platformclient"
 	"github.com/replicatedhq/replicated/pkg/types"
 )
 
@@ -49,13 +52,47 @@ func (c *Client) ListApps(excludeChannels bool) ([]types.AppAndChannels, error) 
 }
 
 func (c *Client) GetApp(appID string) (interface{}, error) {
-	return nil, nil
+	app, _, err := c.GetAppType(context.TODO(), appID, true)
+	if err != nil {
+		return nil, err
+	}
+	return app, nil
 }
 
 func (c *Client) CreateApp(appOptions interface{}) (interface{}, error) {
-	return nil, nil
+	switch opts := appOptions.(type) {
+	case string:
+		return c.KotsClient.CreateKOTSApp(context.TODO(), opts)
+	case kotsclient.CreateKOTSAppRequest:
+		return c.KotsClient.CreateKOTSApp(context.TODO(), opts.Name)
+	case *kotsclient.CreateKOTSAppRequest:
+		if opts == nil {
+			return nil, errors.New("create app options cannot be nil")
+		}
+		return c.KotsClient.CreateKOTSApp(context.TODO(), opts.Name)
+	case platformclient.AppOptions:
+		return c.PlatformClient.CreateApp(&opts)
+	case *platformclient.AppOptions:
+		if opts == nil {
+			return nil, errors.New("create app options cannot be nil")
+		}
+		return c.PlatformClient.CreateApp(opts)
+	default:
+		return nil, errors.Errorf("unsupported app options type %T", appOptions)
+	}
 }
 
 func (c *Client) DeleteApp(appID string) error {
-	return nil
+	app, appType, err := c.GetAppType(context.TODO(), appID, true)
+	if err != nil {
+		return err
+	}
+
+	if appType == "platform" {
+		return c.PlatformClient.DeleteApp(app.ID)
+	} else if appType == "kots" {
+		return c.KotsClient.DeleteKOTSApp(context.TODO(), app.ID)
+	}
+
+	return errors.Errorf("unknown app type %q", appType)
 }

--- a/client/app.go
+++ b/client/app.go
@@ -61,8 +61,6 @@ func (c *Client) GetApp(appID string) (interface{}, error) {
 
 func (c *Client) CreateApp(appOptions interface{}) (interface{}, error) {
 	switch opts := appOptions.(type) {
-	case string:
-		return c.KotsClient.CreateKOTSApp(context.TODO(), opts)
 	case kotsclient.CreateKOTSAppRequest:
 		return c.KotsClient.CreateKOTSApp(context.TODO(), opts.Name)
 	case *kotsclient.CreateKOTSAppRequest:

--- a/client/app_test.go
+++ b/client/app_test.go
@@ -1,0 +1,47 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/replicatedhq/replicated/pkg/kotsclient"
+	"github.com/replicatedhq/replicated/pkg/platformclient"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestClient(origin string) Client {
+	platformHTTPClient := platformclient.NewHTTPClient(origin, "fake-api-key")
+	return Client{
+		PlatformClient: platformHTTPClient,
+		KotsClient:     &kotsclient.VendorV3Client{HTTPClient: *platformHTTPClient},
+	}
+}
+
+func TestClientGetAppReturnsBackendError(t *testing.T) {
+	c := newTestClient("http://%")
+
+	app, err := c.GetApp("app-id")
+	require.Nil(t, app)
+	require.Error(t, err)
+}
+
+func TestClientCreateAppRejectsUnsupportedOptions(t *testing.T) {
+	c := newTestClient("http://127.0.0.1")
+
+	app, err := c.CreateApp(struct{}{})
+	require.Nil(t, app)
+	require.ErrorContains(t, err, "unsupported app options type")
+}
+
+func TestClientCreateAppRejectsNilOptions(t *testing.T) {
+	c := newTestClient("http://127.0.0.1")
+
+	app, err := c.CreateApp((*platformclient.AppOptions)(nil))
+	require.Nil(t, app)
+	require.ErrorContains(t, err, "create app options cannot be nil")
+}
+
+func TestClientDeleteAppReturnsLookupError(t *testing.T) {
+	c := newTestClient("http://%")
+
+	require.Error(t, c.DeleteApp("app-id"))
+}


### PR DESCRIPTION
problem: The exported aggregate client exposes GetApp, CreateApp, and DeleteApp as successful operations, but they either return a nil result with nil error or a nil error without calling either backend. The context platform client has real CreateApp/DeleteApp implementations, so callers using the higher-level client can believe an app was fetched, created, or deleted when no API request happened. DeleteApp is especially risky because it silently reports success for a no-op.

solution: Implement these methods by delegating to the appropriate platform/KOTS client based on app type or input options. If this abstraction cannot support an operation, return a non-nil unsupported-operation error rather than nil success.