### PR TITLE
fix: cancel cluster prepare child processes via context

### DIFF
--- a/cli/cmd/cluster_prepare.go
+++ b/cli/cmd/cluster_prepare.go
@@ -272,7 +272,7 @@ func (r *runners) prepareCluster(cmd *cobra.Command, args []string) error {
 			return errors.Wrap(err, "failed to install builder app")
 		}
 	} else {
-		if err := installKotsApp(r, log, kubeConfig, customer, appRelease); err != nil {
+		if err := installKotsApp(ctx, r, log, kubeConfig, customer, appRelease); err != nil {
 			return errors.Wrap(err, "failed to install kots")
 		}
 	}
@@ -600,7 +600,7 @@ func installHelmChart(r *runners, appSlug string, chartName string, chartVersion
 	return helmRelease, nil
 }
 
-func installKotsApp(r *runners, log *logger.Logger, kubeConfig []byte, customer *types.Customer, release *types.AppRelease) error {
+func installKotsApp(ctx context.Context, r *runners, log *logger.Logger, kubeConfig []byte, customer *types.Customer, release *types.AppRelease) error {
 	var releaseYamls []releaseTypes.KotsSingleSpec
 	if err := json.Unmarshal([]byte(release.Config), &releaseYamls); err != nil {
 		return errors.Wrap(err, "failed to unmarshal release yamls")
@@ -621,7 +621,7 @@ func installKotsApp(r *runners, log *logger.Logger, kubeConfig []byte, customer 
 		return errors.Wrap(err, "failed to create temp dir")
 	}
 	defer os.RemoveAll(kotsDir)
-	kotCLI, err := installKotsCLI(r, kotsCliVersion, kotsDir)
+	kotCLI, err := installKotsCLI(ctx, r, kotsCliVersion, kotsDir)
 	if err != nil {
 		return errors.Wrap(err, "failed to install KOTS cli")
 	}
@@ -658,7 +658,7 @@ func installKotsApp(r *runners, log *logger.Logger, kubeConfig []byte, customer 
 		return errors.Wrap(err, "chmod kubeconfig file")
 	}
 
-	cmd := exec.Command(kotCLI, "install",
+	installCmd := exec.CommandContext(ctx, kotCLI, "install",
 		fmt.Sprintf("%s/%s", r.appSlug, "test-channel"),
 		"--kubeconfig", kubeconfigFile.Name(),
 		"--license-file", licenseFile.Name(),
@@ -674,21 +674,21 @@ func installKotsApp(r *runners, log *logger.Logger, kubeConfig []byte, customer 
 			return errors.Wrapf(err, "config values file %q does not exist", r.args.prepareClusterKotsConfigValuesFile)
 		}
 
-		cmd.Args = append(cmd.Args, "--config-values", r.args.prepareClusterKotsConfigValuesFile)
+		installCmd.Args = append(installCmd.Args, "--config-values", r.args.prepareClusterKotsConfigValuesFile)
 	}
 
 	log.Verbose()
-	log.Debug("%s", cmd.String())
-	cmd.Stdout = r.w
-	cmd.Stderr = r.w
-	if err := cmd.Run(); err != nil {
+	log.Debug("%s", installCmd.String())
+	installCmd.Stdout = r.w
+	installCmd.Stderr = r.w
+	if err := installCmd.Run(); err != nil {
 		return errors.Wrap(err, "failed to install KOTS and deploy app")
 	}
 
 	return nil
 }
 
-func installKotsCLI(r *runners, version string, kotsDir string) (string, error) {
+func installKotsCLI(ctx context.Context, r *runners, version string, kotsDir string) (string, error) {
 	kotsInstallURL := "https://kots.io/install"
 	if version != "" {
 		kotsInstallURL = fmt.Sprintf("%s/%s", kotsInstallURL, version)
@@ -724,11 +724,11 @@ func installKotsCLI(r *runners, version string, kotsDir string) (string, error) 
 		return "", errors.Wrap(err, "failed to close install script")
 	}
 
-	cmd := exec.Command(installScript.Name())
-	cmd.Env = append(cmd.Env, fmt.Sprintf("REPL_INSTALL_PATH=%s", kotsDir))
-	cmd.Stdout = r.w
-	cmd.Stderr = r.w
-	if err := cmd.Run(); err != nil {
+	installCmd := exec.CommandContext(ctx, installScript.Name())
+	installCmd.Env = append(installCmd.Env, fmt.Sprintf("REPL_INSTALL_PATH=%s", kotsDir))
+	installCmd.Stdout = r.w
+	installCmd.Stderr = r.w
+	if err := installCmd.Run(); err != nil {
 		return "", errors.Wrap(err, "failed to run KOTS cli install")
 	}
 

--- a/cli/cmd/cluster_prepare_commandcontext_test.go
+++ b/cli/cmd/cluster_prepare_commandcontext_test.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// Structural check: cluster prepare must launch child processes with CommandContext
+// so cobra cancellation (Ctrl+C) reaches kots install and the kots install script.
+func TestClusterPrepareUsesCommandContext(t *testing.T) {
+	t.Parallel()
+
+	src, err := os.ReadFile("cluster_prepare.go")
+	if err != nil {
+		t.Fatalf("read cluster_prepare.go: %v", err)
+	}
+	content := string(src)
+
+	if !strings.Contains(content, `exec.CommandContext(ctx, kotCLI, "install"`) {
+		t.Fatal("installKotsApp must use exec.CommandContext for kots install")
+	}
+	if !strings.Contains(content, `exec.CommandContext(ctx, installScript.Name())`) {
+		t.Fatal("installKotsCLI must use exec.CommandContext for the kots install script")
+	}
+	if strings.Contains(content, `exec.Command(kotCLI, "install"`) {
+		t.Fatal("installKotsApp must not use context-less exec.Command for kots install")
+	}
+	if strings.Contains(content, `exec.Command(installScript.Name())`) {
+		t.Fatal("installKotsCLI must not use context-less exec.Command for the install script")
+	}
+}


### PR DESCRIPTION
## Why this matters

`cluster prepare` downloads and runs the KOTS install script, then runs `kots install`, both via plain `exec.Command` with no link to the command context.

If the user hits Ctrl+C (or the parent context is otherwise canceled):

- Those child processes keep running as orphans
- Install work continues against the cluster after the CLI has already exited
- There is no ownership path for the CLI to stop or reap them

Happy-path product behavior is unchanged: same arguments, same install flow, same success output when nothing is canceled. Only cancellation now reaches the children.

## What changed

- Thread the existing `cmd.Context()` into `installKotsApp` and `installKotsCLI`
- Replace `exec.Command(...)` with `exec.CommandContext(ctx, ...)` for:
  - the kots install invocation
  - the kots install script invocation
- Add a structural test that both call sites use `CommandContext` and no longer use bare `Command` for those paths

## Test plan

- [x] `go test ./cli/cmd/ -run TestClusterPrepareUsesCommandContext`
- [x] Source contains `CommandContext` for both child launches
- [ ] Manual: Ctrl+C during `cluster prepare` kots install stops the child process