### PR TITLE
chore(vm): remove "beta feature" note from vm command help text

### DIFF
--- a/cli/cmd/vm.go
+++ b/cli/cmd/vm.go
@@ -12,9 +12,7 @@ func (r *runners) InitVMCommand(parent *cobra.Command) *cobra.Command {
 		Use:   "vm",
 		Short: "Manage test virtual machines.",
 		Long: `The 'vm' command allows you to manage and interact with virtual machines (VMs) used for testing purposes.
-With this command, you can create, list, remove, update, and manage VMs, as well as retrieve information about available VM versions.
-
-VMs are currently a beta feature.`,
+With this command, you can create, list, remove, update, and manage VMs, as well as retrieve information about available VM versions.`,
 		Example: `# Create a single Ubuntu VM
 replicated vm create --distribution ubuntu --version 20.04
 

--- a/cli/cmd/vm_create.go
+++ b/cli/cmd/vm_create.go
@@ -36,9 +36,7 @@ This command allows you to provision VMs with different distributions (e.g., Ubu
 
 By default, the command provisions one VM, but you can customize the number of VMs to create by using the "--count" flag. Additionally, you can use the "--dry-run" flag to simulate the creation without actually provisioning the VMs.
 
-The command also supports a "--wait" flag to wait for the VMs to be ready before returning control, with a customizable timeout duration.
-
-VMs are currently a beta feature.`,
+The command also supports a "--wait" flag to wait for the VMs to be ready before returning control, with a customizable timeout duration.`,
 		Example: `# Create a single Ubuntu 22.04 VM
 replicated vm create --distribution ubuntu --version 22.04
 

--- a/cli/cmd/vm_endpoints.go
+++ b/cli/cmd/vm_endpoints.go
@@ -70,9 +70,7 @@ You can identify the VM either by its unique ID or by its name.
 
 By default, the username in the endpoint is the GitHub username linked to your Vendor Portal account. If the VM was created with 'replicated vm create --ssh-public-key', the Linux user on the VM is derived from the key's comment (the portion before the first '@') instead — pass that username via --username so the endpoint matches the user the key was added to.
 
-Note: %s endpoints can only be retrieved from VMs in the "running" state.
-
-VMs are currently a beta feature.`, protocol, outputFormat, protocol)
+Note: %s endpoints can only be retrieved from VMs in the "running" state.`, protocol, outputFormat, protocol)
 
 	cmdExample := fmt.Sprintf(`# Get %s endpoint for a specific VM by ID
 replicated vm %s-endpoint aaaaa11

--- a/cli/cmd/vm_ls.go
+++ b/cli/cmd/vm_ls.go
@@ -23,9 +23,7 @@ By default, the command will return a table of all VMs, but you can switch to JS
 
 You can use the '--watch' flag to monitor VMs continuously. This will refresh the list of VMs every 2 seconds, displaying any updates in real-time, such as new VMs being created or existing VMs being terminated.
 
-The command also allows you to customize the output format, supporting 'json', 'table', and 'wide' views for flexibility based on your needs.
-
-VMs are currently a beta feature.`,
+The command also allows you to customize the output format, supporting 'json', 'table', and 'wide' views for flexibility based on your needs.`,
 		Example: `# List all active VMs
 replicated vm ls
 

--- a/cli/cmd/vm_port.go
+++ b/cli/cmd/vm_port.go
@@ -10,9 +10,7 @@ func (r *runners) InitVMPort(parent *cobra.Command) *cobra.Command {
 		Short: "Manage VM ports.",
 		Long: `The 'vm port' command is a parent command for managing ports in a vm. It allows users to list, remove, or expose specific ports used by the vm. Use the subcommands (such as 'ls', 'rm', and 'expose') to manage port configurations effectively.
 
-This command provides flexibility for handling ports in various test vms, ensuring efficient management of vm networking settings.
-
-VMs are currently a beta feature.`,
+This command provides flexibility for handling ports in various test vms, ensuring efficient management of vm networking settings.`,
 		Example: `# List all exposed ports in a vm
 replicated vm port ls VM_ID_OR_NAME
 

--- a/cli/cmd/vm_port_expose.go
+++ b/cli/cmd/vm_port_expose.go
@@ -12,9 +12,7 @@ func (r *runners) InitVMPortExpose(parent *cobra.Command) *cobra.Command {
 		Short: "Expose a port on a vm to the public internet.",
 		Long: `The 'vm port expose' command is used to expose a specified port on a vm to the public internet. When exposing a port, the command automatically creates a DNS entry and, if using the "https" protocol, provisions a TLS certificate for secure communication.
 
-This command supports different protocols including "http", "https", "ws", and "wss" for web traffic and web socket communication.
-
-VMs are currently a beta feature.`,
+This command supports different protocols including "http", "https", "ws", and "wss" for web traffic and web socket communication.`,
 		Example: `# Expose port for Embedded Cluster (Port: 30000) with HTTP Protocol
 replicated vm port expose VM_ID_OR_NAME --port 30000 --protocol http
 

--- a/cli/cmd/vm_port_ls.go
+++ b/cli/cmd/vm_port_ls.go
@@ -11,9 +11,7 @@ func (r *runners) InitVMPortLs(parent *cobra.Command) *cobra.Command {
 		Short: "List vm ports for a vm.",
 		Long: `The 'vm port ls' command lists all the ports configured for a specific vm. You must provide the vm ID or name to retrieve and display the ports.
 
-This command is useful for viewing the current port configurations, protocols, and other related settings of your test vm. The output format can be customized to suit your needs, and the available formats include table, JSON, and wide views.
-
-VMs are currently a beta feature.`,
+This command is useful for viewing the current port configurations, protocols, and other related settings of your test vm. The output format can be customized to suit your needs, and the available formats include table, JSON, and wide views.`,
 		Example: `# List ports for a vm in the default table format
 replicated vm port ls VM_ID_OR_NAME
 

--- a/cli/cmd/vm_port_rm.go
+++ b/cli/cmd/vm_port_rm.go
@@ -11,9 +11,7 @@ func (r *runners) InitVMPortRm(parent *cobra.Command) *cobra.Command {
 		Short: "Remove vm port by ID.",
 		Long: `The 'vm port rm' command removes a specific port from a vm. You must provide the ID or name of the vm and the ID of the port to remove.
 
-This command is useful for managing the network settings of your test vms by allowing you to clean up unused or incorrect ports. After removing a port, the updated list of ports will be displayed.
-
-VMs are currently a beta feature.`,
+This command is useful for managing the network settings of your test vms by allowing you to clean up unused or incorrect ports. After removing a port, the updated list of ports will be displayed.`,
 		Example: `# Remove a port using its ID
 replicated vm port rm VM_ID_OR_NAME --id PORT_ID
 

--- a/cli/cmd/vm_rm.go
+++ b/cli/cmd/vm_rm.go
@@ -19,9 +19,7 @@ This command supports multiple filtering options, including removing VMs by thei
 
 When specifying a name that matches multiple VMs, all VMs with that name will be removed.
 
-You can also use the '--dry-run' flag to simulate the removal without actually deleting the VMs.
-
-VMs are currently a beta feature.`,
+You can also use the '--dry-run' flag to simulate the removal without actually deleting the VMs.`,
 		Example: `# Remove a VM by ID or name
 replicated vm rm aaaaa11
 

--- a/cli/cmd/vm_update.go
+++ b/cli/cmd/vm_update.go
@@ -16,9 +16,7 @@ func (r *runners) InitVMUpdateCommand(parent *cobra.Command) *cobra.Command {
 - Alternatively, to update the VM by its ID, use the '--id' flag.
 - Alternatively, to update the VM by its name, use the '--name' flag.
 
-Subcommands will allow for more specific updates like TTL.
-
-VMs are currently a beta feature.`,
+Subcommands will allow for more specific updates like TTL.`,
 		Example: `# Update a VM TTL by specifying its ID or name directly
 replicated vm update ttl my-test-vm --ttl 12h
 

--- a/cli/cmd/vm_update_ttl.go
+++ b/cli/cmd/vm_update_ttl.go
@@ -18,9 +18,7 @@ The TTL specifies how long the VM will run before it is automatically terminated
 
 The command accepts a VM ID or name as an argument and requires the '--ttl' flag to specify the new TTL value.
 
-You can also specify the output format (json, table, wide) using the '--output' flag.
-
-VMs are currently a beta feature.`,
+You can also specify the output format (json, table, wide) using the '--output' flag.`,
 		Example: `# Update the TTL of a VM to 2 hours
 replicated vm update ttl aaaaa11 --ttl 2h
 

--- a/cli/cmd/vm_versions.go
+++ b/cli/cmd/vm_versions.go
@@ -15,9 +15,7 @@ func (r *runners) InitVMVersions(parent *cobra.Command) *cobra.Command {
 		Long: `The 'vm versions' command lists all the available versions of virtual machines that can be provisioned. This includes the available distributions and their respective versions.
 
 - You can filter the list by a specific distribution using the '--distribution' flag.
-- The output can be formatted as a table or in JSON format using the '--output' flag.
-
-VMs are currently a beta feature.`,
+- The output can be formatted as a table or in JSON format using the '--output' flag.`,
 		Example: `# List all available VM versions
 replicated vm versions
 


### PR DESCRIPTION
## What this PR does

Removes the trailing `VMs are currently a beta feature.` line from the long help text of every `replicated vm ...` command. Ubuntu is the only VM distribution offered, so the VM commands are no longer beta.

Touches 12 files under `cli/cmd/` (`vm.go`, `vm_create.go`, `vm_ls.go`, `vm_rm.go`, `vm_update.go`, `vm_update_ttl.go`, `vm_versions.go`, `vm_port.go`, `vm_port_ls.go`, `vm_port_rm.go`, `vm_port_expose.go`, `vm_endpoints.go`) — help text only. No flags, logic, or examples changed.

`go build ./cli/...` passes and `go vet` is clean.

## Note

The `replicated-docs` CLI reference pages (`replicated-cli-vm-*.mdx`) are generated from these descriptions and will be updated separately.

Opened as a draft.