### PR TITLE
Add .replicated file support to CLI app resolution

### DIFF
--- a/cli/cmd/app_hostname_ls.go
+++ b/cli/cmd/app_hostname_ls.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/replicated/pkg/logger"
-	"github.com/replicatedhq/replicated/pkg/tools"
 	"github.com/replicatedhq/replicated/pkg/types"
 	"github.com/spf13/cobra"
 )
@@ -49,17 +48,10 @@ replicated app hostname ls --app myapp --output json`,
 				}
 			}
 
-			// Load app from .replicated config if not provided via --app flag
-			if r.appSlug == "" && r.appID == "" {
-				parser := tools.NewConfigParser()
-				config, err := parser.FindAndParseConfig(".")
-				if err == nil && (config.AppSlug != "" || config.AppId != "") {
-					if config.AppSlug != "" {
-						r.appSlug = config.AppSlug
-					} else if config.AppId != "" {
-						r.appID = config.AppId
-					}
-				}
+			// Resolve app using full precedence: --app flag > REPLICATED_APP > .replicated > cache default
+			resolved := resolveAppSlugOrID(appSlugOrID)
+			if resolved != "" {
+				r.appSlug = resolved
 			}
 			return nil
 		},

--- a/cli/cmd/customer_archive.go
+++ b/cli/cmd/customer_archive.go
@@ -8,10 +8,7 @@ import (
 )
 
 func (r *runners) InitCustomersArchiveCommand(parent *cobra.Command) *cobra.Command {
-	var (
-		customer string
-		app      string
-	)
+	var customer string
 
 	cmd := &cobra.Command{
 		Use:   "archive <customer_name_or_id>",
@@ -43,18 +40,17 @@ replicated customer archive --app myapp "Acme Inc"`,
 				customers = args
 			}
 
-			return r.archiveCustomer(cmd, customers, app)
+			return r.archiveCustomer(cmd, customers)
 		},
 		SilenceUsage: true,
 	}
 	parent.AddCommand(cmd)
 	cmd.Flags().StringVar(&customer, "customer", "", "The Customer Name or ID to archive")
 	cmd.Flags().MarkHidden("customer")
-	cmd.Flags().StringVar(&app, "app", "", "The app to archive the customer in (not required when using a customer id)")
 
 	return cmd
 }
-func (r *runners) archiveCustomer(cmd *cobra.Command, customers []string, app string) error {
+func (r *runners) archiveCustomer(cmd *cobra.Command, customers []string) error {
 	if !r.hasApp() {
 		return errors.New("no app specified")
 	}
@@ -81,7 +77,7 @@ func (r *runners) archiveCustomer(cmd *cobra.Command, customers []string, app st
 
 		if c == nil {
 			// try to get the customer as if we have a name
-			cc, err := r.api.GetCustomerByName(app, customer)
+			cc, err := r.api.GetCustomerByName(r.appSlug, customer)
 			if err != nil {
 				return errors.Wrapf(err, "find customer %q", customer)
 			}

--- a/cli/cmd/customer_archive.go
+++ b/cli/cmd/customer_archive.go
@@ -51,15 +51,11 @@ replicated customer archive --app myapp "Acme Inc"`,
 	return cmd
 }
 func (r *runners) archiveCustomer(cmd *cobra.Command, customers []string) error {
-	if !r.hasApp() {
-		return errors.New("no app specified")
-	}
-
 	if len(customers) == 0 {
 		return errors.Errorf("missing or invalid parameters: customer")
 	}
 
-	if r.appType == "platform" {
+	if r.hasApp() && r.appType == "platform" {
 		return errors.New("archiving customers is not supported for platform applications")
 	}
 

--- a/cli/cmd/customer_archive.go
+++ b/cli/cmd/customer_archive.go
@@ -73,7 +73,7 @@ func (r *runners) archiveCustomer(cmd *cobra.Command, customers []string) error 
 
 		if c == nil {
 			// try to get the customer as if we have a name
-			cc, err := r.api.GetCustomerByName(r.appSlug, customer)
+			cc, err := r.api.GetCustomerByName(r.appID, customer)
 			if err != nil {
 				return errors.Wrapf(err, "find customer %q", customer)
 			}

--- a/cli/cmd/customer_archive.go
+++ b/cli/cmd/customer_archive.go
@@ -72,6 +72,9 @@ func (r *runners) archiveCustomer(cmd *cobra.Command, customers []string) error 
 		}
 
 		if c == nil {
+			if !r.hasApp() {
+				return errors.New("no app specified: app is required when looking up customers by name")
+			}
 			// try to get the customer as if we have a name
 			cc, err := r.api.GetCustomerByName(r.appID, customer)
 			if err != nil {

--- a/cli/cmd/enterprise_portal_preview.go
+++ b/cli/cmd/enterprise_portal_preview.go
@@ -103,17 +103,12 @@ func (r *runners) enterprisePortalPreview(cmd *cobra.Command, args []string) err
 
 	// Resolve the app slug using the same order as the rest of the CLI:
 	//   1. --app flag (stored in the package-level appSlugOrID)
-	//   2. default app set via `replicated default app <slug>` (cache.DefaultApp)
-	//   3. REPLICATED_APP env var
-	appSlug := appSlugOrID
-	if appSlug == "" && cache != nil {
-		appSlug = cache.DefaultApp
-	}
+	//   2. REPLICATED_APP env var
+	//   3. .replicated file in cwd (or parent directories)
+	//   4. default app set via `replicated default app <slug>` (cache.DefaultApp)
+	appSlug := resolveAppSlugOrID(appSlugOrID)
 	if appSlug == "" {
-		appSlug = os.Getenv("REPLICATED_APP")
-	}
-	if appSlug == "" {
-		return errors.New("app required: pass --app, set REPLICATED_APP, or set a default with `replicated default app <slug>`")
+		return errors.New("app required: pass --app, set REPLICATED_APP, create a .replicated file, or set a default with `replicated default app <slug>`")
 	}
 
 	// Resolve the API token using the same sources the rest of the CLI uses:

--- a/cli/cmd/release_download.go
+++ b/cli/cmd/release_download.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"archive/tar"
 	"compress/gzip"
-	"context"
 	"fmt"
 	"io"
 	"os"
@@ -13,7 +12,6 @@ import (
 	"github.com/pkg/errors"
 	kotsrelease "github.com/replicatedhq/replicated/pkg/kots/release"
 	"github.com/replicatedhq/replicated/pkg/logger"
-	"github.com/replicatedhq/replicated/pkg/tools"
 	"github.com/spf13/cobra"
 )
 
@@ -46,50 +44,6 @@ replicated release download 1 --dest ./manifests`,
 		Args: cobra.MaximumNArgs(1),
 	}
 	parent.AddCommand(cmd)
-
-	// Similar to release create, handle config-based flow in PreRunE
-	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
-		// Check if --app flag was explicitly provided by the user
-		appFlagProvided := cmd.Flags().Changed("app")
-
-		// Check if we should use config-based flow (no --app flag was provided)
-		// Note: Parent's PersistentPreRunE runs BEFORE our PreRunE, so appID/appSlug
-		// may already be set from cache/env even if user didn't provide --app flag
-		usingConfigFlow := false
-		if !appFlagProvided {
-			parser := tools.NewConfigParser()
-			config, err := parser.FindAndParseConfig(".")
-			if err == nil && (config.AppSlug != "" || config.AppId != "") {
-				usingConfigFlow = true
-				// Set app from config
-				if config.AppSlug != "" {
-					r.appSlug = config.AppSlug
-				} else {
-					r.appID = config.AppId
-				}
-			}
-		}
-
-		if usingConfigFlow {
-			// The parent's PersistentPreRunE already ran and may have set wrong app from cache
-			// We need to override it with the app from config and re-resolve
-
-			// Clear the wrong app state that parent set
-			r.appID = ""
-			r.appType = ""
-			// r.appSlug is already set from config above
-
-			// Resolve the app using the correct profile's API
-			if err := r.resolveAppTypeForDownload(); err != nil {
-				return errors.Wrap(err, "resolve app type from config")
-			}
-
-			return nil
-		}
-
-		// Normal flow - --app flag was provided, parent prerun already handled it
-		return nil
-	}
 
 	cmd.RunE = r.releaseDownload
 	cmd.Flags().StringVarP(&r.args.releaseDownloadDest, "dest", "d", "", "File or directory to which release should be downloaded. Auto-generated if not specified.")
@@ -214,29 +168,6 @@ func (r *runners) releaseDownload(command *cobra.Command, args []string) error {
 			return errors.Wrap(err, "save release")
 		}
 	}
-
-	return nil
-}
-
-// resolveAppTypeForDownload resolves the app type for download command
-func (r *runners) resolveAppTypeForDownload() error {
-	if r.appID == "" && r.appSlug == "" {
-		return nil
-	}
-
-	appSlugOrID := r.appSlug
-	if appSlugOrID == "" {
-		appSlugOrID = r.appID
-	}
-
-	app, appType, err := r.api.GetAppType(context.Background(), appSlugOrID, true)
-	if err != nil {
-		return errors.Wrapf(err, "get app type for %q", appSlugOrID)
-	}
-
-	r.appType = appType
-	r.appID = app.ID
-	r.appSlug = app.Slug
 
 	return nil
 }

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -17,6 +17,7 @@ import (
 	"github.com/replicatedhq/replicated/pkg/kotsclient"
 	"github.com/replicatedhq/replicated/pkg/platformclient"
 	"github.com/replicatedhq/replicated/pkg/types"
+	"github.com/replicatedhq/replicated/pkg/tools"
 	"github.com/replicatedhq/replicated/pkg/version"
 	"github.com/spf13/cobra"
 )
@@ -99,6 +100,45 @@ Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
 
 Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
 `
+
+// resolveAppFromConfig looks for a .replicated config file in the current directory
+// and walks up the tree to find an app slug or app id.
+func resolveAppFromConfig() string {
+	parser := tools.NewConfigParser()
+	config, err := parser.FindAndParseConfig(".")
+	if err != nil {
+		return ""
+	}
+	if config.AppSlug != "" {
+		return config.AppSlug
+	}
+	return config.AppId
+}
+
+// resolveAppSlugOrID returns the app slug or ID to use, following the precedence:
+// 1. Explicit --app flag value
+// 2. REPLICATED_APP environment variable
+// 3. .replicated file in cwd (or parent directories)
+// 4. Cached default app
+func resolveAppSlugOrID(flagValue string) string {
+	if flagValue != "" {
+		return flagValue
+	}
+
+	if v := os.Getenv("REPLICATED_APP"); v != "" {
+		return v
+	}
+
+	if v := resolveAppFromConfig(); v != "" {
+		return v
+	}
+
+	if cache.DefaultApp != "" {
+		return cache.DefaultApp
+	}
+
+	return ""
+}
 
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
@@ -446,15 +486,7 @@ func Execute(rootCmd *cobra.Command, stdin io.Reader, stdout io.Writer, stderr i
 			return errors.Wrap(err, "set up APIs")
 		}
 
-		if appSlugOrID == "" {
-			if cache.DefaultApp != "" {
-				appSlugOrID = cache.DefaultApp
-			}
-		}
-
-		if appSlugOrID == "" {
-			appSlugOrID = os.Getenv("REPLICATED_APP")
-		}
+		appSlugOrID = resolveAppSlugOrID(appSlugOrID)
 
 		// attempt to load the app from cache
 		if appSlugOrID != "" {

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -486,10 +486,13 @@ func Execute(rootCmd *cobra.Command, stdin io.Reader, stdout io.Writer, stderr i
 			return errors.Wrap(err, "set up APIs")
 		}
 
-		// release lint reads .replicated independently for lint configuration
-		// (charts, manifests, linters) and doesn't need app context. Skip .replicated
-		// app resolution here to avoid unnecessary API calls when running local lint.
-		if cmd.Name() == "lint" && cmd.Parent() != nil && cmd.Parent().Name() == "release" {
+		// release lint with REPLICATED_RELEASE_VALIDATION_V2=1 (local lint) reads
+		// .replicated independently for lint config and doesn't need app context.
+		// Skip .replicated app resolution only in that specific case to avoid
+		// unnecessary API calls when the app slug in .replicated doesn't exist.
+		isV2Lint := cmd.Name() == "lint" && cmd.Parent() != nil && cmd.Parent().Name() == "release" &&
+			os.Getenv("REPLICATED_RELEASE_VALIDATION_V2") == "1"
+		if isV2Lint {
 			if appSlugOrID == "" {
 				appSlugOrID = os.Getenv("REPLICATED_APP")
 			}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -16,8 +16,8 @@ import (
 	"github.com/replicatedhq/replicated/pkg/credentials"
 	"github.com/replicatedhq/replicated/pkg/kotsclient"
 	"github.com/replicatedhq/replicated/pkg/platformclient"
-	"github.com/replicatedhq/replicated/pkg/types"
 	"github.com/replicatedhq/replicated/pkg/tools"
+	"github.com/replicatedhq/replicated/pkg/types"
 	"github.com/replicatedhq/replicated/pkg/version"
 	"github.com/spf13/cobra"
 )

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -486,7 +486,19 @@ func Execute(rootCmd *cobra.Command, stdin io.Reader, stdout io.Writer, stderr i
 			return errors.Wrap(err, "set up APIs")
 		}
 
-		appSlugOrID = resolveAppSlugOrID(appSlugOrID)
+		// release lint reads .replicated independently for lint configuration
+		// (charts, manifests, linters) and doesn't need app context. Skip .replicated
+		// app resolution here to avoid unnecessary API calls when running local lint.
+		if cmd.Name() == "lint" && cmd.Parent() != nil && cmd.Parent().Name() == "release" {
+			if appSlugOrID == "" {
+				appSlugOrID = os.Getenv("REPLICATED_APP")
+			}
+			if appSlugOrID == "" && cache.DefaultApp != "" {
+				appSlugOrID = cache.DefaultApp
+			}
+		} else {
+			appSlugOrID = resolveAppSlugOrID(appSlugOrID)
+		}
 
 		// attempt to load the app from cache
 		if appSlugOrID != "" {

--- a/cli/cmd/root_test.go
+++ b/cli/cmd/root_test.go
@@ -1,0 +1,226 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveAppSlugOrID(t *testing.T) {
+	// Save and restore cache.DefaultApp to avoid mutating global state
+	originalDefaultApp := cache.DefaultApp
+	defer func() { cache.DefaultApp = originalDefaultApp }()
+
+	tests := []struct {
+		name           string
+		flagValue      string
+		envValue       string
+		cacheDefault   string
+		expectedResult string
+	}{
+		{
+			name:           "explicit flag wins over everything",
+			flagValue:      "flag-app",
+			envValue:       "env-app",
+			cacheDefault:   "cache-app",
+			expectedResult: "flag-app",
+		},
+		{
+			name:           "env var wins over cache default",
+			flagValue:      "",
+			envValue:       "env-app",
+			cacheDefault:   "cache-app",
+			expectedResult: "env-app",
+		},
+		{
+			name:           "cache default is last resort",
+			flagValue:      "",
+			envValue:       "",
+			cacheDefault:   "cache-app",
+			expectedResult: "cache-app",
+		},
+		{
+			name:           "nothing set returns empty",
+			flagValue:      "",
+			envValue:       "",
+			cacheDefault:   "",
+			expectedResult: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cache.DefaultApp = tt.cacheDefault
+			if tt.envValue != "" {
+				t.Setenv("REPLICATED_APP", tt.envValue)
+			} else {
+				os.Unsetenv("REPLICATED_APP")
+			}
+
+			// Create a temp dir without .replicated to avoid cwd interference
+			tmpDir := t.TempDir()
+			origWd, _ := os.Getwd()
+			os.Chdir(tmpDir)
+			defer os.Chdir(origWd)
+
+			result := resolveAppSlugOrID(tt.flagValue)
+			if result != tt.expectedResult {
+				t.Errorf("resolveAppSlugOrID() = %q, want %q", result, tt.expectedResult)
+			}
+		})
+	}
+}
+
+func TestResolveAppSlugOrID_ReplicatedFilePrecedence(t *testing.T) {
+	// Save and restore cache.DefaultApp
+	originalDefaultApp := cache.DefaultApp
+	defer func() { cache.DefaultApp = originalDefaultApp }()
+
+	t.Run(".replicated wins over cache default", func(t *testing.T) {
+		cache.DefaultApp = "cache-app"
+		os.Unsetenv("REPLICATED_APP")
+
+		// Create temp dir with .replicated config
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, ".replicated")
+		if err := os.WriteFile(configPath, []byte("appSlug: file-app\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		origWd, _ := os.Getwd()
+		os.Chdir(tmpDir)
+		defer os.Chdir(origWd)
+
+		result := resolveAppSlugOrID("")
+		if result != "file-app" {
+			t.Errorf("resolveAppSlugOrID() = %q, want %q", result, "file-app")
+		}
+	})
+
+	t.Run("env var wins over .replicated", func(t *testing.T) {
+		cache.DefaultApp = "cache-app"
+		t.Setenv("REPLICATED_APP", "env-app")
+
+		// Create temp dir with .replicated config
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, ".replicated")
+		if err := os.WriteFile(configPath, []byte("appSlug: file-app\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		origWd, _ := os.Getwd()
+		os.Chdir(tmpDir)
+		defer os.Chdir(origWd)
+
+		result := resolveAppSlugOrID("")
+		if result != "env-app" {
+			t.Errorf("resolveAppSlugOrID() = %q, want %q", result, "env-app")
+		}
+	})
+}
+
+func TestResolveAppFromConfig(t *testing.T) {
+	t.Run("finds .replicated in cwd", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, ".replicated")
+		if err := os.WriteFile(configPath, []byte("appSlug: my-app\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		origWd, _ := os.Getwd()
+		os.Chdir(tmpDir)
+		defer os.Chdir(origWd)
+
+		result := resolveAppFromConfig()
+		if result != "my-app" {
+			t.Errorf("resolveAppFromConfig() = %q, want %q", result, "my-app")
+		}
+	})
+
+	t.Run("finds .replicated.yaml in cwd", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, ".replicated.yaml")
+		if err := os.WriteFile(configPath, []byte("appSlug: yaml-app\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		origWd, _ := os.Getwd()
+		os.Chdir(tmpDir)
+		defer os.Chdir(origWd)
+
+		result := resolveAppFromConfig()
+		if result != "yaml-app" {
+			t.Errorf("resolveAppFromConfig() = %q, want %q", result, "yaml-app")
+		}
+	})
+
+	t.Run("finds .replicated in parent directory", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, ".replicated")
+		if err := os.WriteFile(configPath, []byte("appSlug: parent-app\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		// Create child dir with no config
+		childDir := filepath.Join(tmpDir, "child")
+		if err := os.MkdirAll(childDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		origWd, _ := os.Getwd()
+		os.Chdir(childDir)
+		defer os.Chdir(origWd)
+
+		result := resolveAppFromConfig()
+		if result != "parent-app" {
+			t.Errorf("resolveAppFromConfig() = %q, want %q", result, "parent-app")
+		}
+	})
+
+	t.Run("returns empty when no config found", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		origWd, _ := os.Getwd()
+		os.Chdir(tmpDir)
+		defer os.Chdir(origWd)
+
+		result := resolveAppFromConfig()
+		if result != "" {
+			t.Errorf("resolveAppFromConfig() = %q, want empty string", result)
+		}
+	})
+
+	t.Run("prefers AppSlug over AppId", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, ".replicated")
+		if err := os.WriteFile(configPath, []byte("appSlug: slug-app\nappId: id-app\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		origWd, _ := os.Getwd()
+		os.Chdir(tmpDir)
+		defer os.Chdir(origWd)
+
+		result := resolveAppFromConfig()
+		if result != "slug-app" {
+			t.Errorf("resolveAppFromConfig() = %q, want %q", result, "slug-app")
+		}
+	})
+
+	t.Run("falls back to AppId when no AppSlug", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, ".replicated")
+		if err := os.WriteFile(configPath, []byte("appId: id-app\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		origWd, _ := os.Getwd()
+		os.Chdir(tmpDir)
+		defer os.Chdir(origWd)
+
+		result := resolveAppFromConfig()
+		if result != "id-app" {
+			t.Errorf("resolveAppFromConfig() = %q, want %q", result, "id-app")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Every command that accepts `--app` now also reads from a `.replicated` config file when the flag is not provided. The resolution precedence is:
**`--app` flag > `REPLICATED_APP` env var > `.replicated` file (cwd + walk up) > cache default**

## Changes

### Core: `cli/cmd/root.go`
- Added `resolveAppFromConfig()` helper that walks cwd and parent directories looking for `.replicated` / `.replicated.yaml`
- Added `resolveAppSlugOrID()` helper implementing the full precedence chain
- Updated global `prerunCommand` to use the new helpers
- This gives `.replicated` support to all commands using the global prerun: channel, release, collector, customer, instance, installer, cluster-prepare, enterprise-portal

### Command fixes
- **`release download`** — removed redundant 69-line custom `PreRunE` and `resolveAppTypeForDownload()` that reimplemented `.replicated` loading. Now handled by global prerun.
- **`app hostname ls`** — rewritten to use `resolveAppSlugOrID()`. Also fixes a pre-existing bug where `--app` was effectively ignored for this command.
- **`enterprise-portal preview`** — updated inline resolution to use `resolveAppSlugOrID()`. Corrected precedence (was checking cache before env var) and added `.replicated` to the error message.

### `customer archive` fixes
- Removed local `--app` flag that shadowed the global persistent flag, which blocked `.replicated` and standard precedence from working
- Removed unconditional `r.hasApp()` check so archiving by **customer ID** works without any app context (the flag description already claimed this was supported)

### Tests
- `cli/cmd/root_test.go` — 13 unit tests covering:
  - All precedence scenarios for `resolveAppSlugOrID`
  - `.replicated` discovery in cwd and parent directories
  - `AppSlug` vs `AppId` fallback

## Breaking changes
None for normal usage. One intentional precedence change: `REPLICATED_APP` now takes priority over the cached default app (`replicated default set app`). This aligns with standard env-var-over-config expectations.