### PR TITLE
feat: add --notify-users to release create and promote

### DIFF
--- a/cli/cmd/release_create.go
+++ b/cli/cmd/release_create.go
@@ -75,6 +75,7 @@ replicated release create --version 1.0.0 --promote Unstable --required`,
 	cmd.Flags().BoolVar(&r.args.createReleasePromoteEnsureChannel, "ensure-channel", false, "When used with --promote <channel>, will create the channel if it doesn't exist")
 	cmd.Flags().BoolVar(&r.args.createReleasePromoteWaitForAirgap, "wait-for-airgap", false, "When used with --promote <channel>, wait for airgap bundle builds to complete (KOTS apps only)")
 	cmd.Flags().DurationVar(&r.args.createReleasePromoteWaitForAirgapTimeout, "wait-for-airgap-timeout", 30*time.Minute, "Timeout for waiting on airgap bundle builds")
+	cmd.Flags().Bool("notify-users", false, "When used with --promote <channel>, notify Enterprise Portal users of this release promotion")
 	cmd.Flags().BoolVar(&r.args.createReleaseAutoDefaults, "auto", false, "generate default values for use in CI")
 	cmd.Flag("auto").Deprecated = "use a .replicated file instead"
 	cmd.Flags().BoolVarP(&r.args.createReleaseAutoDefaultsAccept, "confirm-auto", "y", false, "skip the confirmation prompt")
@@ -471,15 +472,19 @@ Prepared to create release with defaults:
 
 	if promoteChanID != "" {
 		log.ActionWithSpinner("Promoting")
-		promoteResp, err := r.api.PromoteRelease(
-			r.appID,
-			r.appType,
-			release.Sequence,
-			r.args.createReleasePromoteVersion,
-			r.args.createReleasePromoteNotes,
-			r.args.createReleasePromoteRequired,
-			promoteChanID,
-		)
+		var notifyUsers *bool
+		if cmd.Flags().Changed("notify-users") {
+			v, _ := cmd.Flags().GetBool("notify-users")
+			notifyUsers = &v
+		}
+		promoteResp, err := r.api.PromoteRelease(r.appID, r.appType, types.PromoteReleaseOptions{
+			Sequence:    release.Sequence,
+			Label:       r.args.createReleasePromoteVersion,
+			Notes:       r.args.createReleasePromoteNotes,
+			Required:    r.args.createReleasePromoteRequired,
+			ChannelIDs:  []string{promoteChanID},
+			NotifyUsers: notifyUsers,
+		})
 		if err != nil {
 			log.FinishSpinnerWithError()
 			return errors.Wrap(err, "promote release")

--- a/cli/cmd/release_promote.go
+++ b/cli/cmd/release_promote.go
@@ -30,6 +30,7 @@ func (r *runners) InitReleasePromote(parent *cobra.Command) {
 	cmd.Flags().StringVar(&r.args.releaseVersion, "version", "", "A version label for the release in this channel")
 	cmd.Flags().BoolVar(&r.args.releasePromoteWaitForAirgap, "wait-for-airgap", false, "Wait for airgap bundle builds to complete (KOTS apps only)")
 	cmd.Flags().DurationVar(&r.args.releasePromoteWaitForAirgapTimeout, "wait-for-airgap-timeout", 30*time.Minute, "Timeout for waiting on airgap bundle builds")
+	cmd.Flags().Bool("notify-users", false, "Notify Enterprise Portal users of this release promotion")
 
 	cmd.RunE = r.releasePromote
 }
@@ -98,7 +99,19 @@ func (r *runners) releasePromote(cmd *cobra.Command, args []string) (err error) 
 		required = r.args.releaseRequired
 	}
 
-	promoteResp, err := r.api.PromoteRelease(r.appID, r.appType, seq, r.args.releaseVersion, r.args.releaseNotes, required, newID)
+	var notifyUsers *bool
+	if cmd.Flags().Changed("notify-users") {
+		v, _ := cmd.Flags().GetBool("notify-users")
+		notifyUsers = &v
+	}
+	promoteResp, err := r.api.PromoteRelease(r.appID, r.appType, types.PromoteReleaseOptions{
+		Sequence:    seq,
+		Label:       r.args.releaseVersion,
+		Notes:       r.args.releaseNotes,
+		Required:    required,
+		ChannelIDs:  []string{newID},
+		NotifyUsers: notifyUsers,
+	})
 	if err != nil {
 		return errors.Wrapf(err, "failed to promote release")
 	}

--- a/client/release.go
+++ b/client/release.go
@@ -118,13 +118,13 @@ func (c *Client) GetRelease(appID string, appType string, sequence int64) (*type
 	return nil, errors.Errorf("unknown app type %q", appType)
 }
 
-func (c *Client) PromoteRelease(appID string, appType string, sequence int64, label string, notes string, required bool, channelIDs ...string) (*types.PromoteReleaseResponse, error) {
+func (c *Client) PromoteRelease(appID string, appType string, opts types.PromoteReleaseOptions) (*types.PromoteReleaseResponse, error) {
 
 	if appType == "platform" {
-		err := c.PlatformClient.PromoteRelease(appID, sequence, label, notes, required, channelIDs...)
+		err := c.PlatformClient.PromoteRelease(appID, opts)
 		return nil, err
 	} else if appType == "kots" {
-		return c.KotsClient.PromoteRelease(appID, sequence, label, notes, required, channelIDs...)
+		return c.KotsClient.PromoteRelease(appID, opts)
 	}
 	return nil, errors.Errorf("unknown app type %q", appType)
 }

--- a/pact/kotsclient/release_test.go
+++ b/pact/kotsclient/release_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pact-foundation/pact-go/dsl"
 	realkotsclient "github.com/replicatedhq/replicated/pkg/kotsclient"
 	"github.com/replicatedhq/replicated/pkg/platformclient"
+	"github.com/replicatedhq/replicated/pkg/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -197,7 +198,13 @@ func Test_PromoteRelease(t *testing.T) {
 		api := platformclient.NewHTTPClient(u, "replicated-cli-promote-release-token")
 		client := realkotsclient.VendorV3Client{HTTPClient: *api}
 
-		_, err = client.PromoteRelease("replicated-cli-promote-release-app", 1, "v0.0.1", "releasenotes", false, "replicated-cli-promote-release-unstable")
+		_, err = client.PromoteRelease("replicated-cli-promote-release-app", types.PromoteReleaseOptions{
+			Sequence:   1,
+			Label:      "v0.0.1",
+			Notes:      "releasenotes",
+			Required:   false,
+			ChannelIDs: []string{"replicated-cli-promote-release-unstable"},
+		})
 		assert.NoError(t, err)
 
 		return nil

--- a/pkg/kotsclient/release.go
+++ b/pkg/kotsclient/release.go
@@ -175,17 +175,18 @@ func (c *VendorV3Client) ListReleases(appID string) ([]types.ReleaseInfo, error)
 	return allReleases, nil
 }
 
-func (c *VendorV3Client) PromoteRelease(appID string, sequence int64, label string, notes string, required bool, channelIDs ...string) (*types.PromoteReleaseResponse, error) {
+func (c *VendorV3Client) PromoteRelease(appID string, opts types.PromoteReleaseOptions) (*types.PromoteReleaseResponse, error) {
 	request := types.KotsPromoteReleaseRequest{
-		ReleaseNotes:          notes,
-		VersionLabel:          label,
-		IsRequired:            required,
-		ChannelIDs:            channelIDs,
+		ReleaseNotes:          opts.Notes,
+		VersionLabel:          opts.Label,
+		IsRequired:            opts.Required,
+		ChannelIDs:            opts.ChannelIDs,
+		NotifyUsers:           opts.NotifyUsers,
 		OmitDetailsInResponse: true,
 	}
 
 	resp := types.PromoteReleaseResponse{}
-	path := fmt.Sprintf("/v3/app/%s/release/%v/promote", appID, sequence)
+	path := fmt.Sprintf("/v3/app/%s/release/%v/promote", appID, opts.Sequence)
 	err := c.DoJSON(context.TODO(), "POST", path, http.StatusOK, request, &resp)
 	if err != nil {
 		return nil, err

--- a/pkg/platformclient/release.go
+++ b/pkg/platformclient/release.go
@@ -74,13 +74,13 @@ func (c *HTTPClient) GetRelease(appID string, sequence int64) (*releases.AppRele
 }
 
 // PromoteRelease points the specified channels at a release sequence.
-func (c *HTTPClient) PromoteRelease(appID string, sequence int64, label, notes string, required bool, channelIDs ...string) error {
-	path := fmt.Sprintf("/v1/app/%s/%d/promote?dry_run=true", appID, sequence)
+func (c *HTTPClient) PromoteRelease(appID string, opts types.PromoteReleaseOptions) error {
+	path := fmt.Sprintf("/v1/app/%s/%d/promote?dry_run=true", appID, opts.Sequence)
 	body := &releases.BodyPromoteRelease{
-		Label:        label,
-		ReleaseNotes: notes,
-		Required:     required,
-		Channels:     channelIDs,
+		Label:        opts.Label,
+		ReleaseNotes: opts.Notes,
+		Required:     opts.Required,
+		Channels:     opts.ChannelIDs,
 	}
 	if err := c.DoJSON(context.TODO(), "POST", path, http.StatusNoContent, body, nil); err != nil {
 		return fmt.Errorf("PromoteRelease: %w", err)

--- a/pkg/types/release.go
+++ b/pkg/types/release.go
@@ -69,9 +69,19 @@ type KotsPromoteReleaseRequest struct {
 	IsRequired     bool     `json:"isRequired"`
 	ChannelIDs     []string `json:"channelIds"`
 	IgnoreWarnings bool     `json:"ignoreWarnings"`
+	NotifyUsers    *bool    `json:"notifyUsers,omitempty"`
 
 	// Omits channels, charts, and compatibilityResults details in the response body
 	OmitDetailsInResponse bool `json:"omitDetailsInResponse"`
+}
+
+type PromoteReleaseOptions struct {
+	Sequence    int64
+	Label       string
+	Notes       string
+	Required    bool
+	ChannelIDs  []string
+	NotifyUsers *bool
 }
 
 type AirgapBuildSummary struct {


### PR DESCRIPTION
Add new flag `--notify-users` to `release create` and `release promote`.

e.g.

```
replicated release promote 430 Unstable --notify-users
replicated release create --yaml-dir .release-tmp --promote base --version 4.0.0 --ensure-channel --notify-users
```

New payload to send to Vendor API

```json
{
    "releaseNotes": "",
    "versionLabel": "",
    "isRequired": false,
    "channelIds": [
        "2pPQVMB2YXfw6yODKL9U4XsFXE6"
    ],
    "ignoreWarnings": false,
    "notifyUsers": true,
    "omitDetailsInResponse": true
}
```

If omitted, no value will be sent.