### PR TITLE
fix: propagate command context instead of Background/TODO

### DIFF
--- a/cli/cmd/app_create.go
+++ b/cli/cmd/app_create.go
@@ -36,13 +36,11 @@ replicated app create "Another App" --output json
 replicated app create "Custom App" --output table`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
-
 			if len(args) != 1 {
 				return errors.New("missing app name")
 			}
 			opts.name = args[0]
-			return r.createApp(ctx, cmd, opts)
+			return r.createApp(cmd.Context(), cmd, opts)
 		},
 		SilenceUsage: true,
 	}

--- a/cli/cmd/app_hostname_ls.go
+++ b/cli/cmd/app_hostname_ls.go
@@ -54,8 +54,7 @@ replicated app hostname ls --app myapp --output json`,
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
-			return r.listAppHostnames(ctx)
+			return r.listAppHostnames(cmd.Context())
 		},
 		SilenceUsage: true,
 	}

--- a/cli/cmd/app_ls.go
+++ b/cli/cmd/app_ls.go
@@ -36,8 +36,7 @@ replicated app ls --output json
 # Search for an application and display results in table format
 replicated app ls "App Name" --output table`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
-			return r.listApps(ctx, cmd, args)
+			return r.listApps(cmd.Context(), cmd, args)
 		},
 		SilenceUsage: true,
 	}

--- a/cli/cmd/app_rm.go
+++ b/cli/cmd/app_rm.go
@@ -36,11 +36,10 @@ replicated app delete "Another App" --force
 # Delete an app and output the result in JSON format
 replicated app delete "Custom App" --output json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
 			if len(args) != 1 {
 				return errors.New("missing app slug or id")
 			}
-			return r.deleteApp(ctx, cmd, args[0], opts)
+			return r.deleteApp(cmd.Context(), cmd, args[0], opts)
 		},
 		SilenceUsage: true,
 	}

--- a/cli/cmd/cache_helper.go
+++ b/cli/cmd/cache_helper.go
@@ -8,7 +8,7 @@ import (
 	"github.com/replicatedhq/replicated/pkg/types"
 )
 
-func getApp(appSlugOrID string, kotsClient *kotsclient.VendorV3Client) (*types.App, error) {
+func getApp(ctx context.Context, appSlugOrID string, kotsClient *kotsclient.VendorV3Client) (*types.App, error) {
 	app, err := cache.GetApp(appSlugOrID)
 	if err == nil && app != nil {
 		return app, nil
@@ -19,7 +19,7 @@ func getApp(appSlugOrID string, kotsClient *kotsclient.VendorV3Client) (*types.A
 	}
 
 	if app == nil {
-		a, err := kotsClient.GetApp(context.TODO(), appSlugOrID, true)
+		a, err := kotsClient.GetApp(ctx, appSlugOrID, true)
 		if err != nil {
 			return nil, errors.Wrap(err, "get app from api")
 		}

--- a/cli/cmd/cluster_prepare.go
+++ b/cli/cmd/cluster_prepare.go
@@ -149,7 +149,7 @@ func validateClusterPrepareFlags(args runnerArgs) error {
 	return nil
 }
 
-func (r *runners) prepareCluster(_ *cobra.Command, args []string) error {
+func (r *runners) prepareCluster(cmd *cobra.Command, args []string) error {
 	if !r.hasApp() {
 		return errors.New("no app specified")
 	}
@@ -161,6 +161,7 @@ func (r *runners) prepareCluster(_ *cobra.Command, args []string) error {
 		return errors.Wrap(err, "prepare release")
 	}
 
+	ctx := cmd.Context()
 	wg := sync.WaitGroup{}
 	clusterName := ""
 	clusterID := ""
@@ -267,7 +268,7 @@ func (r *runners) prepareCluster(_ *cobra.Command, args []string) error {
 	}
 
 	if appRelease.IsHelmOnly {
-		if err := installBuilderApp(r, log, kubeConfig, customer, appRelease); err != nil {
+		if err := installBuilderApp(ctx, r, log, kubeConfig, customer, appRelease); err != nil {
 			return errors.Wrap(err, "failed to install builder app")
 		}
 	} else {
@@ -465,7 +466,7 @@ func runPreflights(ctx context.Context, r *runners, log *logger.Logger, kubeConf
 	return nil
 }
 
-func installBuilderApp(r *runners, log *logger.Logger, kubeConfig []byte, customer *types.Customer, release *types.AppRelease) error {
+func installBuilderApp(ctx context.Context, r *runners, log *logger.Logger, kubeConfig []byte, customer *types.Customer, release *types.AppRelease) error {
 	kubeconfigFile, err := os.CreateTemp("", "kubeconfig")
 	if err != nil {
 		return errors.Wrap(err, "failed to create kubeConfigFile file")
@@ -515,7 +516,6 @@ func installBuilderApp(r *runners, log *logger.Logger, kubeConfig []byte, custom
 		return errors.Wrap(err, "failed to write credentials file")
 	}
 
-	ctx := context.Background()
 	for _, chart := range release.Charts {
 		if chart.Status != types.ChartStatusPushed {
 			continue

--- a/cli/cmd/default_set.go
+++ b/cli/cmd/default_set.go
@@ -36,7 +36,7 @@ replicated default set app my-app-slug`,
 func (r *runners) setDefault(cmd *cobra.Command, defaultType string, defaultValue string) error {
 	switch defaultType {
 	case "app":
-		app, err := getApp(defaultValue, r.api.KotsClient)
+		app, err := getApp(cmd.Context(), defaultValue, r.api.KotsClient)
 		if err != nil {
 			return errors.Wrap(err, "get app")
 		}

--- a/cli/cmd/default_show.go
+++ b/cli/cmd/default_show.go
@@ -53,7 +53,7 @@ func (r *runners) showDefault(cmd *cobra.Command, defaultType string) error {
 
 	switch defaultType {
 	case "app":
-		app, err := getApp(defaultValue, r.api.KotsClient)
+		app, err := getApp(cmd.Context(), defaultValue, r.api.KotsClient)
 		if err != nil {
 			return errors.Wrap(err, "get app")
 		}

--- a/cli/cmd/enterprise_portal_preview.go
+++ b/cli/cmd/enterprise_portal_preview.go
@@ -183,7 +183,7 @@ func (r *runners) enterprisePortalPreview(cmd *cobra.Command, args []string) err
 	// offer a switcher. Without a token we skip this and the switcher is hidden.
 	customersB64 := ""
 	if token != "" {
-		b64, err := buildPreviewCustomersEnv(appSlug, token)
+		b64, err := buildPreviewCustomersEnv(cmd.Context(), appSlug, token)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: could not fetch customers (%v) — switcher will be hidden\n", err)
 		} else {
@@ -297,11 +297,11 @@ type previewEntitlementValue struct {
 // buildPreviewCustomersEnv fetches the app + its customers from the vendor API
 // and returns a base64-encoded JSON array of License-shaped objects suitable
 // for the EP_PREVIEW_CUSTOMERS_JSON env var.
-func buildPreviewCustomersEnv(appSlug, token string) (string, error) {
+func buildPreviewCustomersEnv(ctx context.Context, appSlug, token string) (string, error) {
 	httpClient := platformclient.NewHTTPClient(platformOrigin, token)
 	client := &kotsclient.VendorV3Client{HTTPClient: *httpClient}
 
-	app, err := client.GetApp(context.TODO(), appSlug, true)
+	app, err := client.GetApp(ctx, appSlug, true)
 	if err != nil {
 		return "", errors.Wrap(err, "get app")
 	}

--- a/cli/cmd/model_pull.go
+++ b/cli/cmd/model_pull.go
@@ -94,14 +94,16 @@ func (r *runners) pullModel(cmd *cobra.Command, args []string) error {
 	}
 	defer fs.Close()
 
+	ctx := cmd.Context()
+
 	// Copy the manifest from the remote repository
-	manifestDescriptor, err := oras.Copy(context.Background(), repo, tag, fs, tag, oras.DefaultCopyOptions)
+	manifestDescriptor, err := oras.Copy(ctx, repo, tag, fs, tag, oras.DefaultCopyOptions)
 	if err != nil {
 		return err
 	}
 
 	// Fetch the manifest content
-	manifestContent, err := fs.Fetch(context.Background(), manifestDescriptor)
+	manifestContent, err := fs.Fetch(ctx, manifestDescriptor)
 	if err != nil {
 		return err
 	}
@@ -146,7 +148,7 @@ func (r *runners) pullModel(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		err = downloadBlob(context.Background(), repo, layer, layerFile)
+		err = downloadBlob(ctx, repo, layer, layerFile)
 		if err != nil {
 			layerFile.Close()
 			return err

--- a/cli/cmd/model_push.go
+++ b/cli/cmd/model_push.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -50,7 +49,7 @@ func (r *runners) pushModel(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err := ociclient.UploadFiles(context.Background(), endpoint, name, tag, modelFiles, baseDir); err != nil {
+	if err := ociclient.UploadFiles(cmd.Context(), endpoint, name, tag, modelFiles, baseDir); err != nil {
 		return err
 	}
 

--- a/cli/cmd/release_create.go
+++ b/cli/cmd/release_create.go
@@ -275,7 +275,7 @@ func (r *runners) releaseCreate(cmd *cobra.Command, args []string) (err error) {
 		// because the prerun might have run with a different app (from cache/env) before we loaded the config
 		// Clear the appType to force a fresh resolution
 		r.appType = ""
-		if err := r.resolveAppType(); err != nil {
+		if err := r.resolveAppType(cmd.Context()); err != nil {
 			return errors.Wrap(err, "resolve app type from config")
 		}
 
@@ -958,7 +958,7 @@ func copyFile(src, dst string) error {
 }
 
 // resolveAppType resolves the app type by querying the API with the current appID or appSlug
-func (r *runners) resolveAppType() error {
+func (r *runners) resolveAppType(ctx context.Context) error {
 	if r.appID == "" && r.appSlug == "" {
 		return nil // nothing to resolve
 	}
@@ -968,7 +968,7 @@ func (r *runners) resolveAppType() error {
 		appSlugOrID = r.appID
 	}
 
-	app, appType, err := r.api.GetAppType(context.Background(), appSlugOrID, true)
+	app, appType, err := r.api.GetAppType(ctx, appSlugOrID, true)
 	if err != nil {
 		return errors.Wrapf(err, "get app type for %q", appSlugOrID)
 	}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"os"
@@ -530,7 +529,7 @@ func Execute(rootCmd *cobra.Command, stdin io.Reader, stdout io.Writer, stderr i
 		}
 
 		if appSlugOrID != "" && (runCmds.appType == "" || runCmds.appID == "" || runCmds.appSlug == "") {
-			app, appType, err := runCmds.api.GetAppType(context.TODO(), appSlugOrID, true)
+			app, appType, err := runCmds.api.GetAppType(cmd.Context(), appSlugOrID, true)
 			if err != nil {
 				return errors.Wrap(err, "get app type")
 			}


### PR DESCRIPTION
## Why this matters

Several CLI commands started work with `context.Background()` or `context.TODO()` instead of the Cobra command context. That breaks cancellation:

- **Ctrl+C does not cancel in-flight API calls** for paths like `app create/ls/rm`, `app hostname ls`, `default set/show`, release create app resolution, and enterprise-portal preview customer fetch.
- **Long-running work keeps going after interrupt** — model pull/push OCI transfers and `cluster prepare` preflights could not observe signal cancellation.
- **Persistent prerun app resolution** used `context.TODO()`, so early setup API calls were also uncancellable.

Cobra already wires signal handling into `cmd.Context()`. Commands that drop that context silently ignore user cancellation.

## What changed

- Replace `context.Background()` / `context.TODO()` in command paths with `cmd.Context()`.
- Thread context through helpers (`getApp`, `resolveAppType`, `buildPreviewCustomersEnv`, `installBuilderApp`).
- Leave test-only `context.Background()` / `cmd.SetContext(...)` usage unchanged.

## Test plan

- [x] `go build ./cli/`
- [x] `go test ./cli/cmd/`
- [ ] Manually: start a slow API-backed command and Ctrl+C; request should abort
- [ ] Manually: normal successful runs of `app ls`, `app create`, etc. still work