### PR TITLE
fix: align DoJSONWithoutUnmarshal with DoJSON contract

### DIFF
--- a/cli/cmd/api_get.go
+++ b/cli/cmd/api_get.go
@@ -48,7 +48,7 @@ func (r *runners) apiGet(cmd *cobra.Command, args []string) error {
 
 	} else if pathParts[0] == "v3" {
 		kotsRestClient := kotsclient.VendorV3Client{HTTPClient: *r.platformAPI}
-		response, err := kotsRestClient.Get(path)
+		response, err := kotsRestClient.Get(cmd.Context(), path)
 		if err != nil {
 			return err
 		}

--- a/cli/cmd/api_patch.go
+++ b/cli/cmd/api_patch.go
@@ -50,7 +50,7 @@ func (r *runners) apiPatch(cmd *cobra.Command, args []string) error {
 
 	} else if pathParts[0] == "v3" {
 		kotsRestClient := kotsclient.VendorV3Client{HTTPClient: *r.platformAPI}
-		response, err := kotsRestClient.Patch(path, r.args.apiPatchBody)
+		response, err := kotsRestClient.Patch(cmd.Context(), path, r.args.apiPatchBody)
 		if err != nil {
 			return err
 		}

--- a/cli/cmd/api_post.go
+++ b/cli/cmd/api_post.go
@@ -50,7 +50,7 @@ func (r *runners) apiPost(cmd *cobra.Command, args []string) error {
 
 	} else if pathParts[0] == "v3" {
 		kotsRestClient := kotsclient.VendorV3Client{HTTPClient: *r.platformAPI}
-		response, err := kotsRestClient.Post(path, r.args.apiPostBody)
+		response, err := kotsRestClient.Post(cmd.Context(), path, r.args.apiPostBody)
 		if err != nil {
 			return err
 		}

--- a/cli/cmd/api_put.go
+++ b/cli/cmd/api_put.go
@@ -50,7 +50,7 @@ func (r *runners) apiPut(cmd *cobra.Command, args []string) error {
 
 	} else if pathParts[0] == "v3" {
 		kotsRestClient := kotsclient.VendorV3Client{HTTPClient: *r.platformAPI}
-		response, err := kotsRestClient.Put(path, r.args.apiPutBody)
+		response, err := kotsRestClient.Put(cmd.Context(), path, r.args.apiPutBody)
 		if err != nil {
 			return err
 		}

--- a/pkg/kotsclient/api.go
+++ b/pkg/kotsclient/api.go
@@ -1,7 +1,9 @@
 package kotsclient
 
-func (c *VendorV3Client) Get(path string) ([]byte, error) {
-	resp, err := c.DoJSONWithoutUnmarshal("GET", path, "")
+import "context"
+
+func (c *VendorV3Client) Get(ctx context.Context, path string) ([]byte, error) {
+	resp, err := c.DoJSONWithoutUnmarshal(ctx, "GET", path, "")
 	if err != nil {
 		return nil, err
 	}
@@ -9,8 +11,8 @@ func (c *VendorV3Client) Get(path string) ([]byte, error) {
 	return resp, nil
 }
 
-func (c *VendorV3Client) Post(path string, body string) ([]byte, error) {
-	resp, err := c.DoJSONWithoutUnmarshal("POST", path, body)
+func (c *VendorV3Client) Post(ctx context.Context, path string, body string) ([]byte, error) {
+	resp, err := c.DoJSONWithoutUnmarshal(ctx, "POST", path, body)
 	if err != nil {
 		return nil, err
 	}
@@ -18,8 +20,8 @@ func (c *VendorV3Client) Post(path string, body string) ([]byte, error) {
 	return resp, nil
 }
 
-func (c *VendorV3Client) Put(path string, body string) ([]byte, error) {
-	resp, err := c.DoJSONWithoutUnmarshal("PUT", path, body)
+func (c *VendorV3Client) Put(ctx context.Context, path string, body string) ([]byte, error) {
+	resp, err := c.DoJSONWithoutUnmarshal(ctx, "PUT", path, body)
 	if err != nil {
 		return nil, err
 	}
@@ -27,8 +29,8 @@ func (c *VendorV3Client) Put(path string, body string) ([]byte, error) {
 	return resp, nil
 }
 
-func (c *VendorV3Client) Patch(path string, body string) ([]byte, error) {
-	resp, err := c.DoJSONWithoutUnmarshal("PATCH", path, body)
+func (c *VendorV3Client) Patch(ctx context.Context, path string, body string) ([]byte, error) {
+	resp, err := c.DoJSONWithoutUnmarshal(ctx, "PATCH", path, body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/platformclient/client.go
+++ b/pkg/platformclient/client.go
@@ -129,7 +129,7 @@ func (c *HTTPClient) GetOrigin() string {
 	return c.apiOrigin
 }
 
-func (c *HTTPClient) DoJSONWithoutUnmarshal(method string, path string, reqBody string) ([]byte, error) {
+func (c *HTTPClient) DoJSONWithoutUnmarshal(ctx context.Context, method string, path string, reqBody string) ([]byte, error) {
 	endpoint := fmt.Sprintf("%s%s", c.apiOrigin, path)
 	var buf *bytes.Buffer
 	if reqBody != "" {
@@ -137,14 +137,18 @@ func (c *HTTPClient) DoJSONWithoutUnmarshal(method string, path string, reqBody 
 	} else {
 		buf = &bytes.Buffer{}
 	}
-	req, err := http.NewRequest(method, endpoint, buf)
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	req, err := http.NewRequestWithContext(ctx, method, endpoint, buf)
 	if err != nil {
 		return nil, err
 	}
 
-	req.Header.Set("Authorization", c.apiKey)
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Accept", "application/json")
+	if err := c.setCommonHeaders(req); err != nil {
+		return nil, err
+	}
+
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, err
@@ -156,13 +160,21 @@ func (c *HTTPClient) DoJSONWithoutUnmarshal(method string, path string, reqBody 
 		return nil, errors.Wrap(err, "read body")
 	}
 
-	// if the response code was NOT a 2xx code, then we either return what the server responded with
-	// or a static error if the server didn't respond with a body
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, ErrNotFound
+	}
+	// Accept any 2xx so callers can use this helper without knowing the exact success code.
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		if len(bodyBytes) > 0 {
-			return nil, errors.Errorf("unexpected status code %d: %s", resp.StatusCode, string(bodyBytes))
+		if resp.StatusCode == http.StatusForbidden {
+			return nil, parseForbiddenError(bodyBytes)
 		}
-		return nil, errors.Errorf("unexpected status code %d", resp.StatusCode)
+		return nil, APIError{
+			Method:     method,
+			Endpoint:   endpoint,
+			StatusCode: resp.StatusCode,
+			Message:    responseBodyToErrorMessage(bodyBytes),
+			Body:       bodyBytes,
+		}
 	}
 
 	return bodyBytes, nil
@@ -185,17 +197,8 @@ func (c *HTTPClient) DoJSON(ctx context.Context, method string, path string, suc
 		return err
 	}
 
-	req.Header.Set("Authorization", c.apiKey)
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Accept", "application/json")
-	req.Header.Set("User-Agent", fmt.Sprintf("Replicated/%s", version.Version()))
-
-	if _, ok := os.LookupEnv("CI"); ok {
-		req.Header.Set("X-Replicated-CI", os.Getenv("CI"))
-	}
-
-	if err := addGitHubActionsHeaders(req); err != nil {
-		return errors.Wrap(err, "add github actions headers")
+	if err := c.setCommonHeaders(req); err != nil {
+		return err
 	}
 
 	resp, err := httpClient.Do(req)
@@ -234,6 +237,23 @@ func (c *HTTPClient) DoJSON(ctx context.Context, method string, path string, suc
 		if err := json.NewDecoder(bytes.NewReader(bodyBytes)).Decode(respBody); err != nil {
 			return fmt.Errorf("%s %s response decoding: %w", method, endpoint, err)
 		}
+	}
+
+	return nil
+}
+
+func (c *HTTPClient) setCommonHeaders(req *http.Request) error {
+	req.Header.Set("Authorization", c.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", fmt.Sprintf("Replicated/%s", version.Version()))
+
+	if _, ok := os.LookupEnv("CI"); ok {
+		req.Header.Set("X-Replicated-CI", os.Getenv("CI"))
+	}
+
+	if err := addGitHubActionsHeaders(req); err != nil {
+		return errors.Wrap(err, "add github actions headers")
 	}
 
 	return nil

--- a/pkg/platformclient/client_test.go
+++ b/pkg/platformclient/client_test.go
@@ -1,9 +1,12 @@
 package platformclient
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"io"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 )
@@ -32,6 +35,124 @@ func TestGetFeaturesRespectsCanceledContext(t *testing.T) {
 	_, err := client.GetFeatures(ctx)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("expected context.Canceled error, got %v", err)
+	}
+}
+
+func TestDoJSONWithoutUnmarshalRespectsCanceledContext(t *testing.T) {
+	originalHTTPClient := httpClient
+	defer func() {
+		httpClient = originalHTTPClient
+	}()
+
+	httpClient = &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			select {
+			case <-r.Context().Done():
+				return nil, r.Context().Err()
+			case <-time.After(20 * time.Millisecond):
+				return nil, errors.New("request context was not canceled")
+			}
+		}),
+	}
+
+	client := NewHTTPClient("https://example.test", "test-api-key")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := client.DoJSONWithoutUnmarshal(ctx, "GET", "/v3/apps", "")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled error, got %v", err)
+	}
+}
+
+func TestDoJSONWithoutUnmarshalErrorHandlingAndHeaders(t *testing.T) {
+	originalHTTPClient := httpClient
+	defer func() {
+		httpClient = originalHTTPClient
+	}()
+
+	tests := []struct {
+		name           string
+		statusCode     int
+		body           string
+		wantErrIs      error
+		wantForbidden  bool
+		wantAPIError   bool
+		wantStatusCode int
+	}{
+		{
+			name:       "not found",
+			statusCode: http.StatusNotFound,
+			body:       `{"message":"missing"}`,
+			wantErrIs:  ErrNotFound,
+		},
+		{
+			name:          "forbidden",
+			statusCode:    http.StatusForbidden,
+			body:          `{"error":{"message":"no access"}}`,
+			wantForbidden: true,
+		},
+		{
+			name:           "other error",
+			statusCode:     http.StatusBadRequest,
+			body:           `{"message":"bad request"}`,
+			wantAPIError:   true,
+			wantStatusCode: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotReq *http.Request
+			httpClient = &http.Client{
+				Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+					gotReq = r
+					return &http.Response{
+						StatusCode: tt.statusCode,
+						Body:       io.NopCloser(bytes.NewBufferString(tt.body)),
+						Header:     make(http.Header),
+					}, nil
+				}),
+			}
+
+			client := NewHTTPClient("https://example.test", "test-api-key")
+			_, err := client.DoJSONWithoutUnmarshal(context.Background(), "GET", "/v3/apps", "")
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+
+			if gotReq == nil {
+				t.Fatal("request was not made")
+			}
+			if gotReq.Header.Get("Authorization") != "test-api-key" {
+				t.Fatalf("expected Authorization header, got %q", gotReq.Header.Get("Authorization"))
+			}
+			if !strings.HasPrefix(gotReq.Header.Get("User-Agent"), "Replicated/") {
+				t.Fatalf("expected User-Agent header, got %q", gotReq.Header.Get("User-Agent"))
+			}
+
+			if tt.wantErrIs != nil && !errors.Is(err, tt.wantErrIs) {
+				t.Fatalf("expected error %v, got %v", tt.wantErrIs, err)
+			}
+			if tt.wantForbidden {
+				var forbiddenErr ForbiddenError
+				if !errors.As(err, &forbiddenErr) {
+					t.Fatalf("expected ForbiddenError, got %T: %v", err, err)
+				}
+				if !errors.Is(err, ErrForbidden) {
+					t.Fatalf("expected ErrForbidden unwrap, got %v", err)
+				}
+			}
+			if tt.wantAPIError {
+				var apiErr APIError
+				if !errors.As(err, &apiErr) {
+					t.Fatalf("expected APIError, got %T: %v", err, err)
+				}
+				if apiErr.StatusCode != tt.wantStatusCode {
+					t.Fatalf("expected status %d, got %d", tt.wantStatusCode, apiErr.StatusCode)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Why this matters

The `replicated api get|post|put|patch` commands go through `DoJSONWithoutUnmarshal`, a weaker HTTP path that diverged from the main `DoJSON` client used by the rest of the CLI.

That meant those commands:

- **Could not be canceled** — requests were built with `http.NewRequest` (no context). Ctrl+C / signal cancellation and caller deadlines never reached the in-flight HTTP call. A hung API server could block the CLI indefinitely (the shared client has no overall timeout).
- **Did not identify the CLI to the API** — no `User-Agent` header (`Replicated/<version>`), so vendor-side logs and support could not tell which CLI version made the request.
- **Did not mark CI / GitHub Actions traffic** — missing `X-Replicated-CI` and related GitHub Actions headers that `DoJSON` sets when running in automation, so CMX and other backend linking that depends on those headers never applied to raw `api` calls.
- **Lost structured error handling** — non-2xx responses were generic string errors. Callers could not use `errors.Is(..., ErrNotFound)` for 404s, and 403s did not parse into `ForbiddenError` with the server message.

Most other kotsclient/platformclient methods already use `DoJSON` and get the full contract. The `api` helpers were the odd path out.

## What changed

- Align `DoJSONWithoutUnmarshal` with `DoJSON`: context via `NewRequestWithContext`, shared header enrichment (`setCommonHeaders`), and consistent 404 / 403 / `APIError` handling.
- Thread context through kotsclient `Get`/`Post`/`Put`/`Patch`.
- Pass `cmd.Context()` from the `api` CLI commands so cancellation actually works.

## Test plan

- [x] `go test ./pkg/platformclient/ ./pkg/kotsclient/`
- [x] `go build ./cli/... ./pkg/platformclient/ ./pkg/kotsclient/`
- [ ] Manually: `replicated api get /v3/apps` still returns JSON
- [ ] Manually: Ctrl+C interrupts an in-flight `api get` against a slow/hung endpoint