### PR TITLE
fix: map wait-timeout exit codes at process boundary

### DIFF
--- a/cli/cmd/cluster_addon_create_objectstore.go
+++ b/cli/cmd/cluster_addon_create_objectstore.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/pkg/errors"
@@ -72,9 +71,11 @@ func (r *runners) clusterAddonCreateObjectStoreCreateRun() error {
 	}
 
 	addon, err := r.createAndWaitForClusterAddonCreateObjectStore(opts, r.args.clusterAddonCreateObjectStoreDuration)
+	var waitTimeout error
 	if err != nil {
 		if errors.Cause(err) == ErrWaitDurationExceeded {
-			defer os.Exit(124)
+			// Still print the partially ready addon below, then exit 124.
+			waitTimeout = err
 		} else {
 			return err
 		}
@@ -82,10 +83,17 @@ func (r *runners) clusterAddonCreateObjectStoreCreateRun() error {
 
 	if opts.DryRun {
 		_, err := fmt.Fprintln(r.w, "Dry run succeeded for addon object-store creation.")
+		if err != nil {
+			return err
+		}
+	} else if err := print.Addon(r.outputFormat, r.w, addon); err != nil {
 		return err
 	}
 
-	return print.Addon(r.outputFormat, r.w, addon)
+	if waitTimeout != nil {
+		return newExitError(124, waitTimeout)
+	}
+	return nil
 }
 
 func (r *runners) createAndWaitForClusterAddonCreateObjectStore(opts kotsclient.CreateClusterAddonObjectStoreOpts, waitDuration time.Duration) (*types.ClusterAddon, error) {

--- a/cli/cmd/cluster_create.go
+++ b/cli/cmd/cluster_create.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -166,10 +165,12 @@ func (r *runners) createCluster(cmd *cobra.Command, args []string) error {
 		opts.MaxNodeCount = &maxNodes
 	}
 	cl, err := r.createAndWaitForCluster(opts)
+	var waitTimeout error
 	if err != nil {
 		if _, ok := errors.Cause(err).(ClusterTimeoutError); ok {
+			// Still print the partially ready cluster below, then exit 124.
 			printIfError(cmd, err)
-			defer os.Exit(124)
+			waitTimeout = err
 		} else {
 			return err
 		}
@@ -188,10 +189,19 @@ func (r *runners) createCluster(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		_, err = fmt.Fprintln(r.w, "Dry run succeeded for cluster create.")
+		if err != nil {
+			return err
+		}
+	} else if err := print.Cluster(r.outputFormat, r.w, cl); err != nil {
 		return err
 	}
 
-	return print.Cluster(r.outputFormat, r.w, cl)
+	if waitTimeout != nil {
+		// Error details already printed above; map to exit 124 in main only.
+		cmd.SilenceErrors = true
+		return newExitError(124, waitTimeout)
+	}
+	return nil
 }
 
 func (r *runners) createAndWaitForAddons(clusterID string) error {

--- a/cli/cmd/errors.go
+++ b/cli/cmd/errors.go
@@ -1,6 +1,58 @@
 package cmd
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// ExitError is a command failure that should terminate the process with a
+// specific exit code. It must only be converted to os.Exit at the process
+// boundary (main), so deferred cleanup and tests can still observe the error.
+type ExitError struct {
+	Code int
+	Err  error
+}
+
+func (e *ExitError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.Err != nil {
+		return e.Err.Error()
+	}
+	return fmt.Sprintf("exit status %d", e.Code)
+}
+
+func (e *ExitError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+// Cause supports github.com/pkg/errors.Cause unwrapping.
+func (e *ExitError) Cause() error {
+	return e.Unwrap()
+}
+
+func newExitError(code int, err error) error {
+	return &ExitError{Code: code, Err: err}
+}
+
+// ExitCode returns the process exit code for err. Non-nil errors without an
+// ExitError wrapper map to 1; nil maps to 0.
+func ExitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	var exitErr *ExitError
+	if errors.As(err, &exitErr) && exitErr.Code != 0 {
+		return exitErr.Code
+	}
+	return 1
+}
 
 func isRBACDeniedError(err error) bool {
 	message := strings.TrimSpace(strings.ToLower(err.Error()))

--- a/cli/cmd/errors_test.go
+++ b/cli/cmd/errors_test.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestExitCode(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{name: "nil", err: nil, want: 0},
+		{name: "plain error", err: errors.New("boom"), want: 1},
+		{name: "exit 124", err: newExitError(124, errors.New("wait duration exceeded")), want: 124},
+		{name: "wrapped exit 124", err: errors.Join(errors.New("outer"), newExitError(124, errors.New("timeout"))), want: 124},
+		{name: "zero code falls back to 1", err: &ExitError{Code: 0, Err: errors.New("x")}, want: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := ExitCode(tt.err); got != tt.want {
+				t.Fatalf("ExitCode() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/cli/cmd/network_create.go
+++ b/cli/cmd/network_create.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/pkg/errors"
@@ -35,7 +34,7 @@ func (r *runners) InitNetworkCreate(parent *cobra.Command) *cobra.Command {
 	return cmd
 }
 
-func (r *runners) createNetwork(_ *cobra.Command, args []string) error {
+func (r *runners) createNetwork(cmd *cobra.Command, args []string) error {
 	if r.args.createNetworkName == "" {
 		r.args.createNetworkName = namesgenerator.GetRandomName(0)
 	}
@@ -48,9 +47,12 @@ func (r *runners) createNetwork(_ *cobra.Command, args []string) error {
 	}
 
 	network, err := r.createAndWaitForNetwork(opts)
+	var waitTimeout error
 	if err != nil {
-		if errors.Cause(err) == ErrVMWaitDurationExceeded {
-			defer os.Exit(124)
+		// waitForNetwork returns ErrWaitDurationExceeded (not the VM sentinel).
+		if errors.Cause(err) == ErrWaitDurationExceeded {
+			// Still print the partially ready network below, then exit 124.
+			waitTimeout = err
 		} else {
 			return err
 		}
@@ -58,10 +60,18 @@ func (r *runners) createNetwork(_ *cobra.Command, args []string) error {
 
 	if opts.DryRun {
 		_, err = fmt.Fprintln(r.w, "Dry run succeeded.")
+		if err != nil {
+			return err
+		}
+	} else if err := print.Network(r.outputFormat, r.w, network); err != nil {
 		return err
 	}
 
-	return print.Network(r.outputFormat, r.w, network)
+	if waitTimeout != nil {
+		cmd.SilenceErrors = true
+		return newExitError(124, waitTimeout)
+	}
+	return nil
 }
 
 func (r *runners) createAndWaitForNetwork(opts kotsclient.CreateNetworkOpts) (*types.Network, error) {

--- a/cli/cmd/vm_create.go
+++ b/cli/cmd/vm_create.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/pkg/errors"
@@ -143,10 +142,12 @@ func (r *runners) createVM(cmd *cobra.Command, args []string) error {
 	}
 
 	vms, err := r.createAndWaitForVM(opts)
+	var waitTimeout error
 	if err != nil {
 		if _, ok := errors.Cause(err).(VMTimeoutError); ok {
+			// Still print the partially ready VMs below, then exit 124.
 			printIfError(cmd, err)
-			defer os.Exit(124)
+			waitTimeout = err
 		} else {
 			return err
 		}
@@ -163,10 +164,19 @@ func (r *runners) createVM(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		_, err = fmt.Fprintln(r.w, "Dry run succeeded.")
+		if err != nil {
+			return err
+		}
+	} else if err := print.VMs(r.outputFormat, r.w, vms, true); err != nil {
 		return err
 	}
 
-	return print.VMs(r.outputFormat, r.w, vms, true)
+	if waitTimeout != nil {
+		// Error details already printed above; map to exit 124 in main only.
+		cmd.SilenceErrors = true
+		return newExitError(124, waitTimeout)
+	}
+	return nil
 }
 
 func (r *runners) createAndWaitForVM(opts kotsclient.CreateVMOpts) ([]*types.VM, error) {

--- a/cli/main.go
+++ b/cli/main.go
@@ -8,6 +8,6 @@ import (
 
 func main() {
 	if err := cmd.Execute(nil, os.Stdin, os.Stdout, os.Stderr); err != nil {
-		os.Exit(1)
+		os.Exit(cmd.ExitCode(err))
 	}
 }


### PR DESCRIPTION
## Why this matters

Several create commands (`cluster create`, `vm create`, `network create`, `cluster addon create object-store`) used `defer os.Exit(124)` when a `--wait` timeout expired.

That pattern is unsafe:

- **Bypasses Cobra and main** — process exit happens inside command code, so deferred cleanup, tests, and any shared error handling never see a normal return.
- **Always exits 124 once scheduled** — the defer runs even if later steps return an error or succeed at printing, and it runs after `return`, so the real command result is discarded at the process boundary.
- **Prevents callers from handling failure** — anything embedding or testing these RunE functions cannot observe the timeout as an error value.

`cli/main.go` already owns process termination for ordinary failures; wait-timeouts should use that same path with a non-1 exit code.

## What changed

- Add `ExitError` / `ExitCode()` so commands can request a specific exit status without calling `os.Exit`.
- On wait timeout, still print partial resource state (same UX as before), then return `ExitError{Code: 124}` instead of `defer os.Exit(124)`.
- `main` maps `cmd.ExitCode(err)` once at the process boundary.
- Fix `network create` comparing against the wrong sentinel (`ErrVMWaitDurationExceeded` → `ErrWaitDurationExceeded`), so timeout exit-124 actually works for networks.

## Test plan

- [x] `go test ./cli/cmd/ -run TestExitCode`
- [x] `go build ./cli/`
- [ ] Manually: create with a short `--wait` and confirm exit code 124 and partial resource output still print
- [ ] Manually: successful create still exits 0