### PR TITLE
fix: make api commands execute v1 and v2 paths

### DIFF
--- a/cli/cmd/api.go
+++ b/cli/cmd/api.go
@@ -1,6 +1,11 @@
 package cmd
 
 import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -14,4 +19,57 @@ func (r *runners) InitAPICommand(parent *cobra.Command) *cobra.Command {
 	parent.AddCommand(cmd)
 
 	return cmd
+}
+
+// normalizeAPIPath ensures the path starts with "/" and returns the version
+// segment (v1/v2/v3) for validation.
+func normalizeAPIPath(raw string) (path string, version string, err error) {
+	path = strings.TrimSpace(raw)
+	if path == "" {
+		return "", "", errors.New("path is required")
+	}
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+
+	parts := strings.Split(path, "/")
+	// Drop empty segments from leading/trailing slashes.
+	cleaned := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p != "" {
+			cleaned = append(cleaned, p)
+		}
+	}
+	if len(cleaned) == 0 {
+		return "", "", errors.New("path is required")
+	}
+
+	version = cleaned[0]
+	switch version {
+	case "v1", "v2", "v3":
+		return path, version, nil
+	default:
+		return "", "", errors.Errorf("unsupported API version %q; path must start with /v1, /v2, or /v3 (got %q)", version, path)
+	}
+}
+
+// doAPIRequest performs a raw JSON HTTP call against the vendor API origin and
+// writes the response body to stdout. Supports v1, v2, and v3 paths.
+func (r *runners) doAPIRequest(ctx context.Context, method, rawPath, body string) error {
+	path, _, err := normalizeAPIPath(rawPath)
+	if err != nil {
+		return err
+	}
+
+	if r.platformAPI == nil {
+		return errors.New("API client is not configured")
+	}
+
+	response, err := r.platformAPI.DoJSONWithoutUnmarshal(ctx, method, path, body)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("%s", response)
+	return nil
 }

--- a/cli/cmd/api_get.go
+++ b/cli/cmd/api_get.go
@@ -1,24 +1,22 @@
 package cmd
 
 import (
-	"fmt"
-	"strings"
-
-	"github.com/replicatedhq/replicated/pkg/kotsclient"
 	"github.com/spf13/cobra"
 )
 
 func (r *runners) InitAPIGet(parent *cobra.Command) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "get",
+		Use:   "get PATH",
 		Short: "Make ad-hoc GET API calls to the Replicated API",
 		Long: `This is essentially like curl for the Replicated API, but
 uses your local credentials and prints the response unmodified.
 
 We recommend piping the output to jq for easier reading.
 
-Pass the PATH of the request as the final argument. Do not include the host or version.`,
-		Example:      `replicated api get /v3/apps`,
+Pass the PATH of the request as the final argument (including the API version
+prefix). Supported versions are /v1, /v2, and /v3. Do not include the host.`,
+		Example: `replicated api get /v3/apps
+replicated api get /v1/apps`,
 		RunE:         r.apiGet,
 		SilenceUsage: true,
 		Args:         cobra.ExactArgs(1),
@@ -29,32 +27,5 @@ Pass the PATH of the request as the final argument. Do not include the host or v
 }
 
 func (r *runners) apiGet(cmd *cobra.Command, args []string) error {
-	path := args[0]
-
-	if !strings.HasPrefix(args[0], "/") {
-		path = fmt.Sprintf("/%s", args[0])
-	}
-	pathParts := strings.Split(path, "/")
-	// remove any empty parts
-	for i := len(pathParts) - 1; i >= 0; i-- {
-		if pathParts[i] == "" {
-			pathParts = append(pathParts[:i], pathParts[i+1:]...)
-		}
-	}
-
-	// v1 and v2 paths use platform client, v3 uses kots client
-	// split the path on the first slash to determine which client to use
-	if pathParts[0] == "v1" {
-
-	} else if pathParts[0] == "v3" {
-		kotsRestClient := kotsclient.VendorV3Client{HTTPClient: *r.platformAPI}
-		response, err := kotsRestClient.Get(cmd.Context(), path)
-		if err != nil {
-			return err
-		}
-
-		fmt.Printf("%s", response)
-	}
-
-	return nil
+	return r.doAPIRequest(cmd.Context(), "GET", args[0], "")
 }

--- a/cli/cmd/api_patch.go
+++ b/cli/cmd/api_patch.go
@@ -15,7 +15,7 @@ We recommend piping the output to jq for easier reading.
 
 Pass the PATH of the request as the final argument (including the API version
 prefix). Supported versions are /v1, /v2, and /v3. Do not include the host.`,
-		Example: `replicated api patch /v3/customer/2VffY549paATVfHSGpJhjh6Ehpy -b '{"name":"Valuable Customer"}'`,
+		Example:      `replicated api patch /v3/customer/2VffY549paATVfHSGpJhjh6Ehpy -b '{"name":"Valuable Customer"}'`,
 		RunE:         r.apiPatch,
 		SilenceUsage: true,
 		Args:         cobra.ExactArgs(1),

--- a/cli/cmd/api_patch.go
+++ b/cli/cmd/api_patch.go
@@ -1,24 +1,21 @@
 package cmd
 
 import (
-	"fmt"
-	"strings"
-
-	"github.com/replicatedhq/replicated/pkg/kotsclient"
 	"github.com/spf13/cobra"
 )
 
 func (r *runners) InitAPIPatch(parent *cobra.Command) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "patch",
+		Use:   "patch PATH",
 		Short: "Make ad-hoc PATCH API calls to the Replicated API",
 		Long: `This is essentially like curl for the Replicated API, but
 uses your local credentials and prints the response unmodified.
 
 We recommend piping the output to jq for easier reading.
 
-Pass the PATH of the request as the final argument. Do not include the host or version.`,
-		Example:      `replicated api patch /v3/customer/2VffY549paATVfHSGpJhjh6Ehpy -b '{"name":"Valuable Customer"}'`,
+Pass the PATH of the request as the final argument (including the API version
+prefix). Supported versions are /v1, /v2, and /v3. Do not include the host.`,
+		Example: `replicated api patch /v3/customer/2VffY549paATVfHSGpJhjh6Ehpy -b '{"name":"Valuable Customer"}'`,
 		RunE:         r.apiPatch,
 		SilenceUsage: true,
 		Args:         cobra.ExactArgs(1),
@@ -31,32 +28,5 @@ Pass the PATH of the request as the final argument. Do not include the host or v
 }
 
 func (r *runners) apiPatch(cmd *cobra.Command, args []string) error {
-	path := args[0]
-
-	if !strings.HasPrefix(args[0], "/") {
-		path = fmt.Sprintf("/%s", args[0])
-	}
-	pathParts := strings.Split(path, "/")
-	// remove any empty parts
-	for i := len(pathParts) - 1; i >= 0; i-- {
-		if pathParts[i] == "" {
-			pathParts = append(pathParts[:i], pathParts[i+1:]...)
-		}
-	}
-
-	// v1 and v2 paths use platform client, v3 uses kots client
-	// split the path on the first slash to determine which client to use
-	if pathParts[0] == "v1" {
-
-	} else if pathParts[0] == "v3" {
-		kotsRestClient := kotsclient.VendorV3Client{HTTPClient: *r.platformAPI}
-		response, err := kotsRestClient.Patch(cmd.Context(), path, r.args.apiPatchBody)
-		if err != nil {
-			return err
-		}
-
-		fmt.Printf("%s", response)
-	}
-
-	return nil
+	return r.doAPIRequest(cmd.Context(), "PATCH", args[0], r.args.apiPatchBody)
 }

--- a/cli/cmd/api_post.go
+++ b/cli/cmd/api_post.go
@@ -1,24 +1,22 @@
 package cmd
 
 import (
-	"fmt"
-	"strings"
-
-	"github.com/replicatedhq/replicated/pkg/kotsclient"
 	"github.com/spf13/cobra"
 )
 
 func (r *runners) InitAPIPost(parent *cobra.Command) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "post",
+		Use:   "post PATH",
 		Short: "Make ad-hoc POST API calls to the Replicated API",
 		Long: `This is essentially like curl for the Replicated API, but
 uses your local credentials and prints the response unmodified.
 
 We recommend piping the output to jq for easier reading.
 
-Pass the PATH of the request as the final argument. Do not include the host or version.`,
-		Example:      `replicated api post /v3/app/2EuFxKLDxKjPNk2jxMTmF6Vxvxu/channel -b '{"name":"marc-waz-here"}'`,
+Pass the PATH of the request as the final argument (including the API version
+prefix). Supported versions are /v1, /v2, and /v3. Do not include the host.`,
+		Example: `replicated api post /v3/app/2EuFxKLDxKjPNk2jxMTmF6Vxvxu/channel -b '{"name":"marc-waz-here"}'
+replicated api post /v1/app -b '{"name":"My App"}'`,
 		RunE:         r.apiPost,
 		SilenceUsage: true,
 		Args:         cobra.ExactArgs(1),
@@ -31,32 +29,5 @@ Pass the PATH of the request as the final argument. Do not include the host or v
 }
 
 func (r *runners) apiPost(cmd *cobra.Command, args []string) error {
-	path := args[0]
-
-	if !strings.HasPrefix(args[0], "/") {
-		path = fmt.Sprintf("/%s", args[0])
-	}
-	pathParts := strings.Split(path, "/")
-	// remove any empty parts
-	for i := len(pathParts) - 1; i >= 0; i-- {
-		if pathParts[i] == "" {
-			pathParts = append(pathParts[:i], pathParts[i+1:]...)
-		}
-	}
-
-	// v1 and v2 paths use platform client, v3 uses kots client
-	// split the path on the first slash to determine which client to use
-	if pathParts[0] == "v1" {
-
-	} else if pathParts[0] == "v3" {
-		kotsRestClient := kotsclient.VendorV3Client{HTTPClient: *r.platformAPI}
-		response, err := kotsRestClient.Post(cmd.Context(), path, r.args.apiPostBody)
-		if err != nil {
-			return err
-		}
-
-		fmt.Printf("%s", response)
-	}
-
-	return nil
+	return r.doAPIRequest(cmd.Context(), "POST", args[0], r.args.apiPostBody)
 }

--- a/cli/cmd/api_put.go
+++ b/cli/cmd/api_put.go
@@ -15,7 +15,7 @@ We recommend piping the output to jq for easier reading.
 
 Pass the PATH of the request as the final argument (including the API version
 prefix). Supported versions are /v1, /v2, and /v3. Do not include the host.`,
-		Example: `replicated api put /v3/app/2EuFxKLDxKjPNk2jxMTmF6Vxvxu/channel/2QLPm10JPkta7jO3Z3Mk4aXTPyZ -b '{"name":"marc-waz-here2"}'`,
+		Example:      `replicated api put /v3/app/2EuFxKLDxKjPNk2jxMTmF6Vxvxu/channel/2QLPm10JPkta7jO3Z3Mk4aXTPyZ -b '{"name":"marc-waz-here2"}'`,
 		RunE:         r.apiPut,
 		SilenceUsage: true,
 		Args:         cobra.ExactArgs(1),

--- a/cli/cmd/api_put.go
+++ b/cli/cmd/api_put.go
@@ -1,24 +1,21 @@
 package cmd
 
 import (
-	"fmt"
-	"strings"
-
-	"github.com/replicatedhq/replicated/pkg/kotsclient"
 	"github.com/spf13/cobra"
 )
 
 func (r *runners) InitAPIPut(parent *cobra.Command) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "put",
+		Use:   "put PATH",
 		Short: "Make ad-hoc PUT API calls to the Replicated API",
 		Long: `This is essentially like curl for the Replicated API, but
 uses your local credentials and prints the response unmodified.
 
 We recommend piping the output to jq for easier reading.
 
-Pass the PATH of the request as the final argument. Do not include the host or version.`,
-		Example:      `replicated api put /v3/app/2EuFxKLDxKjPNk2jxMTmF6Vxvxu/channel/2QLPm10JPkta7jO3Z3Mk4aXTPyZ -b '{"name":"marc-waz-here2"}'`,
+Pass the PATH of the request as the final argument (including the API version
+prefix). Supported versions are /v1, /v2, and /v3. Do not include the host.`,
+		Example: `replicated api put /v3/app/2EuFxKLDxKjPNk2jxMTmF6Vxvxu/channel/2QLPm10JPkta7jO3Z3Mk4aXTPyZ -b '{"name":"marc-waz-here2"}'`,
 		RunE:         r.apiPut,
 		SilenceUsage: true,
 		Args:         cobra.ExactArgs(1),
@@ -31,32 +28,5 @@ Pass the PATH of the request as the final argument. Do not include the host or v
 }
 
 func (r *runners) apiPut(cmd *cobra.Command, args []string) error {
-	path := args[0]
-
-	if !strings.HasPrefix(args[0], "/") {
-		path = fmt.Sprintf("/%s", args[0])
-	}
-	pathParts := strings.Split(path, "/")
-	// remove any empty parts
-	for i := len(pathParts) - 1; i >= 0; i-- {
-		if pathParts[i] == "" {
-			pathParts = append(pathParts[:i], pathParts[i+1:]...)
-		}
-	}
-
-	// v1 and v2 paths use platform client, v3 uses kots client
-	// split the path on the first slash to determine which client to use
-	if pathParts[0] == "v1" {
-
-	} else if pathParts[0] == "v3" {
-		kotsRestClient := kotsclient.VendorV3Client{HTTPClient: *r.platformAPI}
-		response, err := kotsRestClient.Put(cmd.Context(), path, r.args.apiPutBody)
-		if err != nil {
-			return err
-		}
-
-		fmt.Printf("%s", response)
-	}
-
-	return nil
+	return r.doAPIRequest(cmd.Context(), "PUT", args[0], r.args.apiPutBody)
 }

--- a/cli/cmd/api_test.go
+++ b/cli/cmd/api_test.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestNormalizeAPIPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		raw         string
+		wantPath    string
+		wantVersion string
+		wantErr     bool
+	}{
+		{name: "v3 with leading slash", raw: "/v3/apps", wantPath: "/v3/apps", wantVersion: "v3"},
+		{name: "v1 without leading slash", raw: "v1/apps", wantPath: "/v1/apps", wantVersion: "v1"},
+		{name: "v2", raw: "/v2/license", wantPath: "/v2/license", wantVersion: "v2"},
+		{name: "unsupported version", raw: "/v4/apps", wantErr: true},
+		{name: "empty", raw: "", wantErr: true},
+		{name: "no version", raw: "/apps", wantErr: true},
+		{name: "slash only", raw: "/", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			path, version, err := normalizeAPIPath(tt.raw)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got path=%q version=%q", path, version)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if path != tt.wantPath {
+				t.Fatalf("path = %q, want %q", path, tt.wantPath)
+			}
+			if version != tt.wantVersion {
+				t.Fatalf("version = %q, want %q", version, tt.wantVersion)
+			}
+		})
+	}
+}
+
+func TestDoAPIRequestRejectsUnsupportedVersion(t *testing.T) {
+	t.Parallel()
+
+	r := &runners{}
+	err := r.doAPIRequest(context.Background(), "GET", "/v9/apps", "")
+	if err == nil {
+		t.Fatal("expected error for unsupported API version")
+	}
+	if !strings.Contains(err.Error(), "unsupported API version") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDoAPIRequestRequiresClient(t *testing.T) {
+	t.Parallel()
+
+	r := &runners{}
+	err := r.doAPIRequest(context.Background(), "GET", "/v1/apps", "")
+	if err == nil {
+		t.Fatal("expected error when platformAPI is nil")
+	}
+	if !strings.Contains(err.Error(), "not configured") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## Why this matters

`replicated api get|post|put|patch` claimed to work like curl against the Replicated API, but only `/v3/...` actually performed a request.

- **`/v1/...` was a no-op** — empty `if pathParts[0] == "v1" { }` branch, then `return nil`.
- **`/v2/...` was never handled** — fell through to success with no request and no output.
- **Exit code 0 with empty stdout** — scripts and automation treated failed/missing calls as success.

That is a contract-breaking silent success for any non-v3 path.

## What changed

- Shared `doAPIRequest` sends raw JSON requests for **`/v1`, `/v2`, and `/v3`** via `platformAPI.DoJSONWithoutUnmarshal`.
- Unsupported versions / empty paths return a clear error instead of exiting 0.
- Help text documents that paths must include a supported version prefix.
- Unit tests for path normalization and rejection of unsupported versions.

## Test plan

- [x] `go test ./cli/cmd/ -run 'TestNormalizeAPIPath|TestDoAPIRequest'`
- [x] `go build ./cli/`
- [ ] Manually: `replicated api get /v1/apps` performs a real request (auth required)
- [ ] Manually: `replicated api get /v9/apps` fails with unsupported version
- [ ] Manually: `replicated api get /v3/apps` still works