### PR TITLE
fix: use separate HOMEBREW_TAP_GITHUB_TOKEN for tap push

### DIFF
--- a/.depot/workflows/release.yml
+++ b/.depot/workflows/release.yml
@@ -42,9 +42,15 @@ jobs:
           cache-dependency-path: ./go.sum
       - name: Install goreleaser
         run: go install github.com/goreleaser/goreleaser/v2@v2.14.3
+      - name: Check token
+        env:
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+        run: |
+          echo "HOMEBREW_TAP_GITHUB_TOKEN length: ${#HOMEBREW_TAP_GITHUB_TOKEN}"
+          echo "HOMEBREW_TAP_GITHUB_TOKEN first 4: ${HOMEBREW_TAP_GITHUB_TOKEN:0:4}"
       - name: Run goreleaser
         env:
-          GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
         run: goreleaser release --clean
 
   docker-publish:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,6 +12,7 @@ brews:
     name: homebrew-replicated
     owner: replicatedhq
     branch: main
+    token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
   install: bin.install "replicated"
   directory: HomebrewFormula
 universal_binaries:


### PR DESCRIPTION
GITHUB_TOKEN is auto-injected by the runner for the release itself. HOMEBREW_TAP_GITHUB_TOKEN is passed separately so goreleaser can use it specifically for pushing to the homebrew-replicated tap repo.