### PR TITLE
fix: use PATCH for customer updates

### DIFF
--- a/cli/cmd/customer_update.go
+++ b/cli/cmd/customer_update.go
@@ -34,11 +34,33 @@ type updateCustomerOpts struct {
 	IsKurlInstallEnabled              bool
 }
 
+var customerUpdateFieldFlags = []string{
+	"name",
+	"custom-id",
+	"channel",
+	"expires-in",
+	"airgap",
+	"gitops",
+	"snapshot",
+	"kots-install",
+	"helm-install",
+	"kurl-install",
+	"embedded-cluster-download",
+	"embedded-cluster-multinode",
+	"geo-axis",
+	"helmvm-cluster-download",
+	"identity-service",
+	"support-bundle-upload",
+	"developer-mode",
+	"email",
+	"type",
+}
+
 func (r *runners) InitCustomerUpdateCommand(parent *cobra.Command) *cobra.Command {
 	opts := updateCustomerOpts{}
 
 	cmd := &cobra.Command{
-		Use:   "update --customer <id> --name <name> [options]",
+		Use:   "update --customer <id> [options]",
 		Short: "Update an existing customer",
 		Long: `Update an existing customer's information and settings.
 
@@ -93,11 +115,9 @@ replicated customer update --customer cus_abcdef123456 --name "JSON Corp" --outp
 	cmd.Flags().BoolVar(&opts.IsSupportBundleUploadEnabled, "support-bundle-upload", false, "If set, the license will allow uploading support bundles.")
 	cmd.Flags().BoolVar(&opts.IsDeveloperModeEnabled, "developer-mode", false, "If set, Replicated SDK installed in dev mode will use mock data.")
 	cmd.Flags().StringVar(&opts.Email, "email", "", "Email address of the customer that is to be updated.")
-	cmd.Flags().StringVar(&opts.Type, "type", "dev", "The license type to update. One of: dev|trial|paid|community|test (default: dev)")
+	cmd.Flags().StringVar(&opts.Type, "type", "", "The license type to update. One of: dev|trial|paid|community|test")
 
 	cmd.MarkFlagRequired("customer")
-	cmd.MarkFlagRequired("channel")
-	cmd.MarkFlagRequired("name") // until the API supports better patching, this is actually a required field
 
 	return cmd
 }
@@ -115,57 +135,56 @@ func (r *runners) updateCustomer(cmd *cobra.Command, opts updateCustomerOpts) (e
 		return errors.New("missing or invalid parameters: customer")
 	}
 
-	// all of the following validation occurs in the API also, but
-	// we want to fail fast if the user has provided invalid input
-	if err := validateCustomerType(opts.Type); err != nil {
-		return errors.Wrap(err, "validate customer type")
-	}
-	if opts.Type == "test" && opts.ExpiryDuration > time.Hour*48 {
-		return errors.New("test licenses cannot be updated with an expiration date greater than 48 hours")
-	}
-	if opts.Type == "paid" {
-		opts.Type = "prod"
+	if opts.EnsureChannel && !cmd.Flags().Changed("channel") {
+		return errors.New("--ensure-channel requires --channel")
 	}
 
-	getOrCreateChannelOptions := client.GetOrCreateChannelOptions{
-		AppID:          r.appID,
-		AppType:        r.appType,
-		NameOrID:       opts.Channel,
-		Description:    "",
-		CreateIfAbsent: opts.EnsureChannel,
+	if !hasCustomerUpdate(cmd) {
+		return errors.New("at least one customer field must be specified")
 	}
 
-	channel, err := r.api.GetOrCreateChannelByName(getOrCreateChannelOptions)
-	if err != nil {
-		return errors.Wrap(err, "get channel")
+	if cmd.Flags().Changed("type") {
+		// This validation also occurs in the API, but fail fast when possible.
+		if err := validateCustomerType(opts.Type); err != nil {
+			return errors.Wrap(err, "validate customer type")
+		}
+		if opts.Type == "test" && opts.ExpiryDuration > time.Hour*48 {
+			return errors.New("test licenses cannot be updated with an expiration date greater than 48 hours")
+		}
+		if opts.Type == "paid" {
+			opts.Type = "prod"
+		}
 	}
 
-	channels := []kotsclient.CustomerChannel{
-		{
-			ID:        channel.ID,
-			IsDefault: true,
-		},
+	if cmd.Flags().Changed("expires-in") && opts.ExpiryDuration <= 0 {
+		return errors.New("--expires-in must be greater than zero")
 	}
 
 	updateOpts := kotsclient.UpdateCustomerOpts{
-		Name:                         opts.Name,
-		CustomID:                     opts.CustomID,
-		Channels:                     channels,
-		AppID:                        r.appID,
-		ExpiresAtDuration:            opts.ExpiryDuration,
-		IsAirgapEnabled:              opts.IsAirgapEnabled,
-		IsGitopsSupported:            opts.IsGitopsSupported,
-		IsSnapshotSupported:          opts.IsSnapshotSupported,
-		IsKotsInstallEnabled:         opts.IsKotsInstallEnabled,
-		IsGeoaxisSupported:           opts.IsGeoaxisSupported,
-		IsHelmVMDownloadEnabled:      opts.IsHelmVMDownloadEnabled,
-		IsIdentityServiceSupported:   opts.IsIdentityServiceSupported,
-		IsSupportBundleUploadEnabled: opts.IsSupportBundleUploadEnabled,
-		IsDeveloperModeEnabled:       opts.IsDeveloperModeEnabled,
-		LicenseType:                  opts.Type,
-		Email:                        opts.Email,
+		LicenseType: opts.Type,
 	}
 
+	if cmd.Flags().Changed("name") {
+		updateOpts.Name = &opts.Name
+	}
+	if cmd.Flags().Changed("custom-id") {
+		updateOpts.CustomID = &opts.CustomID
+	}
+	if cmd.Flags().Changed("expires-in") {
+		updateOpts.ExpiresAtDuration = &opts.ExpiryDuration
+	}
+	if cmd.Flags().Changed("airgap") {
+		updateOpts.IsAirgapEnabled = &opts.IsAirgapEnabled
+	}
+	if cmd.Flags().Changed("gitops") {
+		updateOpts.IsGitopsSupported = &opts.IsGitopsSupported
+	}
+	if cmd.Flags().Changed("snapshot") {
+		updateOpts.IsSnapshotSupported = &opts.IsSnapshotSupported
+	}
+	if cmd.Flags().Changed("kots-install") {
+		updateOpts.IsKotsInstallEnabled = &opts.IsKotsInstallEnabled
+	}
 	if cmd.Flags().Changed("helm-install") {
 		updateOpts.IsHelmInstallEnabled = &opts.IsHelmInstallEnabled
 	}
@@ -177,6 +196,54 @@ func (r *runners) updateCustomer(cmd *cobra.Command, opts updateCustomerOpts) (e
 	}
 	if cmd.Flags().Changed("embedded-cluster-multinode") {
 		updateOpts.IsEmbeddedClusterMultinodeEnabled = &opts.IsEmbeddedClusterMultinodeEnabled
+	}
+	if cmd.Flags().Changed("geo-axis") {
+		updateOpts.IsGeoaxisSupported = &opts.IsGeoaxisSupported
+	}
+	if cmd.Flags().Changed("helmvm-cluster-download") {
+		updateOpts.IsHelmVMDownloadEnabled = &opts.IsHelmVMDownloadEnabled
+	}
+	if cmd.Flags().Changed("identity-service") {
+		updateOpts.IsIdentityServiceSupported = &opts.IsIdentityServiceSupported
+	}
+	if cmd.Flags().Changed("support-bundle-upload") {
+		updateOpts.IsSupportBundleUploadEnabled = &opts.IsSupportBundleUploadEnabled
+	}
+	if cmd.Flags().Changed("developer-mode") {
+		updateOpts.IsDeveloperModeEnabled = &opts.IsDeveloperModeEnabled
+	}
+	if cmd.Flags().Changed("email") {
+		updateOpts.Email = &opts.Email
+	}
+
+	if cmd.Flags().Changed("channel") {
+		currentCustomer, err := r.api.GetCustomerByID(opts.CustomerID)
+		if err != nil {
+			return errors.Wrap(err, "get customer")
+		}
+
+		getOrCreateChannelOptions := client.GetOrCreateChannelOptions{
+			AppID:          r.appID,
+			AppType:        r.appType,
+			NameOrID:       opts.Channel,
+			Description:    "",
+			CreateIfAbsent: opts.EnsureChannel,
+		}
+
+		channel, err := r.api.GetOrCreateChannelByName(getOrCreateChannelOptions)
+		if err != nil {
+			return errors.Wrap(err, "get channel")
+		}
+
+		updateOpts.AddChannels = []kotsclient.CustomerChannel{{
+			ID:        channel.ID,
+			IsDefault: true,
+		}}
+		for _, currentChannel := range currentCustomer.Channels {
+			if currentChannel.ID != channel.ID {
+				updateOpts.RemoveChannels = append(updateOpts.RemoveChannels, currentChannel.ID)
+			}
+		}
 	}
 
 	customer, err := r.api.UpdateCustomer(r.appType, opts.CustomerID, updateOpts)
@@ -190,4 +257,13 @@ func (r *runners) updateCustomer(cmd *cobra.Command, opts updateCustomerOpts) (e
 	}
 
 	return nil
+}
+
+func hasCustomerUpdate(cmd *cobra.Command) bool {
+	for _, flagName := range customerUpdateFieldFlags {
+		if cmd.Flags().Changed(flagName) {
+			return true
+		}
+	}
+	return false
 }

--- a/cli/cmd/customer_update_test.go
+++ b/cli/cmd/customer_update_test.go
@@ -1,0 +1,114 @@
+package cmd
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"text/tabwriter"
+
+	"github.com/replicatedhq/replicated/client"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCustomerUpdateChannelOnlyUsesPatchWithoutOptionalFields(t *testing.T) {
+	var patchBody map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v3/customer/customer-id":
+			_, _ = w.Write([]byte(`{
+				"customer": {
+					"id": "customer-id",
+					"name": "EC Customer",
+					"email": "customer@example.com",
+					"channels": [{"id": "unstable-channel-id", "name": "Unstable"}],
+					"airgap": true,
+					"isEmbeddedClusterDownloadEnabled": true,
+					"isSupportBundleUploadEnabled": true
+				}
+			}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/v3/app/app-id/channel/stable":
+			_, _ = w.Write([]byte(`{"channel":{"id":"stable-channel-id","name":"Stable"}}`))
+		case r.Method == http.MethodPatch && r.URL.Path == "/v3/customer/customer-id":
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&patchBody))
+			_, _ = w.Write([]byte(`{"customer":{"id":"customer-id","name":"EC Customer"}}`))
+		default:
+			http.Error(w, "unexpected request", http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	api := client.NewClient(server.URL, "fake-api-key", "")
+	r := &runners{
+		appID:        "app-id",
+		appType:      "kots",
+		api:          api,
+		outputFormat: "json",
+		w:            tabwriter.NewWriter(io.Discard, 0, 0, 0, ' ', 0),
+	}
+
+	parent := r.InitCustomersCommand(&cobra.Command{Use: "replicated"})
+	updateCmd := r.InitCustomerUpdateCommand(parent)
+	require.NoError(t, updateCmd.Flags().Set("customer", "customer-id"))
+	require.NoError(t, updateCmd.Flags().Set("channel", "stable"))
+	require.NoError(t, updateCmd.RunE(updateCmd, nil))
+
+	require.ElementsMatch(t, []string{"add_channels", "remove_channels"}, customerUpdateMapKeys(patchBody))
+	require.Equal(t, []interface{}{"unstable-channel-id"}, patchBody["remove_channels"])
+}
+
+func TestCustomerUpdateNameOnlyDoesNotRequireChannel(t *testing.T) {
+	var patchBody map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPatch, r.Method)
+		require.Equal(t, "/v3/customer/customer-id", r.URL.Path)
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&patchBody))
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"customer":{"id":"customer-id","name":"New Name"}}`))
+	}))
+	defer server.Close()
+
+	api := client.NewClient(server.URL, "fake-api-key", "")
+	r := &runners{
+		appID:        "app-id",
+		appType:      "kots",
+		api:          api,
+		outputFormat: "json",
+		w:            tabwriter.NewWriter(io.Discard, 0, 0, 0, ' ', 0),
+	}
+
+	parent := r.InitCustomersCommand(&cobra.Command{Use: "replicated"})
+	updateCmd := r.InitCustomerUpdateCommand(parent)
+	require.NoError(t, updateCmd.Flags().Set("customer", "customer-id"))
+	require.NoError(t, updateCmd.Flags().Set("name", "New Name"))
+	require.NoError(t, updateCmd.RunE(updateCmd, nil))
+
+	require.Equal(t, map[string]interface{}{"name": "New Name"}, patchBody)
+}
+
+func TestCustomerUpdateRequiresAChangedField(t *testing.T) {
+	r := &runners{
+		appID:   "app-id",
+		appType: "kots",
+	}
+
+	parent := r.InitCustomersCommand(&cobra.Command{Use: "replicated"})
+	updateCmd := r.InitCustomerUpdateCommand(parent)
+	require.NoError(t, updateCmd.Flags().Set("customer", "customer-id"))
+
+	err := updateCmd.RunE(updateCmd, nil)
+	require.EqualError(t, err, "at least one customer field must be specified")
+}
+
+func customerUpdateMapKeys(values map[string]interface{}) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	return keys
+}

--- a/pkg/kotsclient/customer_update.go
+++ b/pkg/kotsclient/customer_update.go
@@ -11,30 +11,28 @@ import (
 )
 
 type UpdateCustomerRequest struct {
-	Name                         string             `json:"name"`
-	Channels                     []CustomerChannel  `json:"channels"`
-	CustomID                     string             `json:"custom_id"`
-	AppID                        string             `json:"app_id"`
-	Type                         string             `json:"type"`
-	ExpiresAt                    string             `json:"expires_at"`
-	IsAirgapEnabled              bool               `json:"is_airgap_enabled"`
-	IsGitopsSupported            bool               `json:"is_gitops_supported"`
-	IsSnapshotSupported          bool               `json:"is_snapshot_supported"`
-	IsKotsInstallEnabled         bool               `json:"is_kots_install_enabled"`
-	IsGeoaxisSupported           bool               `json:"is_geoaxis_supported"`
-	IsHelmVMDownloadEnabled      bool               `json:"is_helm_vm_download_enabled"`
-	IsIdentityServiceSupported   bool               `json:"is_identity_service_supported"`
-	IsSupportBundleUploadEnabled bool               `json:"is_support_bundle_upload_enabled"`
-	IsDeveloperModeEnabled       bool               `json:"is_dev_mode_enabled"`
-	Email                        string             `json:"email,omitempty"`
-	EntitlementValues            []EntitlementValue `json:"entitlementValues"`
+	Name           *string           `json:"name,omitempty"`
+	AddChannels    []CustomerChannel `json:"add_channels,omitempty"`
+	RemoveChannels []string          `json:"remove_channels,omitempty"`
+	CustomID       *string           `json:"custom_id,omitempty"`
+	Type           string            `json:"type,omitempty"`
+	ExpiresAt      *string           `json:"expires_at,omitempty"`
 
-	// These fields were added after the "built in" fields feature was released.
-	// If they are not pointer types, they will override the defaults.
-	IsHelmInstallEnabled              *bool `json:"is_helm_install_enabled,omitempty"`
-	IsKurlInstallEnabled              *bool `json:"is_kurl_install_enabled,omitempty"`
-	IsEmbeddedClusterDownloadEnabled  *bool `json:"is_embedded_cluster_download_enabled,omitempty"`
-	IsEmbeddedClusterMultinodeEnabled *bool `json:"is_embedded_cluster_multinode_enabled,omitempty"`
+	// PATCH requests must distinguish an omitted flag from an explicit false value.
+	IsAirgapEnabled                   *bool   `json:"is_airgap_enabled,omitempty"`
+	IsGitopsSupported                 *bool   `json:"is_gitops_supported,omitempty"`
+	IsSnapshotSupported               *bool   `json:"is_snapshot_supported,omitempty"`
+	IsKotsInstallEnabled              *bool   `json:"is_kots_install_enabled,omitempty"`
+	IsHelmInstallEnabled              *bool   `json:"is_helm_install_enabled,omitempty"`
+	IsKurlInstallEnabled              *bool   `json:"is_kurl_install_enabled,omitempty"`
+	IsEmbeddedClusterDownloadEnabled  *bool   `json:"is_embedded_cluster_download_enabled,omitempty"`
+	IsEmbeddedClusterMultinodeEnabled *bool   `json:"is_embedded_cluster_multinode_enabled,omitempty"`
+	IsGeoaxisSupported                *bool   `json:"is_geoaxis_supported,omitempty"`
+	IsHelmVMDownloadEnabled           *bool   `json:"is_helm_vm_download_enabled,omitempty"`
+	IsIdentityServiceSupported        *bool   `json:"is_identity_service_supported,omitempty"`
+	IsSupportBundleUploadEnabled      *bool   `json:"is_support_bundle_upload_enabled,omitempty"`
+	IsDeveloperModeEnabled            *bool   `json:"is_dev_mode_enabled,omitempty"`
+	Email                             *string `json:"email,omitempty"`
 }
 
 type UpdateCustomerResponse struct {
@@ -42,36 +40,35 @@ type UpdateCustomerResponse struct {
 }
 
 type UpdateCustomerOpts struct {
-	Name                              string
-	CustomID                          string
-	Channels                          []CustomerChannel
-	AppID                             string
-	ExpiresAt                         string
-	ExpiresAtDuration                 time.Duration
-	IsAirgapEnabled                   bool
-	IsGitopsSupported                 bool
-	IsSnapshotSupported               bool
-	IsKotsInstallEnabled              bool
+	Name                              *string
+	CustomID                          *string
+	AddChannels                       []CustomerChannel
+	RemoveChannels                    []string
+	ExpiresAt                         *string
+	ExpiresAtDuration                 *time.Duration
+	IsAirgapEnabled                   *bool
+	IsGitopsSupported                 *bool
+	IsSnapshotSupported               *bool
+	IsKotsInstallEnabled              *bool
 	IsHelmInstallEnabled              *bool
 	IsKurlInstallEnabled              *bool
 	IsEmbeddedClusterDownloadEnabled  *bool
 	IsEmbeddedClusterMultinodeEnabled *bool
-	IsGeoaxisSupported                bool
-	IsHelmVMDownloadEnabled           bool
-	IsIdentityServiceSupported        bool
-	IsSupportBundleUploadEnabled      bool
-	IsDeveloperModeEnabled            bool
+	IsGeoaxisSupported                *bool
+	IsHelmVMDownloadEnabled           *bool
+	IsIdentityServiceSupported        *bool
+	IsSupportBundleUploadEnabled      *bool
+	IsDeveloperModeEnabled            *bool
 	LicenseType                       string
-	Email                             string
-	EntitlementValues                 []EntitlementValue
+	Email                             *string
 }
 
 func (c *VendorV3Client) UpdateCustomer(customerID string, opts UpdateCustomerOpts) (*types.Customer, error) {
 	request := &UpdateCustomerRequest{
 		Name:                              opts.Name,
 		CustomID:                          opts.CustomID,
-		Channels:                          opts.Channels,
-		AppID:                             opts.AppID,
+		AddChannels:                       opts.AddChannels,
+		RemoveChannels:                    opts.RemoveChannels,
 		Type:                              opts.LicenseType,
 		IsAirgapEnabled:                   opts.IsAirgapEnabled,
 		IsGitopsSupported:                 opts.IsGitopsSupported,
@@ -87,18 +84,18 @@ func (c *VendorV3Client) UpdateCustomer(customerID string, opts UpdateCustomerOp
 		IsSupportBundleUploadEnabled:      opts.IsSupportBundleUploadEnabled,
 		IsDeveloperModeEnabled:            opts.IsDeveloperModeEnabled,
 		Email:                             opts.Email,
-		EntitlementValues:                 opts.EntitlementValues,
 	}
 
 	// If duration is set, calculate the expiry time
-	if opts.ExpiresAtDuration > 0 {
-		request.ExpiresAt = (time.Now().UTC().Add(opts.ExpiresAtDuration)).Format(time.RFC3339)
+	if opts.ExpiresAtDuration != nil {
+		expiresAt := time.Now().UTC().Add(*opts.ExpiresAtDuration).Format(time.RFC3339)
+		request.ExpiresAt = &expiresAt
 	} else {
 		request.ExpiresAt = opts.ExpiresAt
 	}
 	var response UpdateCustomerResponse
 	endpoint := fmt.Sprintf("/v3/customer/%s", customerID)
-	err := c.DoJSON(context.TODO(), "PUT", endpoint, http.StatusOK, request, &response)
+	err := c.DoJSON(context.TODO(), http.MethodPatch, endpoint, http.StatusOK, request, &response)
 	if err != nil {
 		return nil, errors.Wrap(err, "update customer")
 	}

--- a/pkg/kotsclient/customer_update_test.go
+++ b/pkg/kotsclient/customer_update_test.go
@@ -1,0 +1,84 @@
+package kotsclient
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/replicatedhq/replicated/pkg/platformclient"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateCustomerUsesPatchAndOmitsUnchangedFields(t *testing.T) {
+	var requestBody map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPatch, r.Method)
+		require.Equal(t, "/v3/customer/customer-id", r.URL.Path)
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&requestBody))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"customer":{"id":"customer-id"}}`))
+	}))
+	defer server.Close()
+
+	httpClient := platformclient.NewHTTPClient(server.URL, "fake-api-key")
+	client := &VendorV3Client{HTTPClient: *httpClient}
+
+	customer, err := client.UpdateCustomer("customer-id", UpdateCustomerOpts{
+		AddChannels: []CustomerChannel{{
+			ID:        "stable-channel-id",
+			IsDefault: true,
+		}},
+		RemoveChannels: []string{"unstable-channel-id"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "customer-id", customer.ID)
+
+	require.ElementsMatch(t, []string{"add_channels", "remove_channels"}, mapKeys(requestBody))
+	require.Equal(t, []interface{}{"unstable-channel-id"}, requestBody["remove_channels"])
+
+	addChannels, ok := requestBody["add_channels"].([]interface{})
+	require.True(t, ok)
+	require.Len(t, addChannels, 1)
+	require.Equal(t, map[string]interface{}{
+		"channel_id":              "stable-channel-id",
+		"is_default_for_customer": true,
+		"pinned_channel_sequence": nil,
+	}, addChannels[0])
+}
+
+func TestUpdateCustomerIncludesExplicitFalse(t *testing.T) {
+	var requestBody map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPatch, r.Method)
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&requestBody))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"customer":{"id":"customer-id"}}`))
+	}))
+	defer server.Close()
+
+	httpClient := platformclient.NewHTTPClient(server.URL, "fake-api-key")
+	client := &VendorV3Client{HTTPClient: *httpClient}
+
+	disabled := false
+	_, err := client.UpdateCustomer("customer-id", UpdateCustomerOpts{
+		IsEmbeddedClusterDownloadEnabled: &disabled,
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, map[string]interface{}{
+		"is_embedded_cluster_download_enabled": false,
+	}, requestBody)
+}
+
+func mapKeys(values map[string]interface{}) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	return keys
+}


### PR DESCRIPTION
https://app.shortcut.com/replicated/story/138855/put-v3-customer-resets-omitted-boolean-fields-to-false
## What this PR does

Switches `replicated customer update` from `PUT /v3/customer/{customer_id}` to `PATCH /v3/customer/{customer_id}` so fields omitted by the CLI retain their existing values instead of being reset to zero values by the PUT handler.

- Sends only flags explicitly supplied by the user, while preserving explicit `false` boolean updates.
- Translates the CLI’s single-channel replacement behavior into `add_channels` and `remove_channels`.
- Removes the artificial `--name` and `--channel` requirements and stops defaulting an omitted `--type` to `dev`.
- Adds command- and client-level regression coverage for channel-only updates and omitted fields.

## Testing

- `go test ./pkg/kotsclient ./client ./cli/cmd`
- `make test-unit`
- `make build`
- Reproduced against repldev with a channel-only update from Stable to Beta; the customer email, Embedded Cluster download entitlement, and support-bundle upload entitlement remained unchanged.