### PR TITLE
fix(cli): resolve app slugs against active API

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -512,7 +512,17 @@ func Execute(rootCmd *cobra.Command, stdin io.Reader, stdout io.Writer, stderr i
 
 		// attempt to load the app from cache
 		if appSlugOrID != "" {
-			app, err := cache.GetApp(appSlugOrID)
+			var app *types.App
+			var err error
+			if isV2Lint {
+				// Local v2 lint intentionally works without an API. It is the only
+				// path allowed to resolve an app slug from the origin-agnostic cache.
+				app, err = cache.GetApp(appSlugOrID)
+			} else {
+				// IDs are globally unique enough to cache. Slugs are not: the same
+				// slug can identify different apps when switching API origins.
+				app, err = cache.GetAppByID(appSlugOrID)
+			}
 			if err != nil {
 				return errors.Wrap(err, "get app from cache")
 			}

--- a/pkg/cache/app.go
+++ b/pkg/cache/app.go
@@ -16,6 +16,20 @@ func (c Cache) GetApp(appSlugOrID string) (*types.App, error) {
 	return nil, nil
 }
 
+// GetAppByID returns a cached app only for an exact app ID match. Unlike app
+// IDs, slugs cannot be resolved safely from this cache because it is shared
+// across API origins. The same slug can refer to different app IDs in
+// production, staging, and local development environments.
+func (c Cache) GetAppByID(appID string) (*types.App, error) {
+	for _, app := range c.Apps {
+		if app.ID == appID {
+			return &app, nil
+		}
+	}
+
+	return nil, nil
+}
+
 func (c *Cache) SetApp(app *types.App) error {
 	c.Apps = append(c.Apps, *app)
 

--- a/pkg/cache/app_test.go
+++ b/pkg/cache/app_test.go
@@ -1,0 +1,43 @@
+package cache
+
+import (
+	"testing"
+
+	"github.com/replicatedhq/replicated/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetAppByID(t *testing.T) {
+	c := Cache{Apps: []types.App{
+		{ID: "production-id", Slug: "chartsmith", Scheduler: "kots"},
+		{ID: "local-id", Slug: "chartsmith", Scheduler: "kots"},
+	}}
+
+	app, err := c.GetAppByID("local-id")
+	require.NoError(t, err)
+	require.NotNil(t, app)
+	assert.Equal(t, "local-id", app.ID)
+}
+
+func TestGetAppByIDDoesNotResolveSlugFromOriginAgnosticCache(t *testing.T) {
+	c := Cache{Apps: []types.App{
+		{ID: "production-id", Slug: "chartsmith", Scheduler: "kots"},
+		{ID: "local-id", Slug: "chartsmith", Scheduler: "kots"},
+	}}
+
+	app, err := c.GetAppByID("chartsmith")
+	require.NoError(t, err)
+	assert.Nil(t, app, "slugs must be resolved against the active API origin")
+}
+
+func TestGetAppRetainsSlugLookupForOfflineCallers(t *testing.T) {
+	c := Cache{Apps: []types.App{
+		{ID: "app-id", Slug: "chartsmith", Scheduler: "kots"},
+	}}
+
+	app, err := c.GetApp("chartsmith")
+	require.NoError(t, err)
+	require.NotNil(t, app)
+	assert.Equal(t, "app-id", app.ID)
+}


### PR DESCRIPTION
## Summary
- resolve app slugs against the currently configured API instead of the origin-agnostic app cache
- continue using cached app IDs and preserve offline v2 lint behavior
- add regression coverage for ID-only cache lookup

## Root cause
The app cache is shared across API origins. Reusing a slug such as chartsmith in production and local Vandoor could select an older cached app ID, causing release ls to return an empty list.

## Validation
- make test-unit
- make test-lint
- built the CLI and verified release ls --app chartsmith returns local releases 1 through 80, with release 80 on Stable