### PR TITLE
Fix help error for config init

### DIFF
--- a/cli/cmd/init.go
+++ b/cli/cmd/init.go
@@ -62,7 +62,7 @@ func (r *runners) initConfig(cmd *cobra.Command, nonInteractive bool, skipDetect
 
 	if exists {
 		if nonInteractive {
-			return fmt.Errorf("config file already exists at %s (use --force to overwrite)", existingPath)
+			return fmt.Errorf("config file already exists at %s.", existingPath)
 		}
 
 		// Ask if they want to overwrite


### PR DESCRIPTION
If running `replicated config init --non-interactive` with an existing file, the error suggested a flag that doesn't exist.