### PR TITLE
Add --username flag to replicated registry add ghcr command

### DIFF
--- a/cli/cmd/registry_add_ghcr.go
+++ b/cli/cmd/registry_add_ghcr.go
@@ -19,6 +19,7 @@ func (r *runners) InitRegistryAddGHCR(parent *cobra.Command) {
 	}
 	parent.AddCommand(cmd)
 
+	cmd.Flags().StringVar(&r.args.addRegistryUsername, "username", "", "The userame to authenticate to the registry with")
 	cmd.Flags().StringVar(&r.args.addRegistryToken, "token", "", "The token to use to auth to the registry with")
 	cmd.Flags().BoolVar(&r.args.addRegistryTokenFromStdIn, "token-stdin", false, "Take the token from stdin")
 	cmd.Flags().StringVar(&r.args.addRegistryName, "name", "", "Name for the registry")


### PR DESCRIPTION
Added the --username flag to registry_add_ghcr.go following the pattern in registry_add_quay.go. The validateRegistryAddGHCR function was already checking for r.args.addRegistryUsername, so the flag definition was the only missing piece. 

Fixes: [SC-137178]