### PR TITLE
fix: gracefully shut down credentials login callback server

### DIFF
--- a/pkg/credentials/fetch.go
+++ b/pkg/credentials/fetch.go
@@ -52,52 +52,88 @@ func Fetch(endpoint string) error {
 
 // startLocalWebServer handles the token redirect, returning the token
 func startLocalWebServer(ctx context.Context, port int) (string, error) {
-	errChan := make(chan error)
-	tokenChan := make(chan string)
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	errChan := make(chan error, 1)
+	tokenChan := make(chan string, 1)
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		nonce := r.URL.Query().Get("nonce")
 		if nonce == "" {
-			errChan <- fmt.Errorf("no nonce found in response")
+			select {
+			case errChan <- fmt.Errorf("no nonce found in response"):
+			default:
+			}
+			http.Error(w, "missing nonce", http.StatusBadRequest)
+			return
 		}
 
 		exchange := r.URL.Query().Get("exchange")
 		if exchange == "" {
-			errChan <- fmt.Errorf("no exchange found in response")
+			select {
+			case errChan <- fmt.Errorf("no exchange found in response"):
+			default:
+			}
+			http.Error(w, "missing exchange", http.StatusBadRequest)
+			return
 		}
 
 		token, err := exchangeNonceForToken(exchange, nonce)
 		if err != nil {
-			errChan <- err
+			select {
+			case errChan <- err:
+			default:
+			}
+			http.Error(w, "token exchange failed", http.StatusBadGateway)
+			return
 		}
 
-		tokenChan <- token
+		select {
+		case tokenChan <- token:
+		default:
+		}
 
 		fmt.Fprintln(w, "Authentication successful. You may close this window.")
 	})
 
-	go func() {
-		sm := http.NewServeMux()
-		sm.Handle("/callback", handler)
-		server := &http.Server{
-			Addr:              net.JoinHostPort("127.0.0.1", strconv.Itoa(port)),
-			Handler:           sm,
-			ReadHeaderTimeout: 3 * time.Second,
-		}
+	sm := http.NewServeMux()
+	sm.Handle("/callback", handler)
+	server := &http.Server{
+		Addr:              net.JoinHostPort("127.0.0.1", strconv.Itoa(port)),
+		Handler:           sm,
+		ReadHeaderTimeout: 3 * time.Second,
+	}
 
-		errChan <- server.ListenAndServe()
+	go func() {
+		err := server.ListenAndServe()
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			select {
+			case errChan <- err:
+			default:
+			}
+		}
 	}()
 
-	timeout := time.NewTicker(5 * time.Minute)
+	// Always stop admission and drain in-flight callback work when we leave.
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		_ = server.Shutdown(shutdownCtx)
+	}()
+
+	timeout := time.NewTimer(5 * time.Minute)
+	defer timeout.Stop()
 
 	select {
 	case <-timeout.C:
-		ctx.Done()
 		return "", fmt.Errorf("authentication timeout")
+	case <-ctx.Done():
+		return "", ctx.Err()
 	case token := <-tokenChan:
 		return token, nil
 	case e := <-errChan:
-		ctx.Done()
 		return "", e
 	}
 }

--- a/pkg/credentials/fetch_test.go
+++ b/pkg/credentials/fetch_test.go
@@ -1,0 +1,86 @@
+package credentials
+
+import (
+	"context"
+	"errors"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestStartLocalWebServerRespectsCancel(t *testing.T) {
+	port, err := getAvailablePort()
+	if err != nil {
+		t.Fatalf("getAvailablePort: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := startLocalWebServer(ctx, port)
+		errCh <- err
+	}()
+
+	// Wait until the server is accepting connections.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		conn, dialErr := net.DialTimeout("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)), 50*time.Millisecond)
+		if dialErr == nil {
+			_ = conn.Close()
+			break
+		}
+		if time.Now().After(deadline) {
+			cancel()
+			t.Fatalf("server did not start listening: %v", dialErr)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for startLocalWebServer to return after cancel")
+	}
+
+	// Port should be free again after Shutdown.
+	deadline = time.Now().Add(2 * time.Second)
+	for {
+		ln, listenErr := net.Listen("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)))
+		if listenErr == nil {
+			_ = ln.Close()
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("port %d still in use after cancel/shutdown: %v", port, listenErr)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+func TestStartLocalWebServerSourceUsesShutdown(t *testing.T) {
+	t.Parallel()
+
+	src, err := os.ReadFile("fetch.go")
+	if err != nil {
+		t.Fatalf("read fetch.go: %v", err)
+	}
+	content := string(src)
+	if !strings.Contains(content, "server.Shutdown(shutdownCtx)") {
+		t.Fatal("startLocalWebServer must call server.Shutdown")
+	}
+	if strings.Contains(content, "ctx.Done()\n\t\treturn") {
+		// Old broken pattern called Done() without selecting on it for cancel.
+		// We only check Shutdown presence as the structural requirement.
+	}
+	if !strings.Contains(content, "case <-ctx.Done():") {
+		t.Fatal("startLocalWebServer must select on ctx.Done for cancellation")
+	}
+}


### PR DESCRIPTION
## Why this matters

Browser login (`credentials.Fetch`) starts a local `http.Server` on `127.0.0.1` to receive the OAuth-style callback. That server used `ListenAndServe` with no matching `Shutdown`.

On timeout or after a successful token exchange the process returned, but the listener kept running until the process exited. The old code also called `ctx.Done()` as a no-op (it only returns a channel) instead of observing cancellation.

Happy-path login UX is unchanged: same browser open, same callback URL shape, same success page text, same 5-minute auth timeout. Only lifecycle cleanup is fixed.

## What changed

- Always `Shutdown` the local callback server (bounded 3s) on leave
- Select on `ctx.Done()` so cancel stops waiting for the callback
- Use a `time.Timer` (stopped on leave) instead of a never-stopped ticker
- Buffer error/token channels and return from the handler on missing params so the server cannot wedge
- Tests: cancel ends `startLocalWebServer` with `context.Canceled` and frees the port; source requires `Shutdown` and `ctx.Done` select

## Test plan

- [x] `go test ./pkg/credentials/ -v`
- [x] Cancel path frees the listen port
- [ ] Manual browser login still stores credentials on success