### PR TITLE
add help text and validation customer create

### DIFF
--- a/cli/cmd/customer_create.go
+++ b/cli/cmd/customer_create.go
@@ -79,7 +79,7 @@ replicated customer create --app myapp --name "Full Options Inc" --custom-id "FU
 	cmd.Flags().BoolVar(&opts.IsGitopsSupported, "gitops", false, "If set, the license will allow the GitOps usage.")
 	cmd.Flags().BoolVar(&opts.IsSnapshotSupported, "snapshot", false, "If set, the license will allow Snapshots.")
 	cmd.Flags().BoolVar(&opts.IsKotsInstallEnabled, "kots-install", true, "If set, the license will allow KOTS install. Otherwise license will allow Helm CLI installs only.")
-	cmd.Flags().BoolVar(&opts.IsHelmInstallEnabled, "helm-install", false, "If set, the license will allow Helm installs.")
+	cmd.Flags().BoolVar(&opts.IsHelmInstallEnabled, "helm-install", false, "If set, the license will allow Helm installs. Requires --email.")
 	cmd.Flags().BoolVar(&opts.IsKurlInstallEnabled, "kurl-install", false, "If set, the license will allow kURL installs.")
 	cmd.Flags().BoolVar(&opts.IsEmbeddedClusterDownloadEnabled, "embedded-cluster-download", false, "If set, the license will allow Embedded Cluster downloads.")
 	cmd.Flags().BoolVar(&opts.IsEmbeddedClusterMultinodeEnabled, "embedded-cluster-multinode", true, "If set, users can add nodes to Embedded Cluster instances.")


### PR DESCRIPTION
* Updates the help text for replicated customer create to be clear that --email is required if --helm-install is set

The error if someone missed --email is clear from the API response, no need to add extra validation here:

```
replicated customer create --app xav-pottery-shop --name "testy test test" --channel Stable --type trial --helm-install 
ERROR: 400
METHOD: POST
ENDPOINT: https://api.replicated.com/vendor/v3/customer
email is required for customers with helm install enabled
Error: create customer: create customer: POST https://api.replicated.com/vendor/v3/customer 400: email is required for customers with helm install enabled
```