### PR TITLE
fix: fail fast on interactive prompts without a TTY

### DIFF
--- a/cli/cmd/app_rm.go
+++ b/cli/cmd/app_rm.go
@@ -115,6 +115,10 @@ var templates = &promptui.PromptTemplates{
 }
 
 func promptConfirmDelete() (string, error) {
+	if err := ensureInteractive(); err != nil {
+		return "", errors.Wrap(err, "use --force to skip the confirmation prompt")
+	}
+
 	prompt := promptui.Prompt{
 		Label:     "Delete the above listed application? There is no undo:",
 		Templates: templates,

--- a/cli/cmd/init.go
+++ b/cli/cmd/init.go
@@ -71,7 +71,7 @@ func (r *runners) initConfig(cmd *cobra.Command, nonInteractive bool, skipDetect
 			Items: []string{"Cancel", "Overwrite", "Edit/Merge"},
 		}
 
-		_, result, err := prompt.Run()
+		_, result, err := runSelect(prompt)
 		if err != nil {
 			return errors.Wrap(err, "prompting for action")
 		}
@@ -159,7 +159,7 @@ func (r *runners) initConfig(cmd *cobra.Command, nonInteractive bool, skipDetect
 				Label:   "App ID or App Slug (optional, check vendor.replicated.com)",
 				Default: "",
 			}
-			appValue, err := appPrompt.Run()
+			appValue, err := runPrompt(appPrompt)
 			if err != nil {
 				if err == promptui.ErrInterrupt {
 					fmt.Fprintf(r.w, "\nCancelled\n")
@@ -181,7 +181,7 @@ func (r *runners) initConfig(cmd *cobra.Command, nonInteractive bool, skipDetect
 				Label: fmt.Sprintf("Use detected Helm charts? (%d found)", len(detected.Charts)),
 				Items: []string{"Yes", "No", "Let me specify custom paths"},
 			}
-			_, chartChoice, err := useDetectedCharts.Run()
+			_, chartChoice, err := runSelect(useDetectedCharts)
 			if err != nil {
 				if err == promptui.ErrInterrupt {
 					fmt.Fprintf(r.w, "\nCancelled\n")
@@ -213,7 +213,7 @@ func (r *runners) initConfig(cmd *cobra.Command, nonInteractive bool, skipDetect
 				Label: "Add Helm charts?",
 				Items: []string{"Yes", "No"},
 			}
-			_, addChartsResult, err := addCharts.Run()
+			_, addChartsResult, err := runSelect(addCharts)
 			if err != nil {
 				if err == promptui.ErrInterrupt {
 					fmt.Fprintf(r.w, "\nCancelled\n")
@@ -237,7 +237,7 @@ func (r *runners) initConfig(cmd *cobra.Command, nonInteractive bool, skipDetect
 				Label: fmt.Sprintf("Use detected manifest patterns? (%d found)", len(detected.Manifests)),
 				Items: []string{"Yes", "No", "Let me specify custom patterns"},
 			}
-			_, manifestChoice, err := useDetectedManifests.Run()
+			_, manifestChoice, err := runSelect(useDetectedManifests)
 			if err != nil {
 				if err == promptui.ErrInterrupt {
 					fmt.Fprintf(r.w, "\nCancelled\n")
@@ -270,7 +270,7 @@ func (r *runners) initConfig(cmd *cobra.Command, nonInteractive bool, skipDetect
 					Label: fmt.Sprintf("Add detected support bundle specs to manifests? (%d found)", len(detected.SupportBundles)),
 					Items: []string{"Yes", "No"},
 				}
-				_, sbChoice, err := useSupportBundles.Run()
+				_, sbChoice, err := runSelect(useSupportBundles)
 				if err != nil {
 					if err == promptui.ErrInterrupt {
 						fmt.Fprintf(r.w, "\nCancelled\n")
@@ -294,7 +294,7 @@ func (r *runners) initConfig(cmd *cobra.Command, nonInteractive bool, skipDetect
 				Label: "Do you want to add any Kubernetes manifest files?",
 				Items: []string{"No", "Yes"},
 			}
-			_, manifestsResult, err := addManifests.Run()
+			_, manifestsResult, err := runSelect(addManifests)
 			if err != nil {
 				if err == promptui.ErrInterrupt {
 					fmt.Fprintf(r.w, "\nCancelled\n")
@@ -318,7 +318,7 @@ func (r *runners) initConfig(cmd *cobra.Command, nonInteractive bool, skipDetect
 				Label: fmt.Sprintf("Use detected preflight specs? (%d found)", len(detected.Preflights)),
 				Items: []string{"Yes", "No", "Let me specify custom paths"},
 			}
-			_, preflightChoice, err := useDetectedPreflights.Run()
+			_, preflightChoice, err := runSelect(useDetectedPreflights)
 			if err != nil {
 				if err == promptui.ErrInterrupt {
 					fmt.Fprintf(r.w, "\nCancelled\n")
@@ -367,7 +367,7 @@ func (r *runners) initConfig(cmd *cobra.Command, nonInteractive bool, skipDetect
 				Label: "Add preflight specs?",
 				Items: []string{"No", "Yes"},
 			}
-			_, addPreflightsResult, err := addPreflights.Run()
+			_, addPreflightsResult, err := runSelect(addPreflights)
 			if err != nil {
 				if err == promptui.ErrInterrupt {
 					fmt.Fprintf(r.w, "\nCancelled\n")
@@ -391,7 +391,7 @@ func (r *runners) initConfig(cmd *cobra.Command, nonInteractive bool, skipDetect
 				Label: "Configure linting? (recommended)",
 				Items: []string{"Yes", "No"},
 			}
-			_, lintingResult, err := configureLinting.Run()
+			_, lintingResult, err := runSelect(configureLinting)
 			if err != nil {
 				if err == promptui.ErrInterrupt {
 					fmt.Fprintf(r.w, "\nCancelled\n")
@@ -528,7 +528,7 @@ func (r *runners) promptForChartPaths() ([]tools.ChartConfig, error) {
 			Label:   "Chart path (glob patterns supported, e.g., ./charts/*)",
 			Default: "",
 		}
-		path, err := pathPrompt.Run()
+		path, err := runPrompt(pathPrompt)
 		if err != nil {
 			if err == promptui.ErrInterrupt {
 				return nil, errors.New("cancelled")
@@ -546,7 +546,7 @@ func (r *runners) promptForChartPaths() ([]tools.ChartConfig, error) {
 			Label: "Specify chart/app versions? (optional)",
 			Items: []string{"No", "Yes"},
 		}
-		_, addVersionsResult, err := addVersions.Run()
+		_, addVersionsResult, err := runSelect(addVersions)
 		if err != nil {
 			if err == promptui.ErrInterrupt {
 				return nil, errors.New("cancelled")
@@ -559,7 +559,7 @@ func (r *runners) promptForChartPaths() ([]tools.ChartConfig, error) {
 				Label:   "Chart version (optional)",
 				Default: "",
 			}
-			chart.ChartVersion, err = chartVersionPrompt.Run()
+			chart.ChartVersion, err = runPrompt(chartVersionPrompt)
 			if err != nil {
 				if err == promptui.ErrInterrupt {
 					return nil, errors.New("cancelled")
@@ -571,7 +571,7 @@ func (r *runners) promptForChartPaths() ([]tools.ChartConfig, error) {
 				Label:   "App version (optional)",
 				Default: "",
 			}
-			chart.AppVersion, err = appVersionPrompt.Run()
+			chart.AppVersion, err = runPrompt(appVersionPrompt)
 			if err != nil {
 				if err == promptui.ErrInterrupt {
 					return nil, errors.New("cancelled")
@@ -586,7 +586,7 @@ func (r *runners) promptForChartPaths() ([]tools.ChartConfig, error) {
 			Label: "Add another chart?",
 			Items: []string{"No", "Yes"},
 		}
-		_, result, err := addAnother.Run()
+		_, result, err := runSelect(addAnother)
 		if err != nil {
 			if err == promptui.ErrInterrupt {
 				return nil, errors.New("cancelled")
@@ -649,7 +649,7 @@ func (r *runners) promptForChart(charts []tools.ChartConfig) (string, string, er
 		Items: displayNames,
 	}
 
-	idx, _, err := prompt.Run()
+	idx, _, err := runSelect(prompt)
 	if err != nil {
 		if err == promptui.ErrInterrupt {
 			return "", "", errors.New("cancelled")
@@ -671,7 +671,7 @@ func (r *runners) promptForPreflightPathsWithCharts(charts []tools.ChartConfig, 
 			Label:   "Preflight spec path (e.g., ./preflight.yaml)",
 			Default: "",
 		}
-		path, err := pathPrompt.Run()
+		path, err := runPrompt(pathPrompt)
 		if err != nil {
 			if err == promptui.ErrInterrupt {
 				return nil, errors.New("cancelled")
@@ -705,7 +705,7 @@ func (r *runners) promptForPreflightPathsWithCharts(charts []tools.ChartConfig, 
 			Label: "Add another preflight spec?",
 			Items: []string{"No", "Yes"},
 		}
-		_, result, err := addAnother.Run()
+		_, result, err := runSelect(addAnother)
 		if err != nil {
 			if err == promptui.ErrInterrupt {
 				return nil, errors.New("cancelled")
@@ -729,7 +729,7 @@ func (r *runners) promptForManifests() ([]string, error) {
 			Label:   "Manifest path (glob patterns supported, e.g., ./manifests/*.yaml)",
 			Default: "",
 		}
-		path, err := manifestPrompt.Run()
+		path, err := runPrompt(manifestPrompt)
 		if err != nil {
 			if err == promptui.ErrInterrupt {
 				return nil, errors.New("cancelled")
@@ -746,7 +746,7 @@ func (r *runners) promptForManifests() ([]string, error) {
 			Label: "Add another manifest pattern?",
 			Items: []string{"No", "Yes"},
 		}
-		_, result, err := addAnother.Run()
+		_, result, err := runSelect(addAnother)
 		if err != nil {
 			if err == promptui.ErrInterrupt {
 				return nil, errors.New("cancelled")
@@ -775,7 +775,7 @@ func (r *runners) promptForLintConfig(hasCharts, hasPreflights bool) (*tools.Rep
 			Label: "Enable Helm linting?",
 			Items: []string{"Yes", "No"},
 		}
-		_, result, err := enableHelm.Run()
+		_, result, err := runSelect(enableHelm)
 		if err != nil {
 			if err == promptui.ErrInterrupt {
 				return nil, errors.New("cancelled")
@@ -792,7 +792,7 @@ func (r *runners) promptForLintConfig(hasCharts, hasPreflights bool) (*tools.Rep
 			Label: "Enable preflight linting?",
 			Items: []string{"Yes", "No"},
 		}
-		_, result, err := enablePreflight.Run()
+		_, result, err := runSelect(enablePreflight)
 		if err != nil {
 			if err == promptui.ErrInterrupt {
 				return nil, errors.New("cancelled")
@@ -809,7 +809,7 @@ func (r *runners) promptForLintConfig(hasCharts, hasPreflights bool) (*tools.Rep
 		Label: "Enable support bundle linting?",
 		Items: []string{"Yes", "No"},
 	}
-	_, sbResult, err := enableSupportBundle.Run()
+	_, sbResult, err := runSelect(enableSupportBundle)
 	if err != nil {
 		if err == promptui.ErrInterrupt {
 			return nil, errors.New("cancelled")
@@ -864,7 +864,7 @@ func (r *runners) promptForAppSelection(ctx context.Context) (string, error) {
 		Size:  10,
 	}
 
-	idx, _, err := prompt.Run()
+	idx, _, err := runSelect(prompt)
 	if err != nil {
 		if err == promptui.ErrInterrupt {
 			return "", errors.New("cancelled")

--- a/cli/cmd/lint.go
+++ b/cli/cmd/lint.go
@@ -589,7 +589,10 @@ func (r *runners) initConfigForLint(cmd *cobra.Command) error {
 			Label:   "Chart path (leave empty to skip)",
 			Default: "",
 		}
-		chartPath, _ := chartPrompt.Run()
+		chartPath, err := runPrompt(chartPrompt)
+		if err != nil {
+			return errors.Wrap(err, "prompt for chart path")
+		}
 		if chartPath != "" {
 			config.Charts = append(config.Charts, tools.ChartConfig{Path: chartPath})
 		}
@@ -599,7 +602,10 @@ func (r *runners) initConfigForLint(cmd *cobra.Command) error {
 			Label:   "Preflight spec path (leave empty to skip)",
 			Default: "",
 		}
-		preflightPath, _ := preflightPrompt.Run()
+		preflightPath, err := runPrompt(preflightPrompt)
+		if err != nil {
+			return errors.Wrap(err, "prompt for preflight path")
+		}
 		if preflightPath != "" {
 			config.Preflights = append(config.Preflights, tools.PreflightConfig{Path: preflightPath})
 		}

--- a/cli/cmd/profile_add.go
+++ b/cli/cmd/profile_add.go
@@ -99,6 +99,10 @@ func (r *runners) profileAdd(cmd *cobra.Command, args []string) error {
 }
 
 func (r *runners) readAPITokenFromPrompt(label string) (string, error) {
+	if err := ensureInteractive(); err != nil {
+		return "", errors.Wrap(err, "provide --token to set the API token non-interactively")
+	}
+
 	prompt := promptui.Prompt{
 		Label: label,
 		Mask:  '*',

--- a/cli/cmd/prompt.go
+++ b/cli/cmd/prompt.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"github.com/manifoldco/promptui"
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/replicated/pkg/tools"
+)
+
+// errNonInteractive is returned when a prompt is required but the process is
+// non-interactive (CI set, or stdin is not a terminal).
+var errNonInteractive = errors.New("interactive prompt required but stdin is not a terminal")
+
+// ensureInteractive fails fast when prompts would hang (CI / piped stdin).
+func ensureInteractive() error {
+	if tools.IsNonInteractive() {
+		return errNonInteractive
+	}
+	return nil
+}
+
+// runPrompt runs a promptui.Prompt after verifying stdin is interactive.
+func runPrompt(prompt promptui.Prompt) (string, error) {
+	if err := ensureInteractive(); err != nil {
+		return "", err
+	}
+	return prompt.Run()
+}
+
+// runSelect runs a promptui.Select after verifying stdin is interactive.
+func runSelect(prompt promptui.Select) (int, string, error) {
+	if err := ensureInteractive(); err != nil {
+		return 0, "", err
+	}
+	return prompt.Run()
+}

--- a/cli/cmd/prompt_test.go
+++ b/cli/cmd/prompt_test.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/manifoldco/promptui"
+)
+
+func TestEnsureInteractiveInCI(t *testing.T) {
+	t.Setenv("CI", "true")
+
+	if err := ensureInteractive(); err == nil {
+		t.Fatal("expected ensureInteractive to fail when CI is set")
+	} else if !errors.Is(err, errNonInteractive) {
+		t.Fatalf("expected errNonInteractive, got %v", err)
+	}
+
+	if _, err := runPrompt(promptui.Prompt{Label: "test"}); err == nil {
+		t.Fatal("expected runPrompt to fail when CI is set")
+	}
+
+	if _, _, err := runSelect(promptui.Select{Label: "test", Items: []string{"a"}}); err == nil {
+		t.Fatal("expected runSelect to fail when CI is set")
+	}
+}
+
+func TestEnsureInteractiveUnsetCI(t *testing.T) {
+	// Clear CI for this test process; if stdin is not a TTY (common in test
+	// runners), ensureInteractive should still report non-interactive.
+	t.Setenv("CI", "")
+	_ = os.Unsetenv("CI")
+
+	err := ensureInteractive()
+	// Either interactive (local terminal) or non-interactive (piped CI runner).
+	// Just ensure it does not panic and returns a typed error when failing.
+	if err != nil && !errors.Is(err, errNonInteractive) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/cli/cmd/registry_add.go
+++ b/cli/cmd/registry_add.go
@@ -2,9 +2,12 @@ package cmd
 
 import (
 	"fmt"
+	"io"
+	"strings"
 
 	"github.com/manifoldco/promptui"
 	"github.com/pkg/errors"
+	"github.com/replicatedhq/replicated/pkg/tools"
 	"github.com/spf13/cobra"
 )
 
@@ -32,6 +35,20 @@ func contains(vals []string, val string) bool {
 }
 
 func (r *runners) readPasswordFromStdIn(label string) (string, error) {
+	// --password-stdin / --token-stdin with a pipe: read the secret from stdin
+	// instead of opening an interactive prompt that would hang in CI.
+	if tools.IsNonInteractive() {
+		data, err := io.ReadAll(r.stdin)
+		if err != nil {
+			return "", errors.Wrap(err, "read password from stdin")
+		}
+		password := strings.TrimSpace(string(data))
+		if password == "" {
+			return "", errors.New("password cannot be empty")
+		}
+		return password, nil
+	}
+
 	prompt := promptui.Prompt{
 		Label:     fmt.Sprintf("%s:", label),
 		Mask:      '*',

--- a/cli/cmd/release_create.go
+++ b/cli/cmd/release_create.go
@@ -709,6 +709,10 @@ func makeReleaseFromChart(chartFile string) (string, error) {
 }
 
 func promptForConfirm() (string, error) {
+	if err := ensureInteractive(); err != nil {
+		return "", errors.Wrap(err, "use --confirm-auto or -y to skip the confirmation prompt")
+	}
+
 	prompt := promptui.Prompt{
 		Label:     "Create with these properties? (default Yes) [Y/n]",
 		Templates: templates,


### PR DESCRIPTION
## Why this matters

Several CLI flows open `promptui` prompts with no check that stdin is a terminal. In CI or when stdin is piped that causes:

- **Hangs waiting for input that never arrives** — e.g. `app rm` without `--force` blocks in automation.
- **Silent consumption of piped data** — a confirmation prompt can read unrelated stdin as the answer.
- **Unusable `--password-stdin` / `--token-stdin`** — registry helpers used interactive prompts even when the intent was a pipe.

`config init` already auto-detected non-interactive environments; destructive confirms, credential prompts, and lint setup did not.

## What changed

- Add shared `ensureInteractive` / `runPrompt` / `runSelect` helpers based on `tools.IsNonInteractive()` (CI env or non-TTY stdin).
- Guard confirmation prompts with actionable errors:
  - `app rm` → use `--force`
  - release/installer auto-confirm → use `--confirm-auto` / `-y`
  - profile token → provide `--token`
- Route all `config init` and lint-setup prompts through the guarded helpers.
- When stdin is non-interactive, `readPasswordFromStdIn` reads the secret from the pipe instead of prompting (so `--password-stdin` / `--token-stdin` work in automation).

## Test plan

- [x] `go build ./cli/`
- [x] `go test ./cli/cmd/`
- [ ] Manually: `CI=true replicated app rm foo` fails immediately with `--force` guidance
- [ ] Manually: interactive `app rm` still prompts on a TTY
- [ ] Manually: `echo secret | replicated registry add dockerhub ... --password-stdin` reads the pipe