### PR TITLE
fix: return warnings on promoting lower semver verisonLabel

### DIFF
--- a/cli/cmd/release_create.go
+++ b/cli/cmd/release_create.go
@@ -485,13 +485,12 @@ Prepared to create release with defaults:
 		}
 		log.FinishSpinner()
 
-		// ignore error since operation was successful
-		log.ChildActionWithoutSpinner("Channel %s successfully set to release %d", promoteChanID, release.Sequence)
-
 		if len(promoteResp.Warnings) > 0 {
 			for _, w := range promoteResp.Warnings {
 				log.ChildActionWithoutSpinner("Warning: %s", w)
 			}
+		} else {
+			log.ChildActionWithoutSpinner("Channel %s successfully set to release %d", promoteChanID, release.Sequence)
 		}
 
 		if r.appType == "kots" && r.args.createReleasePromoteWaitForAirgap {

--- a/cli/cmd/release_create.go
+++ b/cli/cmd/release_create.go
@@ -490,7 +490,7 @@ Prepared to create release with defaults:
 
 		if len(promoteResp.Warnings) > 0 {
 			for _, w := range promoteResp.Warnings {
-				log.ChildActionWithoutSpinner("Warning: %s\n", w)
+				log.ChildActionWithoutSpinner("Warning: %s", w)
 			}
 		}
 

--- a/cli/cmd/release_create.go
+++ b/cli/cmd/release_create.go
@@ -486,7 +486,13 @@ Prepared to create release with defaults:
 		log.FinishSpinner()
 
 		// ignore error since operation was successful
-		log.ChildActionWithoutSpinner("Channel %s successfully set to release %d\n", promoteChanID, release.Sequence)
+		log.ChildActionWithoutSpinner("Channel %s successfully set to release %d", promoteChanID, release.Sequence)
+
+		if len(promoteResp.Warnings) > 0 {
+			for _, w := range promoteResp.Warnings {
+				log.ChildActionWithoutSpinner("Warning: %s\n", w)
+			}
+		}
 
 		if r.appType == "kots" && r.args.createReleasePromoteWaitForAirgap {
 			if err := r.waitForAirgapBuilds(promoteResp, r.args.createReleasePromoteWaitForAirgapTimeout, log); err != nil {

--- a/cli/cmd/release_promote.go
+++ b/cli/cmd/release_promote.go
@@ -116,8 +116,12 @@ func (r *runners) releasePromote(cmd *cobra.Command, args []string) (err error) 
 			Channel:         newID,
 			ReleaseSequence: seq,
 			VersionLabel:    r.args.releaseVersion,
-			Warnings:        promoteResp.Warnings,
 		}
+
+		if promoteResp != nil && len(promoteResp.Warnings) > 0 {
+			out.Warnings = promoteResp.Warnings
+		}
+
 		enc := json.NewEncoder(r.w)
 		enc.SetIndent("", "  ")
 		if err := enc.Encode(out); err != nil {

--- a/cli/cmd/release_promote.go
+++ b/cli/cmd/release_promote.go
@@ -128,11 +128,12 @@ func (r *runners) releasePromote(cmd *cobra.Command, args []string) (err error) 
 			return errors.Wrap(err, "encode json output")
 		}
 	} else {
-		fmt.Fprintf(r.w, "Channel %s successfully set to release %d\n", channelName, seq)
 		if len(promoteResp.Warnings) > 0 {
 			for _, w := range promoteResp.Warnings {
 				fmt.Fprintf(r.w, "Warning: %s\n", w)
 			}
+		} else {
+			fmt.Fprintf(r.w, "Channel %s successfully set to release %d\n", channelName, seq)
 		}
 	}
 

--- a/cli/cmd/release_promote.go
+++ b/cli/cmd/release_promote.go
@@ -108,13 +108,15 @@ func (r *runners) releasePromote(cmd *cobra.Command, args []string) (err error) 
 		log.Silence()
 
 		out := struct {
-			Channel         string `json:"channel"`
-			ReleaseSequence int64  `json:"release_sequence"`
-			VersionLabel    string `json:"version_label"`
+			Channel         string   `json:"channel"`
+			ReleaseSequence int64    `json:"release_sequence"`
+			VersionLabel    string   `json:"version_label"`
+			Warnings        []string `json:"warnings,omitempty"`
 		}{
 			Channel:         newID,
 			ReleaseSequence: seq,
 			VersionLabel:    r.args.releaseVersion,
+			Warnings:        promoteResp.Warnings,
 		}
 		enc := json.NewEncoder(r.w)
 		enc.SetIndent("", "  ")
@@ -123,6 +125,11 @@ func (r *runners) releasePromote(cmd *cobra.Command, args []string) (err error) 
 		}
 	} else {
 		fmt.Fprintf(r.w, "Channel %s successfully set to release %d\n", channelName, seq)
+		if len(promoteResp.Warnings) > 0 {
+			for _, w := range promoteResp.Warnings {
+				fmt.Fprintf(r.w, "Warning: %s\n", w)
+			}
+		}
 	}
 
 	if r.appType == "kots" && r.args.releasePromoteWaitForAirgap {

--- a/pkg/types/release.go
+++ b/pkg/types/release.go
@@ -90,6 +90,7 @@ type AirgapBuildSummary struct {
 type PromoteReleaseResponse struct {
 	Release      KotsAppRelease       `json:"release"`
 	AirgapBuilds []AirgapBuildSummary `json:"airgapBuilds"`
+	Warnings     []string             `json:"warnings,omitempty"`
 }
 
 type KotsAppRelease struct {


### PR DESCRIPTION
Fix: https://app.shortcut.com/replicated/story/136313/cli-reports-success-when-channel-promotion-is-silently-rejected-by-semver-ordering

We still allow promoting release with lower semver than latest release in semver channel, e.g. for patch release.
Just show a warning messages if any since the release get promoted but not gonna be the latest release due to semver order.

e.g.

```
replicated release promote 21 3DFXkTmfxiUyocBEU9TFEpw7w3w

Warning: Release 0.0.1 was promoted to channel "Unstable", but 6.0.0 remains the latest release because the channel is sorted by semver.
```

```
REPLICATED_OUTPUT=json replicated release promote 21 3DFXkTmfxiUyocBEU9TFEpw7w3w
{
  "channel": "3DFXkTmfxiUyocBEU9TFEpw7w3w",
  "release_sequence": 21,
  "version_label": "",
  "warnings": [
    "Release 0.0.1 was promoted to channel \"Unstable\", but 6.0.0 remains the latest release because the channel is sorted by semver."
  ]
}
```

```
replicated release create --version 5.4.0 --promote Unstable

  • Packaging charts ✓
  • Copying packaged charts to staging directory ✓
  • Collecting manifest files ✓
  • Copying manifests to staging directory ✓
  • Reading manifests from staging directory ✓
  • Creating Release ✓
    • SEQUENCE: 23
  • Promoting ✓
    • Warning: Release 5.4.0 was promoted to channel "Unstable", but 6.0.0 remains the latest release because the channel is sorted by semver.
```